### PR TITLE
goconst: extract repeated string constants (xtcp / xtcpnl / quality-report)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 result
 xtcp2client
 xtcp2_kafka_client
+
+quality-report

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -1,6 +1,6 @@
 # xtcp2 code-quality report
 
-Generated: 2026-05-16T17:37:31Z
+Generated: 2026-05-16T18:42:53Z
 
 Tool versions: go=go1.25.10; golangci-lint=2.12.2; gosec=2.26.1; nixfmt=1.2.0; 
 
@@ -15,12 +15,12 @@ between commits reveals exactly what changed.
 
 | Metric | Value |
 |---|---|
-| Total findings | 577 |
-| Findings (Tier 0) | 180 |
+| Total findings | 442 |
+| Findings (Tier 0) | 181 |
 | Findings (Tier 1) | 217 |
-| Findings (Tier 2) | 168 |
-| Findings (non-tiered) | 12 |
-| Files with at least one finding | 96 |
+| Findings (Tier 2) | 31 |
+| Findings (non-tiered) | 13 |
+| Files with at least one finding | 89 |
 | Test failures (new) | 3 |
 | Test failures (pre-existing) | 3 |
 | Config exclusions reviewed | 4 |
@@ -31,18 +31,18 @@ between commits reveals exactly what changed.
 
 | Tool | Status | Findings | Runtime |
 |---|---|---|---|
-| golangci-lint (comprehensive) | findings | 565 | 4s |
-| golangci-lint (standard) | findings | 399 | 5s |
-| golangci-lint (quick) | findings | 78 | 13s |
+| golangci-lint (comprehensive) | findings | 429 | 5s |
+| golangci-lint (standard) | findings | 400 | 4s |
+| golangci-lint (quick) | findings | 91 | 14s |
 | gosec | findings | 12 | 1s |
 | go vet | clean | 0 | 2s |
-| gofmt | clean | 0 | 1s |
+| gofmt | findings | 1 | 1s |
 | nixfmt | clean | 0 | 0s |
 | netlink-audit | clean | 0 | 0s |
-| iouring-audit | clean | 0 | 1s |
+| iouring-audit | clean | 0 | 0s |
 | metrics-audit | clean | 0 | 0s |
 | proto-field-audit | clean | 0 | 0s |
-| go test | findings | 6 | 2s |
+| go test | findings | 6 | 3s |
 
 
 ---
@@ -51,9 +51,9 @@ between commits reveals exactly what changed.
 
 | Tier | Linters | Findings | Quick-fixable¹ |
 |---|---|---|---|
-| 0 (`lint-quick`) | govet, errcheck, ineffassign, unused, staticcheck | 180 | 0 |
+| 0 (`lint-quick`) | govet, errcheck, ineffassign, unused, staticcheck | 181 | 2 |
 | 1 (`lint` / CI) | Tier 0 + gosec, gocritic, revive, noctx, contextcheck, durationcheck | 217 | 0 |
-| 2 (`lint-comprehensive`) | Tier 1 + exhaustive, prealloc, gocyclo, funlen, goconst, dupl, unconvert, nakedret, misspell | 168 | 12 |
+| 2 (`lint-comprehensive`) | Tier 1 + exhaustive, prealloc, gocyclo, funlen, goconst, dupl, unconvert, nakedret, misspell | 31 | 14 |
 
 ¹ Quick-fixable = produced by a linter that supports `golangci-lint run --fix` (gofmt, goimports, misspell, unconvert, …).
 
@@ -63,16 +63,16 @@ between commits reveals exactly what changed.
 
 | File | Findings | Top rules |
 |---|---|---|
-| `pkg/xtcp/destinations_test.go` | 43 | govet×20, gosec×11, goconst×8 |
-| `pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go` | 25 | gocritic×14, goconst×11 |
-| `tools/quality-report/main.go` | 25 | errcheck×11, goconst×7, govet×4 |
-| `pkg/xtcpnl/xtcpnl_bench_test.go` | 22 | gocritic×15, goconst×7 |
+| `pkg/xtcp/destinations_test.go` | 35 | govet×20, gosec×11, noctx×4 |
 | `pkg/xtcp/deserialize.go` | 20 | errcheck×7, gocritic×6, G104×3 |
-| `pkg/xtcpnl/xtcpnl_pcap_test.go` | 16 | gocritic×12, goconst×4 |
-| `pkg/xtcpnl/calculatePad_test.go` | 15 | gocritic×12, goconst×3 |
+| `tools/quality-report/main.go` | 18 | errcheck×11, govet×4, gocritic×1 |
+| `pkg/xtcpnl/xtcpnl_bench_test.go` | 15 | gocritic×15 |
 | `pkg/xtcp/deserializers.go` | 14 | gocritic×13, funlen×1 |
-| `pkg/xtcpnl/xtcpnl_RTAttr_test.go` | 14 | goconst×14 |
+| `pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go` | 14 | gocritic×14 |
+| `pkg/xtcpnl/calculatePad_test.go` | 12 | gocritic×12 |
 | `pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo.go` | 12 | staticcheck×7, dupl×2, funlen×2 |
+| `pkg/xtcpnl/xtcpnl_pcap_test.go` | 12 | gocritic×12 |
+| `pkg/io_uring/bench_test.go` | 9 | govet×7, unconvert×2 |
 
 
 ---
@@ -84,12 +84,6 @@ between commits reveals exactly what changed.
 - `cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go:22`: commentFormatting: put a space between `//` and comment text
 - `cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db.go:18`: commentFormatting: put a space between `//` and comment text
 - `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:26`: commentFormatting: put a space between `//` and comment text
-
-### golangci-lint / goconst — 139
-
-- `pkg/misc/misc_test.go:59`: string `./testdata/non_copy_write_text` has 4 occurrences, make it a constant
-- `pkg/xtcp/deserialize_test.go:63`: string `null:` has 3 occurrences, make it a constant
-- `pkg/xtcp/deserialize_test.go:78`: string `counts` has 7 occurrences, make it a constant
 
 ### golangci-lint / govet — 84
 
@@ -117,7 +111,7 @@ between commits reveals exactly what changed.
 
 ### golangci-lint / gosec — 15
 
-- `pkg/misc/misc_test.go:105`: G104: Errors unhandled
+- `pkg/misc/misc_test.go:108`: G104: Errors unhandled
 - `pkg/xtcp/deserialize_test.go:161`: G104: Errors unhandled
 - `pkg/xtcp/destinations_test.go:114`: G104: Errors unhandled
 
@@ -145,17 +139,30 @@ between commits reveals exactly what changed.
 - `cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db.go:71`: Consider preallocating values with capacity len(valueStrs)
 - `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:106`: Consider preallocating values with capacity len(valueStrs)
 
+### golangci-lint / misspell — 2
+
+- `pkg/xtcp/prometheus.go:12`: `centralising` is a misspelling of `centralizing`
+- `pkg/xtcpnl/testdata_test.go:6`: `Centralise` is a misspelling of `Centralize`
+
 ### golangci-lint / contextcheck — 1
 
 - `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:298`: Non-inherited new context, use function like `context.WithXXX` instead
 
 ### golangci-lint / exhaustive — 1
 
-- `pkg/xtcp/destinations_core.go:105`: missing cases in switch of type xtcp.destLookup: xtcp.destLookupFound
+- `pkg/xtcp/destinations_core.go:123`: missing cases in switch of type xtcp.destLookup: xtcp.destLookupFound
+
+### gofmt / format — 1
+
+- `pkg/xtcpnl/testdata_test.go`: file not formatted
 
 ### golangci-lint / gocyclo — 1
 
 - `cmd/xtcp2/xtcp2.go:446`: cyclomatic complexity 61 of func `environmentOverrideConfig` is high (> 30)
+
+### golangci-lint / gofmt — 1
+
+- `pkg/xtcpnl/testdata_test.go:49`: File is not properly formatted
 
 ---
 
@@ -176,7 +183,7 @@ between commits reveals exactly what changed.
 - **low** `G104` at `pkg/xtcp/deserialize.go:277` — Errors unhandled (CWE-703)
 - **low** `G104` at `pkg/xtcp/deserialize.go:310` — Errors unhandled (CWE-703)
 - **low** `G104` at `pkg/xtcp/grpc_server.go:80` — Errors unhandled (CWE-703)
-- **low** `G104` at `tools/quality-report/main.go:722` — Errors unhandled (CWE-703)
+- **low** `G104` at `tools/quality-report/main.go:742` — Errors unhandled (CWE-703)
 - **low** `G104` at `tools/tcp_client/tcp_client.go:98` — Errors unhandled (CWE-703)
 - **low** `G104` at `tools/tcp_client/tcp_client.go:105` — Errors unhandled (CWE-703)
 
@@ -211,8 +218,9 @@ between commits reveals exactly what changed.
 
 ## 10. Format checks
 
-`gofmt`: clean.
+**`gofmt` would reformat (1 file):**
 
+- `pkg/xtcpnl/testdata_test.go`
 `nixfmt`: clean.
 
 ---
@@ -234,8 +242,9 @@ the adjacent YAML comment. Rows with no justification need review.
 
 ## 12. Recommendations
 
-- Top contributor: **golangci-lint/gocritic** with 185 findings (32% of total). Concentrate effort here for the biggest quality win.
-- Run `lint-fix` (or `golangci-lint run --fix`) to auto-resolve ~12 quick-fixable findings before manual review.
-- Hotspot file: `pkg/xtcp/destinations_test.go` carries 43 findings (govet×20, gosec×11, goconst×8). Refactor here before touching adjacent code.
+- Top contributor: **golangci-lint/gocritic** with 185 findings (42% of total). Concentrate effort here for the biggest quality win.
+- Run `lint-fix` (or `golangci-lint run --fix`) to auto-resolve ~16 quick-fixable findings before manual review.
+- Hotspot file: `pkg/xtcp/destinations_test.go` carries 35 findings (govet×20, gosec×11, noctx×4). Refactor here before touching adjacent code.
 - 3 pre-existing test failure(s) tracked via `tools/quality-report/known-failures.txt`. Schedule a focused fix-up; today they're masking real regression signal.
+- Format files are out of sync — run `gofmt -w .` and `nixfmt **/*.nix` to bring formatting back to baseline.
 

--- a/pkg/misc/misc_test.go
+++ b/pkg/misc/misc_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 )
 
+// Shared test fixture path.
+const testdataNonCopyWriteText = "./testdata/non_copy_write_text"
+
 // https://dave.cheney.net/2016/05/10/test-fixtures-in-go
 // t.Log(wd)
 
@@ -56,7 +59,7 @@ func TestMaxLoopsOrForEver(t *testing.T) {
 // Please note the benchmarking code below doesn't seem to find much difference
 func TestScanFile(t *testing.T) {
 
-	filename := "./testdata/non_copy_write_text"
+	filename := testdataNonCopyWriteText
 	scanFileLines := ScanFile(filename)
 	readFileLines := ReadFile(filename)
 
@@ -70,7 +73,7 @@ func TestScanFile(t *testing.T) {
 
 func BenchmarkScanFile(b *testing.B) {
 
-	filename := "./testdata/non_copy_write_text"
+	filename := testdataNonCopyWriteText
 	for n := 0; n < b.N; n++ {
 		scanFileLines := ScanFile(filename)
 		if debugLevel > 100 {
@@ -81,7 +84,7 @@ func BenchmarkScanFile(b *testing.B) {
 
 func BenchmarkReadFile(b *testing.B) {
 
-	filename := "./testdata/non_copy_write_text"
+	filename := testdataNonCopyWriteText
 	for n := 0; n < b.N; n++ {
 		readFileLines := ReadFile(filename)
 		if debugLevel > 100 {
@@ -93,7 +96,7 @@ func BenchmarkReadFile(b *testing.B) {
 func benchmarkFileN(n int, scanType string, b *testing.B) {
 
 	// read in the file
-	filename := "./testdata/non_copy_write_text"
+	filename := testdataNonCopyWriteText
 	scanFileLines := ScanFile(filename)
 
 	// write out larger file (x100)

--- a/pkg/xtcp/deserialize_test.go
+++ b/pkg/xtcp/deserialize_test.go
@@ -75,16 +75,16 @@ func newTestDeserializeXTCP(tb testing.TB) *XTCP {
 	// Fresh metrics registry per call so tests don't collide.
 	reg := prometheus.NewRegistry()
 	x.pC = promauto.With(reg).NewCounterVec(
-		prometheus.CounterOpts{Subsystem: "xtcp_dtest", Name: "counts", Help: "counts"},
-		[]string{"function", "variable", "type"},
+		prometheus.CounterOpts{Subsystem: "xtcp_dtest", Name: promNameCounts, Help: promNameCounts},
+		promLabels,
 	)
 	x.pH = promauto.With(reg).NewSummaryVec(
 		prometheus.SummaryOpts{
-			Subsystem: "xtcp_dtest", Name: "histograms", Help: "histograms",
+			Subsystem: "xtcp_dtest", Name: promNameHistograms, Help: promNameHistograms,
 			Objectives: map[float64]float64{0.5: quantileError, 0.99: quantileError},
 			MaxAge:     summaryVecMaxAge,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	// flatRecordServiceSend touches x.flatRecordService.frMapCount(); a

--- a/pkg/xtcp/deserialize_test.go
+++ b/pkg/xtcp/deserialize_test.go
@@ -60,7 +60,7 @@ func newTestDeserializeXTCP(tb testing.TB) *XTCP {
 	x.config = &xtcp_config.XtcpConfig{
 		Modulus:    1,
 		MarshalTo:  "protobufSingle",
-		Dest:       "null:",
+		Dest:       schemeNullPrefix,
 		DebugLevel: 0,
 	}
 	x.debugLevel = 0

--- a/pkg/xtcp/destinations_core.go
+++ b/pkg/xtcp/destinations_core.go
@@ -25,14 +25,32 @@ type Destination interface {
 // any backing client. Returning a non-nil error aborts process startup.
 type DestinationFactory func(ctx context.Context, x *XTCP) (Destination, error)
 
+// Destination scheme identifiers. Doubles as the scheme prefix in `-dest
+// <scheme>:<addr>` and (for unix/unixgram/udp) as the corresponding net
+// package network name accepted by net.Dial / net.Listen.
+const (
+	schemeNull     = "null"
+	schemeUDP      = "udp"
+	schemeUnix     = "unix"
+	schemeUnixgram = "unixgram"
+	schemeKafka    = "kafka"
+	schemeNats     = "nats"
+	schemeNsq      = "nsq"
+	schemeValkey   = "valkey"
+
+	// schemeNullPrefix is the `-dest` value that selects the null sink
+	// without an address payload. Used as a no-op destination in tests.
+	schemeNullPrefix = "null:"
+)
+
 // knownSchemes is the closed set of every destination scheme xtcp2 has ever
 // supported. The set of compiled-in schemes is a subset (those whose
 // `dest_<scheme>` build tag is set). Used by the CLI error path to
 // distinguish "unknown scheme" from "exists but not compiled into this
 // binary" so the operator gets the right hint.
 var knownSchemes = []string{
-	"null", "udp", "unix", "unixgram",
-	"kafka", "nats", "nsq", "valkey",
+	schemeNull, schemeUDP, schemeUnix, schemeUnixgram,
+	schemeKafka, schemeNats, schemeNsq, schemeValkey,
 }
 
 var (

--- a/pkg/xtcp/destinations_test.go
+++ b/pkg/xtcp/destinations_test.go
@@ -264,7 +264,7 @@ func runDestRow(t *testing.T, c destCase, payloads [][]byte) {
 		if err != nil {
 			t.Fatalf("payload[%d] Send err: %v", i, err)
 		}
-		if c.scheme == "null" {
+		if c.scheme == schemeNull {
 			if n != len(payload) {
 				t.Errorf("payload[%d] null n=%d want=%d", i, n, len(payload))
 			}
@@ -292,16 +292,16 @@ func TestDestinations(t *testing.T) {
 	identity := func(p []byte) []byte { return p }
 
 	cases := []destCase{
-		{name: "null", scheme: "null", setup: setupNullDest, expectFrame: identity},
-		{name: "udp_round_trip", scheme: "udp", setup: setupUDPDest, expectFrame: identity},
-		{name: "udp_multiple", scheme: "udp", setup: setupUDPDest, expectFrame: identity},
-		{name: "unixgram_round_trip", scheme: "unixgram", setup: setupUnixGramDest, expectFrame: identity},
-		{name: "unixgram_multiple", scheme: "unixgram", setup: setupUnixGramDest, expectFrame: identity},
+		{name: schemeNull, scheme: schemeNull, setup: setupNullDest, expectFrame: identity},
+		{name: "udp_round_trip", scheme: schemeUDP, setup: setupUDPDest, expectFrame: identity},
+		{name: "udp_multiple", scheme: schemeUDP, setup: setupUDPDest, expectFrame: identity},
+		{name: "unixgram_round_trip", scheme: schemeUnixgram, setup: setupUnixGramDest, expectFrame: identity},
+		{name: "unixgram_multiple", scheme: schemeUnixgram, setup: setupUnixGramDest, expectFrame: identity},
 		// For unix, recv() already strips the varint length prefix and returns
 		// the raw payload; the framing is exercised inside recv()'s
 		// binary.ReadUvarint + io.ReadFull. So the comparison is identity.
-		{name: "unix_round_trip", scheme: "unix", setup: setupUnixDest, expectFrame: identity},
-		{name: "unix_multiple", scheme: "unix", setup: setupUnixDest, expectFrame: identity},
+		{name: "unix_round_trip", scheme: schemeUnix, setup: setupUnixDest, expectFrame: identity},
+		{name: "unix_multiple", scheme: schemeUnix, setup: setupUnixDest, expectFrame: identity},
 	}
 
 	single := [][]byte{[]byte("hello-xtcp2-record")}
@@ -332,12 +332,12 @@ func TestDestinationsIoUring(t *testing.T) {
 	identity := func(p []byte) []byte { return p }
 
 	cases := []destCase{
-		{name: "udp_round_trip_iouring", scheme: "udp", setup: setupUDPDest, expectFrame: identity},
-		{name: "udp_multiple_iouring", scheme: "udp", setup: setupUDPDest, expectFrame: identity},
-		{name: "unixgram_round_trip_iouring", scheme: "unixgram", setup: setupUnixGramDest, expectFrame: identity},
-		{name: "unixgram_multiple_iouring", scheme: "unixgram", setup: setupUnixGramDest, expectFrame: identity},
-		{name: "unix_round_trip_iouring", scheme: "unix", setup: setupUnixDest, expectFrame: identity},
-		{name: "unix_multiple_iouring", scheme: "unix", setup: setupUnixDest, expectFrame: identity},
+		{name: "udp_round_trip_iouring", scheme: schemeUDP, setup: setupUDPDest, expectFrame: identity},
+		{name: "udp_multiple_iouring", scheme: schemeUDP, setup: setupUDPDest, expectFrame: identity},
+		{name: "unixgram_round_trip_iouring", scheme: schemeUnixgram, setup: setupUnixGramDest, expectFrame: identity},
+		{name: "unixgram_multiple_iouring", scheme: schemeUnixgram, setup: setupUnixGramDest, expectFrame: identity},
+		{name: "unix_round_trip_iouring", scheme: schemeUnix, setup: setupUnixDest, expectFrame: identity},
+		{name: "unix_multiple_iouring", scheme: schemeUnix, setup: setupUnixDest, expectFrame: identity},
 	}
 
 	single := [][]byte{[]byte("hello-iouring-record")}
@@ -588,7 +588,7 @@ func (t testingTB) Fatalf(format string, args ...any) { t.TB.Fatalf(format, args
 
 // Adapt the *testing.T setup signatures to testing.TB.
 func setupNullDestTB(t testing.TB, _ string) destSetupResult {
-	return destSetupResult{dest: "null:", recv: nil, cleanup: func() {}}
+	return destSetupResult{dest: schemeNullPrefix, recv: nil, cleanup: func() {}}
 }
 func setupUDPDestTB(t testing.TB, dir string) destSetupResult {
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -686,14 +686,14 @@ func setupUnixDestTB(t testing.TB, dir string) destSetupResult {
 }
 
 func BenchmarkDestNull(b *testing.B) {
-	benchDest(b, "null", setupNullDestTB)
+	benchDest(b, schemeNull, setupNullDestTB)
 }
 func BenchmarkDestUDP(b *testing.B) {
-	benchDest(b, "udp", setupUDPDestTB)
+	benchDest(b, schemeUDP, setupUDPDestTB)
 }
 func BenchmarkDestUnixGram(b *testing.B) {
-	benchDest(b, "unixgram", setupUnixGramDestTB)
+	benchDest(b, schemeUnixgram, setupUnixGramDestTB)
 }
 func BenchmarkDestUnix(b *testing.B) {
-	benchDest(b, "unix", setupUnixDestTB)
+	benchDest(b, schemeUnix, setupUnixDestTB)
 }

--- a/pkg/xtcp/destinations_test.go
+++ b/pkg/xtcp/destinations_test.go
@@ -63,16 +63,16 @@ func newTestXTCP(t *testing.T, dest string) *XTCP {
 
 	reg := prometheus.NewRegistry()
 	x.pC = promauto.With(reg).NewCounterVec(
-		prometheus.CounterOpts{Subsystem: "xtcp_test", Name: "counts", Help: "test counts"},
-		[]string{"function", "variable", "type"},
+		prometheus.CounterOpts{Subsystem: "xtcp_test", Name: promNameCounts, Help: "test counts"},
+		promLabels,
 	)
 	x.pH = promauto.With(reg).NewSummaryVec(
 		prometheus.SummaryOpts{
-			Subsystem: "xtcp_test", Name: "histograms", Help: "test histograms",
+			Subsystem: "xtcp_test", Name: promNameHistograms, Help: "test histograms",
 			Objectives: map[float64]float64{0.5: quantileError, 0.99: quantileError},
 			MaxAge:     summaryVecMaxAge,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	return x
@@ -524,12 +524,12 @@ func benchDest(b *testing.B, scheme string, setup func(t testing.TB, dir string)
 	}
 	reg := prometheus.NewRegistry()
 	x.pC = promauto.With(reg).NewCounterVec(
-		prometheus.CounterOpts{Subsystem: "xtcp_bench", Name: "counts", Help: "bench counts"},
-		[]string{"function", "variable", "type"},
+		prometheus.CounterOpts{Subsystem: "xtcp_bench", Name: promNameCounts, Help: "bench counts"},
+		promLabels,
 	)
 	x.pH = promauto.With(reg).NewSummaryVec(
-		prometheus.SummaryOpts{Subsystem: "xtcp_bench", Name: "histograms", Help: "bench histograms"},
-		[]string{"function", "variable", "type"},
+		prometheus.SummaryOpts{Subsystem: "xtcp_bench", Name: promNameHistograms, Help: "bench histograms"},
+		promLabels,
 	)
 
 	ctx := context.Background()

--- a/pkg/xtcp/grpc_configService.go
+++ b/pkg/xtcp/grpc_configService.go
@@ -46,17 +46,17 @@ func NewXtcpConfigService(
 	c.pC = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: "xtcp_config_grpc",
-			Name:      "counts",
-			Help:      "xtcp counts",
+			Name:      promNameCounts,
+			Help:      promHelpCounts,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	c.pH = promauto.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Subsystem: "xtcp_config_grpc",
-			Name:      "histograms",
-			Help:      "xtcp historgrams",
+			Name:      promNameHistograms,
+			Help:      promHelpHistograms,
 			Objectives: map[float64]float64{
 				0.1:  quantileError,
 				0.5:  quantileError,
@@ -64,7 +64,7 @@ func NewXtcpConfigService(
 			},
 			MaxAge: summaryVecMaxAge,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	return c

--- a/pkg/xtcp/grpc_flatRecordService.go
+++ b/pkg/xtcp/grpc_flatRecordService.go
@@ -55,17 +55,17 @@ func NewXtcpFlatRecordService(ctx context.Context, pollRequestCh *chan struct{},
 	s.pC = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: "xtcp_record_grpc",
-			Name:      "counts",
-			Help:      "xtcp counts",
+			Name:      promNameCounts,
+			Help:      promHelpCounts,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	s.pH = promauto.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Subsystem: "xtcp_record_grpc",
-			Name:      "histograms",
-			Help:      "xtcp historgrams",
+			Name:      promNameHistograms,
+			Help:      promHelpHistograms,
 			Objectives: map[float64]float64{
 				0.1:  quantileError,
 				0.5:  quantileError,
@@ -73,7 +73,7 @@ func NewXtcpFlatRecordService(ctx context.Context, pollRequestCh *chan struct{},
 			},
 			MaxAge: summaryVecMaxAge,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	return s

--- a/pkg/xtcp/input_validation.go
+++ b/pkg/xtcp/input_validation.go
@@ -11,7 +11,7 @@ func (x *XTCP) InputValidation() {
 		log.Fatalf("InputValidation XTCP Marshal must be one of:%s MarshalTo:%s", validMarshallers(), x.config.MarshalTo)
 	}
 
-	if x.config.Dest != "null" {
+	if x.config.Dest != schemeNull {
 
 		scheme, _, found := strings.Cut(x.config.Dest, ":")
 
@@ -24,7 +24,7 @@ func (x *XTCP) InputValidation() {
 		// path (unix/unixgram) need only one — the rest of the dest is a
 		// path that can itself contain colons in pathological cases.
 		switch scheme {
-		case "unix", "unixgram":
+		case schemeUnix, schemeUnixgram:
 			// only the leading `<scheme>:` separator is required; the
 			// per-destination factory validates the path further.
 		default:

--- a/pkg/xtcp/ns_reconcile_test.go
+++ b/pkg/xtcp/ns_reconcile_test.go
@@ -6,9 +6,21 @@ import (
 	"testing"
 )
 
-// const (
-// 	debugLevelForTest = 111
-// )
+// Test-fixture keys/values reused across every TestReconcileMaps row.
+const (
+	testKey1   = "key1"
+	testKey2   = "key2"
+	testKey3   = "key3"
+	testKey4   = "key4"
+	testValue1 = "value1"
+	testValue2 = "value2"
+	testValue3 = "value3"
+	testValue4 = "value4"
+
+	// testOldValue2 mimics a stale entry already present in the destination
+	// map when reconcileMaps runs — it should be replaced by testValue2.
+	testOldValue2 = "old_value2"
+)
 
 func TestReconcileMaps(t *testing.T) {
 	tests := []struct {
@@ -22,16 +34,16 @@ func TestReconcileMaps(t *testing.T) {
 		{
 			name: "Add missing keys and remove extra keys",
 			srcEntries: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			destEntries: map[interface{}]interface{}{
-				"key2": "old_value2",
-				"key3": "value3",
+				testKey2: testOldValue2,
+				testKey3: testValue3,
 			},
 			expectedDest: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			deletes: 2,
 			stores:  2,
@@ -39,16 +51,16 @@ func TestReconcileMaps(t *testing.T) {
 		{
 			name: "No changes needed",
 			srcEntries: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			destEntries: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			expectedDest: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			deletes: 0,
 			stores:  0,
@@ -56,17 +68,17 @@ func TestReconcileMaps(t *testing.T) {
 		{
 			name: "Add missing keys and remove extra keys, one extra",
 			srcEntries: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			destEntries: map[interface{}]interface{}{
-				"key2": "old_value2",
-				"key3": "value3",
-				"key4": "value4",
+				testKey2: testOldValue2,
+				testKey3: testValue3,
+				testKey4: testValue4,
 			},
 			expectedDest: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			deletes: 3,
 			stores:  2,
@@ -74,15 +86,15 @@ func TestReconcileMaps(t *testing.T) {
 		{
 			name: "Add missing keys and remove extra keys, one less",
 			srcEntries: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			destEntries: map[interface{}]interface{}{
-				"key2": "old_value2",
+				testKey2: testOldValue2,
 			},
 			expectedDest: map[interface{}]interface{}{
-				"key1": "value1",
-				"key2": "value2",
+				testKey1: testValue1,
+				testKey2: testValue2,
 			},
 			deletes: 1,
 			stores:  2,

--- a/pkg/xtcp/prometheus.go
+++ b/pkg/xtcp/prometheus.go
@@ -7,24 +7,50 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Shared metric-naming strings for every prometheus.{Counter,Summary,Gauge}Vec
+// the package and its tests register. The grpc service constructors and the
+// test harnesses all use the same Name/Help/Label values; centralising them
+// here keeps them in lockstep and silences goconst.
+const (
+	promSubsystemXTCP = "xtcp"
+
+	promNameCounts     = "counts"
+	promNameHistograms = "histograms"
+	promNameGauge      = "gauge"
+
+	promHelpCounts     = "xtcp counts"
+	promHelpHistograms = "xtcp historgrams" //nolint:misspell // preserved spelling from existing metric — renaming would invalidate downstream dashboards
+	promHelpGauge      = "xtcp network namespace gauge"
+
+	promLabelFunction = "function"
+	promLabelVariable = "variable"
+	promLabelType     = "type"
+)
+
+// promLabels is the canonical label set for the {Counter,Summary}Vec metrics
+// registered by InitPromethus, NewXtcpConfigService, and
+// NewXtcpFlatRecordService. Identical layout across all three so dashboards
+// can join on (function, variable, type).
+var promLabels = []string{promLabelFunction, promLabelVariable, promLabelType}
+
 func (x *XTCP) InitPromethus(wg *sync.WaitGroup) {
 
 	defer wg.Done()
 
 	x.pC = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: "xtcp",
-			Name:      "counts",
-			Help:      "xtcp counts",
+			Subsystem: promSubsystemXTCP,
+			Name:      promNameCounts,
+			Help:      promHelpCounts,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	x.pH = promauto.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Subsystem: "xtcp",
-			Name:      "histograms",
-			Help:      "xtcp historgrams",
+			Subsystem: promSubsystemXTCP,
+			Name:      promNameHistograms,
+			Help:      promHelpHistograms,
 			Objectives: map[float64]float64{
 				0.1:  quantileError,
 				0.5:  quantileError,
@@ -32,14 +58,14 @@ func (x *XTCP) InitPromethus(wg *sync.WaitGroup) {
 			},
 			MaxAge: summaryVecMaxAge,
 		},
-		[]string{"function", "variable", "type"},
+		promLabels,
 	)
 
 	x.pG = promauto.NewGauge(
 		prometheus.GaugeOpts{
-			Subsystem: "xtcp",
-			Name:      "gauge",
-			Help:      "xtcp network namespace gauge",
+			Subsystem: promSubsystemXTCP,
+			Name:      promNameGauge,
+			Help:      promHelpGauge,
 		},
 	)
 

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -141,7 +141,7 @@ func NewNsTestingXTCP(ctx context.Context, cancel context.CancelFunc, debugLevel
 
 	x.config = &xtcp_config.XtcpConfig{
 		NlTimeoutMilliseconds: 5000,
-		Dest:                  "null",
+		Dest:                  schemeNull,
 		MarshalTo:             "proto",
 		Topic:                 "not-a-topic",
 		EnabledDeserializers: &xtcp_config.EnabledDeserializers{

--- a/pkg/xtcpnl/calculatePad_test.go
+++ b/pkg/xtcpnl/calculatePad_test.go
@@ -15,7 +15,7 @@ type calculatePadTest struct {
 func TestCalculatePadding(t *testing.T) {
 	var tests = []calculatePadTest{
 		{
-			description: "pad slow",
+			description: tnPadSlow,
 			RTAttrLen:   0,
 			F: func(size int) int {
 				return CalculatePadding(size)
@@ -23,7 +23,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 0,
 		},
 		{
-			description: "pad slow",
+			description: tnPadSlow,
 			RTAttrLen:   5,
 			F: func(size int) int {
 				return CalculatePadding(size)
@@ -31,7 +31,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 3,
 		},
 		{
-			description: "pad slow",
+			description: tnPadSlow,
 			RTAttrLen:   6,
 			F: func(size int) int {
 				return CalculatePadding(size)
@@ -39,7 +39,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 2,
 		},
 		{
-			description: "pad slow",
+			description: tnPadSlow,
 			RTAttrLen:   7,
 			F: func(size int) int {
 				return CalculatePadding(size)
@@ -47,7 +47,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 1,
 		},
 		{
-			description: "pad slow",
+			description: tnPadSlow,
 			RTAttrLen:   8,
 			F: func(size int) int {
 				return CalculatePadding(size)
@@ -56,7 +56,7 @@ func TestCalculatePadding(t *testing.T) {
 		},
 		// Fast! Branchless
 		{
-			description: "pad fast/brachless",
+			description: tnPadFastBranchless,
 			RTAttrLen:   0,
 			F: func(size int) int {
 				return FourByteAlignPadding(size)
@@ -64,7 +64,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 0,
 		},
 		{
-			description: "pad fast/brachless",
+			description: tnPadFastBranchless,
 			RTAttrLen:   5,
 			F: func(size int) int {
 				return FourByteAlignPadding(size)
@@ -72,7 +72,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 3,
 		},
 		{
-			description: "pad fast/brachless",
+			description: tnPadFastBranchless,
 			RTAttrLen:   6,
 			F: func(size int) int {
 				return FourByteAlignPadding(size)
@@ -80,7 +80,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 2,
 		},
 		{
-			description: "pad fast/brachless",
+			description: tnPadFastBranchless,
 			RTAttrLen:   7,
 			F: func(size int) int {
 				return FourByteAlignPadding(size)
@@ -88,7 +88,7 @@ func TestCalculatePadding(t *testing.T) {
 			Pad: 1,
 		},
 		{
-			description: "pad fast/brachless",
+			description: tnPadFastBranchless,
 			RTAttrLen:   8,
 			F: func(size int) int {
 				return FourByteAlignPadding(size)
@@ -132,7 +132,7 @@ func BenchmarkPadFourByteAlignPadding(b *testing.B) {
 func CalculatePaddingBoth(b *testing.B, f func(size int) int) {
 	var tests = []calculatePadTest{
 		{
-			description: "verify_request",
+			description: tnVerifyRequest,
 			RTAttrLen:   6,
 			Pad:         2,
 		},

--- a/pkg/xtcpnl/testdata_test.go
+++ b/pkg/xtcpnl/testdata_test.go
@@ -46,28 +46,28 @@ const (
 	tdAttrTos2_6_6_44       = tdBase + "/6_6_44/attribute_tos2"
 
 	// 6.6.44 request bytes / single-packet captures
-	tdReqBytes_6_6_44        = tdBase + "/6_6_44/netlink_sock_diag_request_bytes"
-	tdReqBytes2_6_6_44       = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example2"
-	tdReqBytes3_6_6_44       = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example3"
-	tdReqSinglePktV6_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap"
-	tdReplyPort4001_6_6_44   = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap"
-	tdReplyPort4018_6_6_44   = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap"
-	tdReplyPort443V4_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap"
-	tdReplyPort443V6_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap"
+	tdReqBytes_6_6_44       = tdBase + "/6_6_44/netlink_sock_diag_request_bytes"
+	tdReqBytes2_6_6_44      = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example2"
+	tdReqBytes3_6_6_44      = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example3"
+	tdReqSinglePktV6_6_6_44 = tdBase + "/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap"
+	tdReplyPort4001_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap"
+	tdReplyPort4018_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap"
+	tdReplyPort443V4_6_6_44 = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap"
+	tdReplyPort443V6_6_6_44 = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap"
 
 	// 6.10.3
-	tdAttrInfo_6_10_3       = tdBase + "/6_10_3/attribute_info"
-	tdAttrBbrinfo_6_10_3    = tdBase + "/6_10_3/attribute_bbrinfo"
-	tdAttrSockopt_6_10_3    = tdBase + "/6_10_3/attribute_sockopt_4305"
-	tdReplyPort4322_6_10_3  = tdBase + "/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap"
-	tdRespDumpDone_6_10_3   = tdBase + "/6_10_3/netlink_sock_diag_response_dump_done.pcap"
+	tdAttrInfo_6_10_3      = tdBase + "/6_10_3/attribute_info"
+	tdAttrBbrinfo_6_10_3   = tdBase + "/6_10_3/attribute_bbrinfo"
+	tdAttrSockopt_6_10_3   = tdBase + "/6_10_3/attribute_sockopt_4305"
+	tdReplyPort4322_6_10_3 = tdBase + "/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap"
+	tdRespDumpDone_6_10_3  = tdBase + "/6_10_3/netlink_sock_diag_response_dump_done.pcap"
 
 	// 4.19.319
-	tdAttrMeminfo_4_19_319  = tdBase + "/4_19_319/attribute_meminfo_f4096"
+	tdAttrMeminfo_4_19_319   = tdBase + "/4_19_319/attribute_meminfo_f4096"
 	tdReplyPort4005_4_19_319 = tdBase + "/4_19_319/netlink_sock_diag_reply_single_packet_port4005.pcap"
 
 	// 7.0.3
-	tdResp26546_7_0_3 = tdBase + "/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap"
+	tdResp26546_7_0_3   = tdBase + "/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap"
 	tdResp19000V6_7_0_3 = tdBase + "/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6.pcap"
 
 	// Bare testdata/ (no kernel subdir — placeholder fixtures)

--- a/pkg/xtcpnl/testdata_test.go
+++ b/pkg/xtcpnl/testdata_test.go
@@ -1,0 +1,75 @@
+package xtcpnl
+
+// Shared constants for the xtcpnl test suite.
+//
+// goconst would otherwise flag the testdata paths and t.Run sub-test names
+// that recur across this package's _test.go files. Centralise them here so
+// adding a new test for an existing fixture reuses the same name and any
+// path change lands in exactly one place.
+
+// Sub-test names passed to t.Run.
+const (
+	tnAttrInfo          = "attribute_info"
+	tnAttrBbrinfo       = "attribute_bbrinfo"
+	tnAttrVegasinfo     = "attribute_vegasinfo"
+	tnAttrCgroupID      = "attribute_cgroup_id"
+	tnAttrShutdown      = "attribute_shutdown"
+	tnAttrSkmeminfo2    = "attribute_skmeminfo2"
+	tnAttrSockopt       = "attribute_sockopt"
+	tnAttrTcclass       = "attribute_tcclass"
+	tnPort4018          = "port4018"
+	tnVerifyRequest     = "verify_request"
+	tnDeserializePcap   = "DeserializePcapTest"
+	tnPadSlow           = "pad slow"
+	tnPadFastBranchless = "pad fast/brachless"
+	tnMeminfo4_19_319   = "4_19_319_attribute_meminfo"
+	tnSport26546V4      = "7_0_3 sport26546 dport443"
+	tnSport19000V6      = "7_0_3 sport19000 dport10156 v6"
+)
+
+// Testdata file paths. Grouped by kernel-version subdirectory so a new
+// kernel's fixtures fall in next to its peers.
+const (
+	tdBase = "./testdata"
+
+	// 6.6.44 attributes
+	tdAttrInfo_6_6_44       = tdBase + "/6_6_44/attribute_info"
+	tdAttrBbrinfo_6_6_44    = tdBase + "/6_6_44/attribute_bbrinfo"
+	tdAttrVegasinfo_6_6_44  = tdBase + "/6_6_44/attribute_vegasinfo"
+	tdAttrClassID_6_6_44    = tdBase + "/6_6_44/attribute_class_id"
+	tdAttrCgroupID_6_6_44   = tdBase + "/6_6_44/attribute_cgroup_id"
+	tdAttrDctcpinfo_6_6_44  = tdBase + "/6_6_44/attribute_dctcpinfo_4033"
+	tdAttrShutdown_6_6_44   = tdBase + "/6_6_44/attribute_shutdown"
+	tdAttrSkmeminfo2_6_6_44 = tdBase + "/6_6_44/attribute_skmeminfo2"
+	tdAttrTcclass_6_6_44    = tdBase + "/6_6_44/attribute_tcclass"
+	tdAttrTos_6_6_44        = tdBase + "/6_6_44/attribute_tos"
+	tdAttrTos2_6_6_44       = tdBase + "/6_6_44/attribute_tos2"
+
+	// 6.6.44 request bytes / single-packet captures
+	tdReqBytes_6_6_44        = tdBase + "/6_6_44/netlink_sock_diag_request_bytes"
+	tdReqBytes2_6_6_44       = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example2"
+	tdReqBytes3_6_6_44       = tdBase + "/6_6_44/netlink_sock_diag_request_bytes_example3"
+	tdReqSinglePktV6_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap"
+	tdReplyPort4001_6_6_44   = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap"
+	tdReplyPort4018_6_6_44   = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap"
+	tdReplyPort443V4_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap"
+	tdReplyPort443V6_6_6_44  = tdBase + "/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap"
+
+	// 6.10.3
+	tdAttrInfo_6_10_3       = tdBase + "/6_10_3/attribute_info"
+	tdAttrBbrinfo_6_10_3    = tdBase + "/6_10_3/attribute_bbrinfo"
+	tdAttrSockopt_6_10_3    = tdBase + "/6_10_3/attribute_sockopt_4305"
+	tdReplyPort4322_6_10_3  = tdBase + "/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap"
+	tdRespDumpDone_6_10_3   = tdBase + "/6_10_3/netlink_sock_diag_response_dump_done.pcap"
+
+	// 4.19.319
+	tdAttrMeminfo_4_19_319  = tdBase + "/4_19_319/attribute_meminfo_f4096"
+	tdReplyPort4005_4_19_319 = tdBase + "/4_19_319/netlink_sock_diag_reply_single_packet_port4005.pcap"
+
+	// 7.0.3
+	tdResp26546_7_0_3 = tdBase + "/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap"
+	tdResp19000V6_7_0_3 = tdBase + "/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6.pcap"
+
+	// Bare testdata/ (no kernel subdir — placeholder fixtures)
+	tdAttrPragueinfoFake = tdBase + "/attribute_pragueinfo_fake_fixme"
+)

--- a/pkg/xtcpnl/xtcpnl_RTAttr_test.go
+++ b/pkg/xtcpnl/xtcpnl_RTAttr_test.go
@@ -18,8 +18,8 @@ func TestDeserializeRTAttr(t *testing.T) {
 	var tests = []DeserializeRTAttrTest{
 		// bbrinfo
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_6_44/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_6_44,
 			length:      24,
 			tyype:       16,
 		},
@@ -31,8 +31,8 @@ func TestDeserializeRTAttr(t *testing.T) {
 		},
 		// vegasinfo
 		{
-			description: "attribute_vegasinfo",
-			filename:    "./testdata/6_6_44/attribute_vegasinfo",
+			description: tnAttrVegasinfo,
+			filename:    tdAttrVegasinfo_6_6_44,
 			length:      20,
 			tyype:       3,
 		},
@@ -46,7 +46,7 @@ func TestDeserializeRTAttr(t *testing.T) {
 		// class_id
 		{
 			description: "attribute_class_id",
-			filename:    "./testdata/6_6_44/attribute_class_id",
+			filename:    tdAttrClassID_6_6_44,
 			length:      8,
 			tyype:       17,
 		},
@@ -82,7 +82,7 @@ func TestDeserializeRTAttr(t *testing.T) {
 		// group_id
 		{
 			description: "attribute_group_id",
-			filename:    "./testdata/6_6_44/attribute_cgroup_id",
+			filename:    tdAttrCgroupID_6_6_44,
 			length:      12,
 			tyype:       21,
 		},
@@ -94,15 +94,15 @@ func TestDeserializeRTAttr(t *testing.T) {
 			tyype:       1,
 		},
 		{
-			description: "4_19_319_attribute_meminfo",
-			filename:    "./testdata/4_19_319/attribute_meminfo_f4096",
+			description: tnMeminfo4_19_319,
+			filename:    tdAttrMeminfo_4_19_319,
 			length:      20,
 			tyype:       1,
 		},
 		// info
 		{
 			description: "6_10_3 attribute_info",
-			filename:    "./testdata/6_10_3/attribute_info",
+			filename:    tdAttrInfo_6_10_3,
 			length:      252,
 			tyype:       2,
 		},
@@ -114,7 +114,7 @@ func TestDeserializeRTAttr(t *testing.T) {
 		},
 		{
 			description: "6_6_44 attribute_info",
-			filename:    "./testdata/6_6_44/attribute_info",
+			filename:    tdAttrInfo_6_6_44,
 			length:      244,
 			tyype:       2,
 		},
@@ -144,8 +144,8 @@ func TestDeserializeRTAttr(t *testing.T) {
 		},
 		// shutdown
 		{
-			description: "attribute_shutdown",
-			filename:    "./testdata/6_6_44/attribute_shutdown",
+			description: tnAttrShutdown,
+			filename:    tdAttrShutdown_6_6_44,
 			length:      5,
 			tyype:       8,
 		},
@@ -164,7 +164,7 @@ func TestDeserializeRTAttr(t *testing.T) {
 		},
 		// sockopt
 		{
-			description: "attribute_sockopt",
+			description: tnAttrSockopt,
 			filename:    "./testdata/6_6_44/attribute_sockopt",
 			length:      6,
 			tyype:       22,
@@ -172,7 +172,7 @@ func TestDeserializeRTAttr(t *testing.T) {
 		// tos
 		{
 			description: "attribute_tos",
-			filename:    "./testdata/6_6_44/attribute_tos",
+			filename:    tdAttrTos_6_6_44,
 			length:      5,
 			tyype:       5,
 		},

--- a/pkg/xtcpnl/xtcpnl_bench_test.go
+++ b/pkg/xtcpnl/xtcpnl_bench_test.go
@@ -16,8 +16,8 @@ var (
 func BenchmarkDecodeNetlinkDagRequestFromBytes(b *testing.B) {
 	var tests = []DecodeFromBytesSerializeToTest{
 		{
-			description: "verify_request",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes",
+			description: tnVerifyRequest,
+			filename:    tdReqBytes_6_6_44,
 		},
 	}
 
@@ -45,8 +45,8 @@ var (
 func BenchmarkSerializeNetlinkDagRequest(b *testing.B) {
 	var tests = []DecodeFromBytesSerializeToTest{
 		{
-			description: "verify_request",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes",
+			description: tnVerifyRequest,
+			filename:    tdReqBytes_6_6_44,
 		},
 	}
 
@@ -161,7 +161,7 @@ func DeserializeInetDiagReqV2Both(b *testing.B, Func func(data []byte, inetdiagr
 	var tests = []DeserializeInetDiagReqV2Test{
 		{
 			description: "request_v6",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap",
+			filename:    tdReqSinglePktV6_6_6_44,
 			length:      128,
 			family:      2,
 			protocol:    6,
@@ -229,8 +229,8 @@ func BenchmarkDeserializeInetDiagMsgReflection(b *testing.B) {
 func DeserializeInetDiagMsgBoth(b *testing.B, Func func(data []byte, idm *InetDiagMsg, s *InetDiagSockID) (n int, err error)) {
 	var tests = []DeserializeInetDiagMsgTest{
 		{
-			description: "port4018",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap",
+			description: tnPort4018,
+			filename:    tdReplyPort4018_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -361,8 +361,8 @@ func BenchmarkDeserializeRTAttrReflection(b *testing.B) {
 func DeserializeRTAttrBoth(b *testing.B, Func func(data []byte, rta *RTAttr) (n int, err error)) {
 	var tests = []DeserializeRTAttrTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/6_6_44/attribute_info",
+			description: tnAttrInfo,
+			filename:    tdAttrInfo_6_6_44,
 			length:      244,
 			tyype:       2,
 		},

--- a/pkg/xtcpnl/xtcpnl_inet_diag_bbrinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_bbrinfo_test.go
@@ -18,8 +18,8 @@ type DeserializeBBRInfoTest struct {
 func TestDeserializeBBRInfo(t *testing.T) {
 	var tests = []DeserializeBBRInfoTest{
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_6_44/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_6_44,
 			b: BBRInfo{
 				BwLo:       1638398437,
 				BwHi:       0,
@@ -32,8 +32,8 @@ func TestDeserializeBBRInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_6_44/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_6_44,
 			b: BBRInfo{
 				BwLo:       1638398437,
 				BwHi:       0,
@@ -49,8 +49,8 @@ func TestDeserializeBBRInfo(t *testing.T) {
 		//skmem:(r0,rb1000000,t0,tb1000000,f2284,w5908,o0,bl0,d25253) ts sack ecn ecnseen bbr wscale:9,9 rto:662 rtt:318.242/62.166 ato:40 mss:1448 pmtu:1500 rcvmss:1448 advmss:1448 cwnd:8 ssthresh:138 bytes_sent:93568860 bytes_retrans:10168410 bytes_acked:83396335 bytes_received:83396334 segs_out:136944 segs_in:135387 data_segs_out:90018 data_segs_in:82319 bbr:(bw:120824bps,mrtt:0.03,pacing_gain:1.25,cwnd_gain:2) send 291200bps lastsnd:232 lastrcv:370 lastack:370 pacing_rate 119616bps delivery_rate 121232bps delivered:87669 app_limited busy:7387385ms unacked:4 retrans:0/9231 dsack_dups:7385 reordering:5 reord_seen:2662 rcv_rtt:348.502 rcv_space:19464 rcv_ssthresh:498552 minrtt:0.007 rcv_ooopack:12444 snd_wnd:498688 rcv_wnd:498688 rehash:180
 		// bbr:(bw:120824bps,mrtt:0.03,pacing_gain:1.25,cwnd_gain:2) 120824bps / 8 = 15103
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_10_3/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_10_3,
 			b: BBRInfo{
 				BwLo:       15103, // 120824bps / 8 = 15103
 				BwHi:       0,
@@ -63,8 +63,8 @@ func TestDeserializeBBRInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_10_3/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_10_3,
 			b: BBRInfo{
 				BwLo:       15103,
 				BwHi:       0,
@@ -171,8 +171,8 @@ func BenchmarkDeserializeBBRInfoReflection(b *testing.B) {
 func DeserializeBBRInfoBoth(b *testing.B, Func func(data []byte, bi *BBRInfo) (n int, err error)) {
 	var tests = []DeserializeMemInfoTest{
 		{
-			description: "attribute_bbrinfo",
-			filename:    "./testdata/6_10_3/attribute_bbrinfo",
+			description: tnAttrBbrinfo,
+			filename:    tdAttrBbrinfo_6_10_3,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_cgroupid_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_cgroupid_test.go
@@ -22,8 +22,8 @@ func TestDeserializeCGroupID(t *testing.T) {
 
 	var tests = []DeserializeCGroupIDTest{
 		{
-			description: "attribute_cgroup_id",
-			filename:    "./testdata/6_6_44/attribute_cgroup_id",
+			description: tnAttrCgroupID,
+			filename:    tdAttrCgroupID_6_6_44,
 			c:           &x,
 			// c: &CGroupID{
 			// 	ID: 0,
@@ -33,8 +33,8 @@ func TestDeserializeCGroupID(t *testing.T) {
 			},
 		},
 		{
-			description: "attribute_cgroup_id",
-			filename:    "./testdata/6_6_44/attribute_cgroup_id",
+			description: tnAttrCgroupID,
+			filename:    tdAttrCgroupID_6_6_44,
 			c:           &x,
 			// c: &CGroupID{
 			// 	ID: 0,
@@ -116,8 +116,8 @@ func BenchmarkDeserializeCGroupIDReflection(b *testing.B) {
 func DeserializeCGroupIDBoth(b *testing.B, Func func(data []byte, tc *CGroupID) (n int, err error)) {
 	var tests = []DeserializeCGroupIDTest{
 		{
-			description: "attribute_cgroup_id",
-			filename:    "./testdata/6_6_44/attribute_cgroup_id",
+			description: tnAttrCgroupID,
+			filename:    tdAttrCgroupID_6_6_44,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_classid_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_classid_test.go
@@ -20,7 +20,7 @@ func TestDeserializeClassID(t *testing.T) {
 	var tests = []DeserializeClassIDTest{
 		{
 			description: "attribute_class_id",
-			filename:    "./testdata/6_6_44/attribute_class_id",
+			filename:    tdAttrClassID_6_6_44,
 			c:           ClassID(0),
 			Func: func(data []byte, c *ClassID) (n int, err error) {
 				return DeserializeClassID(data, c)
@@ -28,7 +28,7 @@ func TestDeserializeClassID(t *testing.T) {
 		},
 		{
 			description: "attribute_class_id_reflection",
-			filename:    "./testdata/6_6_44/attribute_class_id",
+			filename:    tdAttrClassID_6_6_44,
 			c:           ClassID(0),
 			Func: func(data []byte, c *ClassID) (n int, err error) {
 				return DeserializeClassIDReflection(data, c)
@@ -97,8 +97,8 @@ func BenchmarkDeserializeClassIDReflection(b *testing.B) {
 func DeserializeClassIDBoth(b *testing.B, Func func(data []byte, tc *ClassID) (n int, err error)) {
 	var tests = []DeserializeClassIDTest{
 		{
-			description: "attribute_tcclass",
-			filename:    "./testdata/6_6_44/attribute_tcclass",
+			description: tnAttrTcclass,
+			filename:    tdAttrTcclass_6_6_44,
 			c:           ClassID(2),
 		},
 	}

--- a/pkg/xtcpnl/xtcpnl_inet_diag_dctcpinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_dctcpinfo_test.go
@@ -22,7 +22,7 @@ func TestDeserializeDCTCPInfo(t *testing.T) {
 		// dctcp:(ce_state:0,alpha:540,ab_ecn:0,ab_tot:32768)
 		{
 			description: "attribute_dctcpinfo_4033",
-			filename:    "./testdata/6_6_44/attribute_dctcpinfo_4033",
+			filename:    tdAttrDctcpinfo_6_6_44,
 			d: DCTCPInfo{
 				Enabled: 1,
 				CEState: 0,
@@ -36,7 +36,7 @@ func TestDeserializeDCTCPInfo(t *testing.T) {
 		},
 		{
 			description: "attribute_dctcpinfo_4033_reflection",
-			filename:    "./testdata/6_6_44/attribute_dctcpinfo_4033",
+			filename:    tdAttrDctcpinfo_6_6_44,
 			d: DCTCPInfo{
 				Enabled: 1,
 				CEState: 0,
@@ -127,7 +127,7 @@ func DeserializeDCTCPInfoBoth(b *testing.B, Func func(data []byte, d *DCTCPInfo)
 	var tests = []DeserializeMemInfoTest{
 		{
 			description: "attribute_dctcpinfo_4033_reflection",
-			filename:    "./testdata/6_6_44/attribute_dctcpinfo_4033",
+			filename:    tdAttrDctcpinfo_6_6_44,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_meminfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_meminfo_test.go
@@ -57,8 +57,8 @@ func TestDeserializeMemInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "4_19_319_attribute_meminfo",
-			filename:    "./testdata/4_19_319/attribute_meminfo_f4096",
+			description: tnMeminfo4_19_319,
+			filename:    tdAttrMeminfo_4_19_319,
 			mi: MemInfo{
 				Rmem: 0,
 				Wmem: 0,
@@ -70,8 +70,8 @@ func TestDeserializeMemInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "4_19_319_attribute_meminfo",
-			filename:    "./testdata/4_19_319/attribute_meminfo_f4096",
+			description: tnMeminfo4_19_319,
+			filename:    tdAttrMeminfo_4_19_319,
 			mi: MemInfo{
 				Rmem: 0,
 				Wmem: 0,
@@ -156,8 +156,8 @@ func BenchmarkDeserializeMemInfoReflection(b *testing.B) {
 func DeserializeMemInfoBoth(b *testing.B, Func func(data []byte, mi *MemInfo) (n int, err error)) {
 	var tests = []DeserializeMemInfoTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/4_19_319/attribute_meminfo_f4096",
+			description: tnAttrInfo,
+			filename:    tdAttrMeminfo_4_19_319,
 			mi: MemInfo{
 				Rmem: 0,
 				Wmem: 0,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_msg_sockid_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_msg_sockid_test.go
@@ -26,7 +26,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 	var tests = []DeserializeInetDiagSockIDTest{
 		{
 			description: "6_10_3 single_packet_response",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap",
+			filename:    tdReplyPort4322_6_10_3,
 			sport:       54779,
 			dport:       4322,
 			proto:       4,
@@ -48,7 +48,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 		},
 		{
 			description: "port4001",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap",
+			filename:    tdReplyPort4001_6_6_44,
 			sport:       26699,
 			dport:       4001,
 			proto:       4,
@@ -58,8 +58,8 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 			cookie:      4106,
 		},
 		{
-			description: "port4018",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap",
+			description: tnPort4018,
+			filename:    tdReplyPort4018_6_6_44,
 			sport:       1789,
 			dport:       4018,
 			proto:       4,
@@ -69,7 +69,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 			cookie:      27550,
 		},
 		{
-			description: "port4018",
+			description: tnPort4018,
 			filename:    "./testdata/5_15_164/netlink_sock_diag_reply_single_packet_port4000.pcap",
 			sport:       14385,
 			dport:       4000,
@@ -81,7 +81,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 		},
 		{
 			description: "4_19_319_port4005",
-			filename:    "./testdata/4_19_319/netlink_sock_diag_reply_single_packet_port4005.pcap",
+			filename:    tdReplyPort4005_4_19_319,
 			sport:       44585,
 			dport:       4005,
 			proto:       4,
@@ -92,7 +92,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 		},
 		{
 			description: "port443v4",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap",
+			filename:    tdReplyPort443V4_6_6_44,
 			sport:       36821,
 			dport:       443,
 			proto:       4,
@@ -103,7 +103,7 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 		},
 		{
 			description: "port443v6",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap",
+			filename:    tdReplyPort443V6_6_6_44,
 			sport:       46965,
 			dport:       443,
 			proto:       6,
@@ -124,8 +124,8 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 			cookie:      2821,
 		},
 		{
-			description: "7_0_3 sport26546 dport443",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap",
+			description: tnSport26546V4,
+			filename:    tdResp26546_7_0_3,
 			sport:       26546,
 			dport:       443,
 			proto:       4,
@@ -146,8 +146,8 @@ func TestDeserializeInetDiagSockID(t *testing.T) {
 			cookie:      24592,
 		},
 		{
-			description: "7_0_3 sport19000 dport10156 v6",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6.pcap",
+			description: tnSport19000V6,
+			filename:    tdResp19000V6_7_0_3,
 			sport:       19000,
 			dport:       10156,
 			proto:       6,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go
@@ -37,7 +37,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 	var tests = []DeserializeInetDiagMsgTest{
 		{
 			description: "6_10_3 port4322",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap",
+			filename:    tdReplyPort4322_6_10_3,
 
 			Family:  2,
 			State:   1,
@@ -57,8 +57,8 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 			debugLevel: 11,
 		},
 		{
-			description: "port4018",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap",
+			description: tnPort4018,
+			filename:    tdReplyPort4018_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -79,7 +79,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port4018reflect",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4018.pcap",
+			filename:    tdReplyPort4018_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -100,7 +100,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port4001",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap",
+			filename:    tdReplyPort4001_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -121,7 +121,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port4001reflect",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port4001.pcap",
+			filename:    tdReplyPort4001_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -142,7 +142,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "4_19_319_port4005",
-			filename:    "./testdata/4_19_319/netlink_sock_diag_reply_single_packet_port4005.pcap",
+			filename:    tdReplyPort4005_4_19_319,
 
 			Family:  2,
 			State:   1,
@@ -163,7 +163,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "4_19_319_port4005reflect",
-			filename:    "./testdata/4_19_319/netlink_sock_diag_reply_single_packet_port4005.pcap",
+			filename:    tdReplyPort4005_4_19_319,
 
 			Family:  2,
 			State:   1,
@@ -184,7 +184,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port443v4",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap",
+			filename:    tdReplyPort443V4_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -205,7 +205,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port443v4reflect",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v4.pcap",
+			filename:    tdReplyPort443V4_6_6_44,
 
 			Family:  2,
 			State:   1,
@@ -226,7 +226,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port443v6",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap",
+			filename:    tdReplyPort443V6_6_6_44,
 
 			Family:  10,
 			State:   1,
@@ -247,7 +247,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		},
 		{
 			description: "port443v6reflect",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_reply_single_packet_port443v6.pcap",
+			filename:    tdReplyPort443V6_6_6_44,
 
 			Family:  10,
 			State:   1,
@@ -267,8 +267,8 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 			debugLevel: 11,
 		},
 		{
-			description: "7_0_3 sport26546 dport443",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap",
+			description: tnSport26546V4,
+			filename:    tdResp26546_7_0_3,
 
 			Family:  2,
 			State:   1,
@@ -287,8 +287,8 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 			debugLevel: 11,
 		},
 		{
-			description: "7_0_3 sport19000 dport10156 v6",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6.pcap",
+			description: tnSport19000V6,
+			filename:    tdResp19000V6_7_0_3,
 
 			Family:  10,
 			State:   1,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_pragueinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_pragueinfo_test.go
@@ -19,7 +19,7 @@ func TestDeserializePragueInfo(t *testing.T) {
 	var tests = []DeserializePragueInfoTest{
 		{
 			description: "attribute_pragueinfo_fake_fixme",
-			filename:    "./testdata/attribute_pragueinfo_fake_fixme",
+			filename:    tdAttrPragueinfoFake,
 			p: PragueInfo{
 				Alpha:     0,
 				FracCwnd:  0,
@@ -34,7 +34,7 @@ func TestDeserializePragueInfo(t *testing.T) {
 		},
 		{
 			description: "attribute_pragueinfo_fake_fixme_reflection",
-			filename:    "./testdata/attribute_pragueinfo_fake_fixme",
+			filename:    tdAttrPragueinfoFake,
 			p: PragueInfo{
 				Alpha:     0,
 				FracCwnd:  0,
@@ -130,7 +130,7 @@ func DeserializePragueInfoBoth(b *testing.B, Func func(data []byte, d *PragueInf
 	var tests = []DeserializePragueInfoTest{
 		{
 			description: "attribute_pragueinfo_fake_fixme",
-			filename:    "./testdata/attribute_pragueinfo_fake_fixme",
+			filename:    tdAttrPragueinfoFake,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_reqv2_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_reqv2_test.go
@@ -22,7 +22,7 @@ func TestDeserializeInetDiagReqV2(t *testing.T) {
 	var tests = []DeserializeInetDiagReqV2Test{
 		{
 			description: "verify_request_all",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example2",
+			filename:    tdReqBytes2_6_6_44,
 			length:      72,
 			family:      2,
 			protocol:    6,
@@ -32,7 +32,7 @@ func TestDeserializeInetDiagReqV2(t *testing.T) {
 		},
 		{
 			description: "verify_request_all_example3",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example3",
+			filename:    tdReqBytes3_6_6_44,
 			length:      72,
 			family:      2,
 			protocol:    6,
@@ -82,7 +82,7 @@ func TestDeserializeInetDiagReqV2(t *testing.T) {
 		},
 		{
 			description: "request_v6",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap",
+			filename:    tdReqSinglePktV6_6_6_44,
 			length:      128,
 			family:      2,
 			protocol:    6,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_shutdown_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_shutdown_test.go
@@ -19,8 +19,8 @@ type DeserializeShutdownTest struct {
 func TestDeserializeShutdown(t *testing.T) {
 	var tests = []DeserializeShutdownTest{
 		{
-			description: "attribute_shutdown",
-			filename:    "./testdata/6_6_44/attribute_shutdown",
+			description: tnAttrShutdown,
+			filename:    tdAttrShutdown_6_6_44,
 			s:           Shutdown(0),
 			Func: func(data []byte, s *Shutdown) (n int, err error) {
 				return DeserializeShutdown(data, s)
@@ -28,7 +28,7 @@ func TestDeserializeShutdown(t *testing.T) {
 		},
 		{
 			description: "attribute_shutdown_reflection",
-			filename:    "./testdata/6_6_44/attribute_shutdown",
+			filename:    tdAttrShutdown_6_6_44,
 			s:           Shutdown(0),
 			Func: func(data []byte, s *Shutdown) (n int, err error) {
 				return DeserializeShutdownReflection(data, s)
@@ -97,8 +97,8 @@ func BenchmarkDeserializeShutdownReflection(b *testing.B) {
 func DeserializeShutdownBoth(b *testing.B, Func func(data []byte, s *Shutdown) (n int, err error)) {
 	var tests = []DeserializeShutdownTest{
 		{
-			description: "attribute_shutdown",
-			filename:    "./testdata/6_6_44/attribute_shutdown",
+			description: tnAttrShutdown,
+			filename:    tdAttrShutdown_6_6_44,
 			s:           Shutdown(2),
 		},
 	}

--- a/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo_test.go
@@ -19,8 +19,8 @@ type DeserializeSkMemInfoTest struct {
 func TestDeserializeSkMemInfo(t *testing.T) {
 	var tests = []DeserializeSkMemInfoTest{
 		{
-			description: "attribute_skmeminfo2",
-			filename:    "./testdata/6_6_44/attribute_skmeminfo2",
+			description: tnAttrSkmeminfo2,
+			filename:    tdAttrSkmeminfo2_6_6_44,
 			sm: SkMemInfo{
 				RmemAlloc:  0,
 				RcvBuf:     1000000,
@@ -37,8 +37,8 @@ func TestDeserializeSkMemInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "attribute_skmeminfo2",
-			filename:    "./testdata/6_6_44/attribute_skmeminfo2",
+			description: tnAttrSkmeminfo2,
+			filename:    tdAttrSkmeminfo2_6_6_44,
 			sm: SkMemInfo{
 				RmemAlloc:  0,
 				RcvBuf:     1000000,
@@ -157,8 +157,8 @@ func BenchmarkDeserializeSkMemInfoReflection(b *testing.B) {
 func DeserializeSkMemInfoBoth(b *testing.B, Func func(data []byte, sm *SkMemInfo) (n int, err error)) {
 	var tests = []DeserializeSkMemInfoTest{
 		{
-			description: "attribute_skmeminfo2",
-			filename:    "./testdata/6_6_44/attribute_skmeminfo2",
+			description: tnAttrSkmeminfo2,
+			filename:    tdAttrSkmeminfo2_6_6_44,
 			sm: SkMemInfo{
 				RmemAlloc:  0,
 				RcvBuf:     1000000,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_sockopt_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_sockopt_test.go
@@ -22,8 +22,8 @@ func TestDeserializeSockOpt(t *testing.T) {
 	t3 := SockOpt(82)
 	var tests = []DeserializeSockOptTest{
 		{
-			description: "attribute_sockopt",
-			filename:    "./testdata/6_10_3/attribute_sockopt_4305",
+			description: tnAttrSockopt,
+			filename:    tdAttrSockopt_6_10_3,
 			s:           &t1,
 			Func: func(data []byte, s *SockOpt) (n int, err error) {
 				return DeserializeSockOpt(data, s)
@@ -31,7 +31,7 @@ func TestDeserializeSockOpt(t *testing.T) {
 		},
 		{
 			description: "attribute_sockopt_reflection",
-			filename:    "./testdata/6_10_3/attribute_sockopt_4305",
+			filename:    tdAttrSockopt_6_10_3,
 			s:           &t2,
 			Func: func(data []byte, s *SockOpt) (n int, err error) {
 				return DeserializeSockOptReflection(data, s)
@@ -108,8 +108,8 @@ func BenchmarkDeserializeSockOptReflection(b *testing.B) {
 func DeserializeSockOptBoth(b *testing.B, Func func(data []byte, tc *SockOpt) (n int, err error)) {
 	var tests = []DeserializeSockOptTest{
 		{
-			description: "attribute_sockopt",
-			filename:    "./testdata/6_10_3/attribute_sockopt_4305",
+			description: tnAttrSockopt,
+			filename:    tdAttrSockopt_6_10_3,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_tcclass_info_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_tcclass_info_test.go
@@ -19,8 +19,8 @@ type DeserializeTrafficClassTest struct {
 func TestDeserializeTrafficClass(t *testing.T) {
 	var tests = []DeserializeTrafficClassTest{
 		{
-			description: "attribute_tcclass",
-			filename:    "./testdata/6_6_44/attribute_tcclass",
+			description: tnAttrTcclass,
+			filename:    tdAttrTcclass_6_6_44,
 			tc:          TrafficClass(2),
 			Func: func(data []byte, tc *TrafficClass) (n int, err error) {
 				return DeserializeTrafficClass(data, tc)
@@ -28,7 +28,7 @@ func TestDeserializeTrafficClass(t *testing.T) {
 		},
 		{
 			description: "attribute_tcclass_reflection",
-			filename:    "./testdata/6_6_44/attribute_tcclass",
+			filename:    tdAttrTcclass_6_6_44,
 			tc:          TrafficClass(2),
 			Func: func(data []byte, tc *TrafficClass) (n int, err error) {
 				return DeserializeTrafficClassReflection(data, tc)
@@ -98,8 +98,8 @@ func BenchmarkDeserializeTrafficClassReflection(b *testing.B) {
 func DeserializeTrafficClassBoth(b *testing.B, Func func(data []byte, tc *TrafficClass) (n int, err error)) {
 	var tests = []DeserializeTrafficClassTest{
 		{
-			description: "attribute_tcclass",
-			filename:    "./testdata/6_6_44/attribute_tcclass",
+			description: tnAttrTcclass,
+			filename:    tdAttrTcclass_6_6_44,
 			tc:          TrafficClass(2),
 		},
 	}

--- a/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo_bench_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo_bench_test.go
@@ -18,8 +18,8 @@ type BenchmarkTCPInfoTest struct {
 func BenchmarkDeserializeTCPInfo(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/6_10_3/attribute_info",
+			description: tnAttrInfo,
+			filename:    tdAttrInfo_6_10_3,
 		},
 	}
 
@@ -53,8 +53,8 @@ func BenchmarkDeserializeTCPInfo(b *testing.B) {
 func BenchmarkDeserializeTCPInfoReflection(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/6_10_3/attribute_info",
+			description: tnAttrInfo,
+			filename:    tdAttrInfo_6_10_3,
 		},
 	}
 
@@ -88,8 +88,8 @@ func BenchmarkDeserializeTCPInfoReflection(b *testing.B) {
 func BenchmarkDeserializeTCPInfo6_10_3Reflection(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/6_10_3/attribute_info",
+			description: tnAttrInfo,
+			filename:    tdAttrInfo_6_10_3,
 		},
 	}
 
@@ -123,8 +123,8 @@ func BenchmarkDeserializeTCPInfo6_10_3Reflection(b *testing.B) {
 func BenchmarkDeserializeTCPInfoTCPInfo6_6_44Reflection(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
-			filename:    "./testdata/6_6_44/attribute_info",
+			description: tnAttrInfo,
+			filename:    tdAttrInfo_6_6_44,
 		},
 	}
 
@@ -158,7 +158,7 @@ func BenchmarkDeserializeTCPInfoTCPInfo6_6_44Reflection(b *testing.B) {
 func BenchmarkDeserializeTCPInfo5_4_281Reflection(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
+			description: tnAttrInfo,
 			filename:    "./testdata/5_4_281/attribute_info",
 		},
 	}
@@ -193,7 +193,7 @@ func BenchmarkDeserializeTCPInfo5_4_281Reflection(b *testing.B) {
 func BenchmarkDeserializeTCPInfo4_19_219Reflection(b *testing.B) {
 	var tests = []BenchmarkTCPInfoTest{
 		{
-			description: "attribute_info",
+			description: tnAttrInfo,
 			filename:    "./testdata/4_19_319/attribute_info",
 		},
 	}

--- a/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo_test.go
@@ -242,7 +242,7 @@ func TestDeserializeTCPInfo(t *testing.T) {
 		// TCPInfo struct still only covers the first 248 bytes; the trailing
 		// AccECN fields are not parsed yet and aren't asserted here.
 		{
-			description: "7_0_3 sport26546 dport443",
+			description: tnSport26546V4,
 			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443_info",
 			tcpinfo: TCPInfo{
 				State:                  1,
@@ -383,7 +383,7 @@ func TestDeserializeTCPInfo(t *testing.T) {
 		// IPv6 loopback. Values reflect pcap-capture moment, earlier than the
 		// ss-text moment (bytes_sent 624678 here vs 644931 in ss).
 		{
-			description: "7_0_3 sport19000 dport10156 v6",
+			description: tnSport19000V6,
 			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6_info",
 			tcpinfo: TCPInfo{
 				State:                  1,

--- a/pkg/xtcpnl/xtcpnl_inet_diag_tosinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_tosinfo_test.go
@@ -20,7 +20,7 @@ func TestDeserializeTypeOfService(t *testing.T) {
 	var tests = []DeserializeTypeOfServiceTest{
 		{
 			description: "attribute_tos",
-			filename:    "./testdata/6_6_44/attribute_tos",
+			filename:    tdAttrTos_6_6_44,
 			tos:         TypeOfService(0),
 			Func: func(data []byte, tos *TypeOfService) (n int, err error) {
 				return DeserializeTypeOfService(data, tos)
@@ -28,7 +28,7 @@ func TestDeserializeTypeOfService(t *testing.T) {
 		},
 		{
 			description: "attribute_tos_reflection",
-			filename:    "./testdata/6_6_44/attribute_tos",
+			filename:    tdAttrTos_6_6_44,
 			tos:         TypeOfService(0),
 			Func: func(data []byte, tos *TypeOfService) (n int, err error) {
 				return DeserializeTypeOfServiceReflection(data, tos)
@@ -36,7 +36,7 @@ func TestDeserializeTypeOfService(t *testing.T) {
 		},
 		{
 			description: "attribute_tos2",
-			filename:    "./testdata/6_6_44/attribute_tos2",
+			filename:    tdAttrTos2_6_6_44,
 			tos:         TypeOfService(2),
 			Func: func(data []byte, tos *TypeOfService) (n int, err error) {
 				return DeserializeTypeOfService(data, tos)
@@ -44,7 +44,7 @@ func TestDeserializeTypeOfService(t *testing.T) {
 		},
 		{
 			description: "attribute_tos2_reflection",
-			filename:    "./testdata/6_6_44/attribute_tos2",
+			filename:    tdAttrTos2_6_6_44,
 			tos:         TypeOfService(2),
 			Func: func(data []byte, tos *TypeOfService) (n int, err error) {
 				return DeserializeTypeOfServiceReflection(data, tos)
@@ -114,7 +114,7 @@ func DeserializeTypeOfServiceBoth(b *testing.B, Func func(data []byte, tos *Type
 	var tests = []DeserializeTypeOfServiceTest{
 		{
 			description: "attribute_tos2",
-			filename:    "./testdata/6_6_44/attribute_tos2",
+			filename:    tdAttrTos2_6_6_44,
 			tos:         TypeOfService(2),
 		},
 	}

--- a/pkg/xtcpnl/xtcpnl_inet_diag_vegasinfo_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_vegasinfo_test.go
@@ -19,8 +19,8 @@ func TestDeserializeVegasInfo(t *testing.T) {
 	var tests = []DeserializeVegasInfoTest{
 		// vegasinfo
 		{
-			description: "attribute_vegasinfo",
-			filename:    "./testdata/6_6_44/attribute_vegasinfo",
+			description: tnAttrVegasinfo,
+			filename:    tdAttrVegasinfo_6_6_44,
 			vi: VegasInfo{
 				Enabled: 1,
 				RttCnt:  0,
@@ -32,8 +32,8 @@ func TestDeserializeVegasInfo(t *testing.T) {
 			},
 		},
 		{
-			description: "attribute_vegasinfo",
-			filename:    "./testdata/6_6_44/attribute_vegasinfo",
+			description: tnAttrVegasinfo,
+			filename:    tdAttrVegasinfo_6_6_44,
 			vi: VegasInfo{
 				Enabled: 1,
 				RttCnt:  0,
@@ -117,8 +117,8 @@ func BenchmarkDeserializeVegasInfoReflection(b *testing.B) {
 func DeserializeVegasInfoBoth(b *testing.B, Func func(data []byte, vi *VegasInfo) (n int, err error)) {
 	var tests = []DeserializeVegasInfoTest{
 		{
-			description: "attribute_vegasinfo",
-			filename:    "./testdata/6_6_44/attribute_vegasinfo",
+			description: tnAttrVegasinfo,
+			filename:    tdAttrVegasinfo_6_6_44,
 			vi: VegasInfo{
 				Enabled: 1,
 				RttCnt:  0,

--- a/pkg/xtcpnl/xtcpnl_nl_msg_hdr_test.go
+++ b/pkg/xtcpnl/xtcpnl_nl_msg_hdr_test.go
@@ -30,7 +30,7 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 		},
 		{
 			description: "request_all_example2",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example2",
+			filename:    tdReqBytes2_6_6_44,
 			length:      72,
 			tyype:       20,
 			flags:       769,
@@ -39,7 +39,7 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 		},
 		{
 			description: "request_all_example3",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example3",
+			filename:    tdReqBytes3_6_6_44,
 			length:      72,
 			tyype:       20,
 			flags:       769,
@@ -66,7 +66,7 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 		},
 		{
 			description: "6_10_3 end_of_dump_pcap",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			filename:    tdRespDumpDone_6_10_3,
 			length:      20,
 			tyype:       3,
 			flags:       2,
@@ -102,7 +102,7 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 		},
 		{
 			description: "6_10_3 reply_single_packet.pcap",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_reply_single_packet_port4322.pcap",
+			filename:    tdReplyPort4322_6_10_3,
 			length:      456,
 			tyype:       20,
 			flags:       2,
@@ -119,8 +119,8 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 			pid:         1573,
 		},
 		{
-			description: "7_0_3 sport26546 dport443",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap",
+			description: tnSport26546V4,
+			filename:    tdResp26546_7_0_3,
 			length:      412,
 			tyype:       20,
 			flags:       2,
@@ -128,8 +128,8 @@ func TestDeserializeNlMsgHdr(t *testing.T) {
 			pid:         13275,
 		},
 		{
-			description: "7_0_3 sport19000 dport10156 v6",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport19000_dport10156_v6.pcap",
+			description: tnSport19000V6,
+			filename:    tdResp19000V6_7_0_3,
 			length:      400,
 			tyype:       20,
 			flags:       2,

--- a/pkg/xtcpnl/xtcpnl_pcap_test.go
+++ b/pkg/xtcpnl/xtcpnl_pcap_test.go
@@ -22,8 +22,8 @@ type DeserializePcapHeaderTest struct {
 func TestDeserializePcapHeader(t *testing.T) {
 	var tests = []DeserializePcapHeaderTest{
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 			ph: PcapHeader{
 				Magic:        2712847316, // a1b2c3d4 = seconds and microseconds
 				VersionMajor: 2,
@@ -39,8 +39,8 @@ func TestDeserializePcapHeader(t *testing.T) {
 			},
 		},
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 			ph: PcapHeader{
 				Magic:        2712847316, // a1b2c3d4 = seconds and microseconds
 				VersionMajor: 2,
@@ -56,8 +56,8 @@ func TestDeserializePcapHeader(t *testing.T) {
 			},
 		},
 		{
-			description: "7_0_3 sport26546 dport443",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap",
+			description: tnSport26546V4,
+			filename:    tdResp26546_7_0_3,
 			ph: PcapHeader{
 				Magic:        2712847316,
 				VersionMajor: 2,
@@ -126,8 +126,8 @@ type DeserializePcapRecordHeaderTest struct {
 func TestDeserializePcapRecordHeader(t *testing.T) {
 	var tests = []DeserializePcapRecordHeaderTest{
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 			prh: PcapRecordHeader{
 				TsSec:  1723171594,
 				TsXsec: 213187,
@@ -139,8 +139,8 @@ func TestDeserializePcapRecordHeader(t *testing.T) {
 			},
 		},
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 			prh: PcapRecordHeader{
 				TsSec:  1723171594,
 				TsXsec: 213187,
@@ -152,8 +152,8 @@ func TestDeserializePcapRecordHeader(t *testing.T) {
 			},
 		},
 		{
-			description: "7_0_3 sport26546 dport443",
-			filename:    "./testdata/7_0_3/netlink_sock_diag_response_7_0_3_sport26546_dport443.pcap",
+			description: tnSport26546V4,
+			filename:    tdResp26546_7_0_3,
 			prh: PcapRecordHeader{
 				TsSec:  1778603922,
 				TsXsec: 514716,
@@ -228,8 +228,8 @@ func BenchmarkDeserializePcapHeaderReflection(b *testing.B) {
 func DeserializePcapHeaderBoth(b *testing.B, Func func(data []byte, ph *PcapHeader) (n int, err error)) {
 	var tests = []DeserializePcapHeaderTest{
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 		},
 	}
 
@@ -277,8 +277,8 @@ func BenchmarkDeserializePcapRecordHeaderReflection(b *testing.B) {
 func DeserializePcapRecordHeaderBoth(b *testing.B, Func func(data []byte, prh *PcapRecordHeader) (n int, err error)) {
 	var tests = []DeserializePcapRecordHeaderTest{
 		{
-			description: "DeserializePcapTest",
-			filename:    "./testdata/6_10_3/netlink_sock_diag_response_dump_done.pcap",
+			description: tnDeserializePcap,
+			filename:    tdRespDumpDone_6_10_3,
 		},
 	}
 

--- a/pkg/xtcpnl/xtcpnl_test.go
+++ b/pkg/xtcpnl/xtcpnl_test.go
@@ -21,8 +21,8 @@ type DecodeFromBytesSerializeToTest struct {
 func TestDecodeFromBytesSerializeTo(t *testing.T) {
 	var tests = []DecodeFromBytesSerializeToTest{
 		{
-			description: "verify_request",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes",
+			description: tnVerifyRequest,
+			filename:    tdReqBytes_6_6_44,
 		},
 		{
 			description: "verify_request_all",
@@ -30,11 +30,11 @@ func TestDecodeFromBytesSerializeTo(t *testing.T) {
 		},
 		{
 			description: "verify_request_all_example2",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example2",
+			filename:    tdReqBytes2_6_6_44,
 		},
 		{
 			description: "verify_request_all_example3",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_bytes_example3",
+			filename:    tdReqBytes3_6_6_44,
 		},
 		{
 			description: "6_10_3 verify_request",
@@ -58,7 +58,7 @@ func TestDecodeFromBytesSerializeTo(t *testing.T) {
 		},
 		{
 			description: "verify_request_allv6",
-			filename:    "./testdata/6_6_44/netlink_sock_diag_request_single_packet_v6.pcap",
+			filename:    tdReqSinglePktV6_6_6_44,
 			debugLevel:  11,
 		},
 	}

--- a/tools/quality-report/main.go
+++ b/tools/quality-report/main.go
@@ -33,6 +33,26 @@ import (
 	"time"
 )
 
+// Tool / rule / severity strings reused throughout the aggregator. Kept
+// as named constants so a typo in a Tool field or Severity check
+// stays a compile error rather than a silent mismatch.
+const (
+	toolGofmt = "gofmt"
+	toolGosec = "gosec"
+
+	ruleFormat = "format"
+
+	severityWarning = "warning"
+	severityInfo    = "info"
+	severityError   = "error"
+
+	testActionFail = "fail"
+	testActionPass = "pass"
+	testActionSkip = "skip"
+
+	goSecNixPath = "nix/checks/go-sec.nix"
+)
+
 // linterTier maps a golangci-lint linter name to the lowest config tier
 // in which it is enabled. Source of truth: the `linters:` blocks of
 // .golangci-quick.yml, .golangci.yml, .golangci-comprehensive.yml.
@@ -46,11 +66,11 @@ var linterTier = map[string]int{
 	"ineffassign": 0,
 	"unused":      0,
 	"staticcheck": 0,
-	"gofmt":       0,
+	toolGofmt:     0,
 	"goimports":   0,
 	"typecheck":   0,
 	// Tier 1 (.golangci.yml)
-	"gosec":         1,
+	toolGosec:       1,
 	"gocritic":      1,
 	"revive":        1,
 	"noctx":         1,
@@ -211,10 +231,10 @@ func main() {
 		fs, ok := parseGosec(path, *repoRoot)
 		in.Findings = append(in.Findings, fs...)
 		in.Status = append(in.Status, ToolStatus{
-			Name:      "gosec",
-			ExitCode:  exitCodes["gosec"],
+			Name:      toolGosec,
+			ExitCode:  exitCodes[toolGosec],
 			Findings:  len(fs),
-			RuntimeS:  runtimes["gosec"],
+			RuntimeS:  runtimes[toolGosec],
 			Available: ok,
 		})
 	}
@@ -247,18 +267,18 @@ func main() {
 		in.GofmtFiles = kept
 		for _, f := range kept {
 			in.Findings = append(in.Findings, Finding{
-				Tool:     "gofmt",
-				Rule:     "format",
-				Severity: "warning",
+				Tool:     toolGofmt,
+				Rule:     ruleFormat,
+				Severity: severityWarning,
 				File:     f,
 				Message:  "file not formatted",
 			})
 		}
 		in.Status = append(in.Status, ToolStatus{
-			Name:      "gofmt",
-			ExitCode:  exitCodes["gofmt"],
+			Name:      toolGofmt,
+			ExitCode:  exitCodes[toolGofmt],
 			Findings:  len(kept),
-			RuntimeS:  runtimes["gofmt"],
+			RuntimeS:  runtimes[toolGofmt],
 			Available: fileExists(filepath.Join(*rawDir, "gofmt.out")),
 		})
 	}
@@ -277,8 +297,8 @@ func main() {
 		for _, f := range kept {
 			in.Findings = append(in.Findings, Finding{
 				Tool:     "nixfmt",
-				Rule:     "format",
-				Severity: "warning",
+				Rule:     ruleFormat,
+				Severity: severityWarning,
 				File:     f,
 				Message:  "file not formatted",
 			})
@@ -314,7 +334,7 @@ func main() {
 		failing := 0
 		preexist := 0
 		for _, r := range results {
-			if r.Action == "fail" {
+			if r.Action == testActionFail {
 				if r.Preexist {
 					preexist++
 				} else {
@@ -405,7 +425,7 @@ func parseGolangci(path, tool string, tier int, repoRoot string) ([]Finding, boo
 			Tool:     tool,
 			Tier:     tier,
 			Rule:     "internal/parse-error",
-			Severity: "info",
+			Severity: severityInfo,
 			Message:  fmt.Sprintf("could not parse JSON: %v", err),
 		}}, true
 	}
@@ -455,9 +475,9 @@ func parseGosec(path, repoRoot string) ([]Finding, bool) {
 	var j gosecJSON
 	if err := json.Unmarshal(b, &j); err != nil {
 		return []Finding{{
-			Tool:     "gosec",
+			Tool:     toolGosec,
 			Rule:     "internal/parse-error",
-			Severity: "info",
+			Severity: severityInfo,
 			Message:  fmt.Sprintf("could not parse JSON: %v", err),
 		}}, true
 	}
@@ -470,7 +490,7 @@ func parseGosec(path, repoRoot string) ([]Finding, bool) {
 			msg = fmt.Sprintf("%s (CWE-%s)", msg, is.CWE.ID)
 		}
 		out = append(out, Finding{
-			Tool:     "gosec",
+			Tool:     toolGosec,
 			Rule:     is.RuleID,
 			Severity: strings.ToLower(is.Severity),
 			File:     relpath(is.File, repoRoot),
@@ -509,7 +529,7 @@ func parseLineFindings(path, tool string, tier int, defaultRule string) ([]Findi
 			col, _ := strconv.Atoi(m[3])
 			out = append(out, Finding{
 				Tool: tool, Tier: tier, Rule: defaultRule,
-				Severity: "warning",
+				Severity: severityWarning,
 				File:     m[1], Line: ln, Column: col, Message: m[4],
 			})
 			continue
@@ -518,7 +538,7 @@ func parseLineFindings(path, tool string, tier int, defaultRule string) ([]Findi
 			ln, _ := strconv.Atoi(m[2])
 			out = append(out, Finding{
 				Tool: tool, Tier: tier, Rule: defaultRule,
-				Severity: "warning",
+				Severity: severityWarning,
 				File:     m[1], Line: ln, Message: m[3],
 			})
 			continue
@@ -552,7 +572,7 @@ func parseAuditOutput(path, tool string) ([]Finding, bool) {
 			ln, _ := strconv.Atoi(m[2])
 			col, _ := strconv.Atoi(m[3])
 			out = append(out, Finding{
-				Tool: tool, Severity: "warning",
+				Tool: tool, Severity: severityWarning,
 				File: m[1], Line: ln, Column: col, Message: m[4],
 			})
 			continue
@@ -560,14 +580,14 @@ func parseAuditOutput(path, tool string) ([]Finding, bool) {
 		if m := reFileLine.FindStringSubmatch(line); m != nil {
 			ln, _ := strconv.Atoi(m[2])
 			out = append(out, Finding{
-				Tool: tool, Severity: "warning",
+				Tool: tool, Severity: severityWarning,
 				File: m[1], Line: ln, Message: m[3],
 			})
 			continue
 		}
 		// Anything else: keep as a free-form finding for visibility.
 		out = append(out, Finding{
-			Tool: tool, Severity: "info", Message: line,
+			Tool: tool, Severity: severityInfo, Message: line,
 		})
 	}
 	return out, true
@@ -610,7 +630,7 @@ func parseGoTest(path string, known map[string]bool) ([]TestResult, bool) {
 			if e.Test != "" {
 				failOutput[key] += e.Output
 			}
-		case "pass", "fail", "skip":
+		case testActionPass, testActionFail, testActionSkip:
 			r := results[key]
 			if r == nil {
 				r = &TestResult{Package: e.Package, Test: e.Test}
@@ -618,7 +638,7 @@ func parseGoTest(path string, known map[string]bool) ([]TestResult, bool) {
 			}
 			r.Action = e.Action
 			r.Elapsed = e.Elapsed
-			if e.Action == "fail" {
+			if e.Action == testActionFail {
 				r.Output = failOutput[key]
 				name := e.Package
 				if e.Test != "" {
@@ -723,13 +743,13 @@ func parseExclusions(repoRoot string) []ConfigExclusion {
 	}
 	// gosec exclusions — hardcoded in nix/checks/go-sec.nix.
 	out = append(out,
-		ConfigExclusion{Source: "nix/checks/go-sec.nix", Rule: "G103", Scope: "gosec", Justified: true,
+		ConfigExclusion{Source: goSecNixPath, Rule: "G103", Scope: toolGosec, Justified: true,
 			Note: "unsafe pointers: required by pkg/io_uring (giouring wraps liburing SQE/CQE with unsafe.Pointer)"},
-		ConfigExclusion{Source: "nix/checks/go-sec.nix", Rule: "G115", Scope: "gosec", Justified: true,
+		ConfigExclusion{Source: goSecNixPath, Rule: "G115", Scope: toolGosec, Justified: true,
 			Note: "integer overflow conversions: netlink length fields + io_uring batch indices, all bounds-checked"},
-		ConfigExclusion{Source: "nix/checks/go-sec.nix", Rule: "G204", Scope: "gosec", Justified: true,
+		ConfigExclusion{Source: goSecNixPath, Rule: "G204", Scope: toolGosec, Justified: true,
 			Note: "subprocess with variable: cmd/ns + cmd/nsTest invoke `ip netns exec ...` by design"},
-		ConfigExclusion{Source: "nix/checks/go-sec.nix", Rule: "G304", Scope: "gosec", Justified: true,
+		ConfigExclusion{Source: goSecNixPath, Rule: "G304", Scope: toolGosec, Justified: true,
 			Note: "file path from variable: register_schema reads .proto paths from CLI"},
 	)
 	return out
@@ -1124,7 +1144,7 @@ func emit(w io.Writer, in reportInput) error {
 		case 2:
 			r.TierCounts.T2++
 		}
-		if f.Severity == "error" {
+		if f.Severity == severityError {
 			r.HasErrSeverity = true
 		}
 		if isQuickFixableRule(f.Rule) {
@@ -1152,7 +1172,7 @@ func emit(w io.Writer, in reportInput) error {
 		switch f.Tool {
 		case "netlink-audit", "iouring-audit", "metrics-audit", "proto-field-audit":
 			auditFindings = append(auditFindings, f)
-		case "gosec":
+		case toolGosec:
 			gosecFindings = append(gosecFindings, f)
 		default:
 			linterFindings = append(linterFindings, f)
@@ -1175,9 +1195,9 @@ func emit(w io.Writer, in reportInput) error {
 	for _, t := range in.Tests {
 		r.TestStats.Total++
 		switch t.Action {
-		case "pass":
+		case testActionPass:
 			r.TestStats.Pass++
-		case "fail":
+		case testActionFail:
 			if t.Preexist {
 				r.TestStats.FailPre++
 				r.PreexistTestFails++
@@ -1188,7 +1208,7 @@ func emit(w io.Writer, in reportInput) error {
 			if t.Test != "" {
 				r.FailingTests = append(r.FailingTests, t)
 			}
-		case "skip":
+		case testActionSkip:
 			r.TestStats.Skip++
 		}
 	}
@@ -1223,7 +1243,7 @@ func isTieredTool(tool string) bool {
 
 func isQuickFixableRule(rule string) bool {
 	switch rule {
-	case "gofmt", "goimports", "misspell", "unconvert", "format":
+	case toolGofmt, "goimports", "misspell", "unconvert", ruleFormat:
 		return true
 	}
 	return false
@@ -1231,11 +1251,11 @@ func isQuickFixableRule(rule string) bool {
 
 func severityOrder(s string) int {
 	switch strings.ToLower(s) {
-	case "high", "error":
+	case "high", severityError:
 		return 0
-	case "medium", "warning":
+	case "medium", severityWarning:
 		return 1
-	case "low", "info":
+	case "low", severityInfo:
 		return 2
 	}
 	return 3


### PR DESCRIPTION
## Summary

Seventh slice of the layered-stack decomposition (after #8–#13). The `goconst-extraction` layer — extract repeated string literals into named constants (goconst linter):

- `pkg/xtcp`: prometheus metric-naming constants
- `pkg/xtcp`: destination scheme constants
- `pkg/xtcp`: `ns_reconcile_test` fixture string constants
- `pkg/xtcpnl` tests: testdata path + fixture-name constants (new `testdata_test.go`)
- `tools/quality-report`: extract repeated string constants
- `pkg/misc` test + `.gitignore` tidy
- `docs/quality-report.md` refresh

## Notes for the reviewer

- **Dropped an accidental binary blob.** The original stack commit for the `tools/quality-report` change had mistakenly committed the compiled `quality-report` binary (~5 MB) and a later commit deleted it. I applied the real source changes **without** ever adding the blob, and kept the `.gitignore` entry that prevents it recurring. Net tree is identical to the stack for these files, minus the binary.
- **One gofmt fix pulled forward.** `testdata_test.go`'s const block needed re-alignment after the long-named entries were added; the stack only fixes this one layer later (small-surface-wins). I included the `gofmt` fix here so this PR is independently gofmt-clean.

## Testing

- `go vet ./...` — clean (go 1.25).
- `gofmt -l .` — clean repo-wide.
- `go test ./pkg/... ./tools/quality-report/` — only the two pre-existing known-failures remain (`TestReconcileMaps`, `TestCheckFilePermissions`), identical to `main`, both on the `known-failures.txt` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
