### PR TITLE
gocritic/staticcheck: doc-comment hygiene (ST1000/ST1020/ST1021)

### DIFF
--- a/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go
+++ b/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go
@@ -19,7 +19,7 @@ import (
 
 // 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 // import "google.golang.org/protobuf/encoding/protowire"
-//import "google.golang.org/protobuf/encoding/protodelim"
+// import "google.golang.org/protobuf/encoding/protodelim"
 
 const (
 	clickhouseConnectStringCst = "127.0.0.1:8123"

--- a/cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db.go
+++ b/cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db.go
@@ -15,7 +15,7 @@ import (
 
 // 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 // import "google.golang.org/protobuf/encoding/protowire"
-//import "google.golang.org/protobuf/encoding/protodelim"
+// import "google.golang.org/protobuf/encoding/protodelim"
 
 const (
 	clickhouseConnectStringCst = "127.0.0.1:19001"

--- a/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
+++ b/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
@@ -23,7 +23,7 @@ import (
 
 // 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 // import "google.golang.org/protobuf/encoding/protowire"
-//import "google.golang.org/protobuf/encoding/protodelim"
+// import "google.golang.org/protobuf/encoding/protodelim"
 
 const (
 	schemaRegistryURLCst = "http://localhost:18081"

--- a/cmd/xtcp2client/xtcp2client.go
+++ b/cmd/xtcp2client/xtcp2client.go
@@ -323,7 +323,7 @@ func stream(ctx context.Context, wg *sync.WaitGroup, conn *grpc.ClientConn, json
 
 	stream, err := client.FlatRecords(ctx, req)
 	// stream, err := client.FlatRecords(ctx, req, grpc.CallContentSubtype(gzip.Name))
-	//stream, err := client.FlatRecords(ctx, req, grpc.UseCompressor(gzip.Name))
+	// stream, err := client.FlatRecords(ctx, req, grpc.UseCompressor(gzip.Name))
 	if err != nil {
 		log.Fatal("Error making gRPC request: ", err.Error())
 	}

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -1,6 +1,6 @@
 # xtcp2 code-quality report
 
-Generated: 2026-05-16T18:58:15Z
+Generated: 2026-05-16T19:16:36Z
 
 Tool versions: go=go1.25.10; golangci-lint=2.12.2; gosec=2.26.1; nixfmt=1.2.0; 
 
@@ -15,12 +15,12 @@ between commits reveals exactly what changed.
 
 | Metric | Value |
 |---|---|
-| Total findings | 423 |
-| Findings (Tier 0) | 180 |
-| Findings (Tier 1) | 216 |
+| Total findings | 379 |
+| Findings (Tier 0) | 143 |
+| Findings (Tier 1) | 208 |
 | Findings (Tier 2) | 15 |
-| Findings (non-tiered) | 12 |
-| Files with at least one finding | 86 |
+| Findings (non-tiered) | 13 |
+| Files with at least one finding | 64 |
 | Test failures (new) | 3 |
 | Test failures (pre-existing) | 3 |
 | Config exclusions reviewed | 4 |
@@ -31,18 +31,18 @@ between commits reveals exactly what changed.
 
 | Tool | Status | Findings | Runtime |
 |---|---|---|---|
-| golangci-lint (comprehensive) | findings | 411 | 5s |
-| golangci-lint (standard) | findings | 398 | 4s |
-| golangci-lint (quick) | findings | 93 | 14s |
+| golangci-lint (comprehensive) | findings | 366 | 5s |
+| golangci-lint (standard) | findings | 351 | 4s |
+| golangci-lint (quick) | findings | 54 | 14s |
 | gosec | findings | 12 | 2s |
 | go vet | clean | 0 | 2s |
-| gofmt | clean | 0 | 0s |
+| gofmt | findings | 1 | 0s |
 | nixfmt | clean | 0 | 0s |
 | netlink-audit | clean | 0 | 0s |
 | iouring-audit | clean | 0 | 0s |
 | metrics-audit | clean | 0 | 0s |
-| proto-field-audit | clean | 0 | 1s |
-| go test | findings | 6 | 2s |
+| proto-field-audit | clean | 0 | 0s |
+| go test | findings | 6 | 3s |
 
 
 ---
@@ -51,8 +51,8 @@ between commits reveals exactly what changed.
 
 | Tier | Linters | Findings | Quick-fixable¹ |
 |---|---|---|---|
-| 0 (`lint-quick`) | govet, errcheck, ineffassign, unused, staticcheck | 180 | 0 |
-| 1 (`lint` / CI) | Tier 0 + gosec, gocritic, revive, noctx, contextcheck, durationcheck | 216 | 0 |
+| 0 (`lint-quick`) | govet, errcheck, ineffassign, unused, staticcheck | 143 | 2 |
+| 1 (`lint` / CI) | Tier 0 + gosec, gocritic, revive, noctx, contextcheck, durationcheck | 208 | 0 |
 | 2 (`lint-comprehensive`) | Tier 1 + exhaustive, prealloc, gocyclo, funlen, goconst, dupl, unconvert, nakedret, misspell | 15 | 2 |
 
 ¹ Quick-fixable = produced by a linter that supports `golangci-lint run --fix` (gofmt, goimports, misspell, unconvert, …).
@@ -68,22 +68,22 @@ between commits reveals exactly what changed.
 | `tools/quality-report/main.go` | 18 | errcheck×11, govet×4, gocritic×1 |
 | `pkg/xtcpnl/xtcpnl_bench_test.go` | 15 | gocritic×15 |
 | `pkg/xtcp/deserializers.go` | 14 | gocritic×13, funlen×1 |
-| `pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go` | 14 | gocritic×14 |
+| `pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go` | 13 | gocritic×13 |
 | `pkg/xtcpnl/calculatePad_test.go` | 12 | gocritic×12 |
 | `pkg/xtcpnl/xtcpnl_pcap_test.go` | 12 | gocritic×12 |
-| `pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo.go` | 11 | staticcheck×7, dupl×2, funlen×2 |
 | `pkg/io_uring/bench_test.go` | 9 | govet×7, unconvert×2 |
+| `pkg/xtcp/netlinker_iouring.go` | 8 | govet×5, errcheck×2, gocritic×1 |
 
 
 ---
 
 ## 5. Findings by linter
 
-### golangci-lint / gocritic — 185
+### golangci-lint / gocritic — 177
 
-- `cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go:22`: commentFormatting: put a space between `//` and comment text
-- `cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db.go:18`: commentFormatting: put a space between `//` and comment text
-- `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:26`: commentFormatting: put a space between `//` and comment text
+- `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:277`: builtinShadow: shadowing of predeclared identifier: len
+- `cmd/xtcp2/xtcp2.go:186`: exitAfterDefer: os.Exit will exit, and `defer cancel()` will not run
+- `cmd/xtcp2_kafka_client/xtcp2_kafka_client.go:61`: exitAfterDefer: log.Fatalf will exit, and `defer cancel()` will not run
 
 ### golangci-lint / govet — 84
 
@@ -96,12 +96,6 @@ between commits reveals exactly what changed.
 - `cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go:213`: Error return value of `io.ReadAll` is not checked
 - `cmd/kafka_to_clickhouse/kafka_to_clickhouse.go:272`: Error return value is not checked
 - `cmd/xtcp2client/xtcp2client.go:318`: Error return value of `conn.Close` is not checked
-
-### golangci-lint / staticcheck — 43
-
-- `cmd/xtcp2/xtcp2.go:399`: SA4009: argument promListen is overwritten before first use
-- `cmd/xtcp2/xtcp2.go:402`: SA4009(related information): assignment to promListen
-- `cmd/xtcp2/xtcp2.go:410`: SA4009(related information): assignment to promPath
 
 ### golangci-lint / noctx — 16
 
@@ -127,14 +121,28 @@ between commits reveals exactly what changed.
 - `pkg/xtcp/deserialize.go:32`: Function 'Deserialize' has too many statements (74 > 60)
 - `pkg/xtcp/deserializers.go:32`: Function 'InitDeserializers' has too many statements (71 > 60)
 
+### golangci-lint / staticcheck — 5
+
+- `cmd/xtcp2/xtcp2.go:399`: SA4009: argument promListen is overwritten before first use
+- `cmd/xtcp2/xtcp2.go:402`: SA4009(related information): assignment to promListen
+- `cmd/xtcp2/xtcp2.go:410`: SA4009(related information): assignment to promPath
+
 ### golangci-lint / unconvert — 2
 
 - `pkg/io_uring/bench_test.go:34`: unnecessary conversion
 - `pkg/io_uring/bench_test.go:35`: unnecessary conversion
 
+### gofmt / format — 1
+
+- `pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go`: file not formatted
+
 ### golangci-lint / gocyclo — 1
 
 - `cmd/xtcp2/xtcp2.go:446`: cyclomatic complexity 61 of func `environmentOverrideConfig` is high (> 30)
+
+### golangci-lint / gofmt — 1
+
+- `pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go:41`: File is not properly formatted
 
 ---
 
@@ -190,8 +198,9 @@ between commits reveals exactly what changed.
 
 ## 10. Format checks
 
-`gofmt`: clean.
+**`gofmt` would reformat (1 file):**
 
+- `pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go`
 `nixfmt`: clean.
 
 ---
@@ -213,8 +222,9 @@ the adjacent YAML comment. Rows with no justification need review.
 
 ## 12. Recommendations
 
-- Top contributor: **golangci-lint/gocritic** with 185 findings (44% of total). Concentrate effort here for the biggest quality win.
-- Run `lint-fix` (or `golangci-lint run --fix`) to auto-resolve ~2 quick-fixable findings before manual review.
+- Top contributor: **golangci-lint/gocritic** with 177 findings (47% of total). Concentrate effort here for the biggest quality win.
+- Run `lint-fix` (or `golangci-lint run --fix`) to auto-resolve ~4 quick-fixable findings before manual review.
 - Hotspot file: `pkg/xtcp/destinations_test.go` carries 35 findings (govet×20, gosec×11, noctx×4). Refactor here before touching adjacent code.
 - 3 pre-existing test failure(s) tracked via `tools/quality-report/known-failures.txt`. Schedule a focused fix-up; today they're masking real regression signal.
+- Format files are out of sync — run `gofmt -w .` and `nixfmt **/*.nix` to bring formatting back to baseline.
 

--- a/pkg/misc/misc_test.go
+++ b/pkg/misc/misc_test.go
@@ -175,7 +175,7 @@ func TestCheckFilePermissions(t *testing.T) {
 		{"/bin/bash", "0755", true}, // test 0
 		{"/bin/ls", "0755", true},   // test 1
 		// {"/etc/shadow", "0640", true},      // test 2 - can't test these in gitlab
-		//{"/etc/sysctl.conf", "0644", true}, // test 3 - can't test these in gitlab
+		// {"/etc/sysctl.conf", "0644", true}, // test 3 - can't test these in gitlab
 		//{"/etc/sudoers", "0440", true},     // test 4 - can't test these in gitlab
 		{"/bin/bash", "0333", false}, // test 5 - negative
 	}

--- a/pkg/xtcp/netlinker.go
+++ b/pkg/xtcp/netlinker.go
@@ -1,8 +1,6 @@
-// Package netlinker is the netlinker go routine of the xtcp package.
-//
-// Netlinker receives netlink packets from the kernel and feeds the
-// deserializer. The function-pointer x.Netlinker (registered in
-// pkg/xtcp/init_netlinkers.go) is one of:
+// Netlinker is the per-namespace goroutine that receives netlink packets
+// from the kernel and feeds the deserializer. The function-pointer
+// x.Netlinker (registered in pkg/xtcp/init_netlinkers.go) is one of:
 //
 //	netlinkerSyscall  — the original synchronous syscall.Recvfrom path.
 //	netlinkerIoUring  — opt-in io_uring path with batched recvmsg SQEs.

--- a/pkg/xtcp/ns_map_count.go
+++ b/pkg/xtcp/ns_map_count.go
@@ -1,6 +1,6 @@
-// Package misc are some small helper functions used throughout the xtcp code
-//
-// It is perhaps poor form to name a module "misc", could be renamed to "utils"
+// Small helper functions used throughout the xtcp package. The original
+// file-level comment said "Package misc" but the file is actually in the
+// xtcp package; the canonical package-doc comment lives in xtcp.go.
 package xtcp
 
 import (

--- a/pkg/xtcp/ns_watch.go
+++ b/pkg/xtcp/ns_watch.go
@@ -69,7 +69,7 @@ breakPoint:
 			}
 
 			// nsName := filepath.Base(event.Name)
-			//nsName := netNsDir + event.Name
+			// nsName := netNsDir + event.Name
 			nsName := event.Name
 
 			if x.debugLevel > 10 {

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -267,7 +267,7 @@ func (x *XTCP) poll(fd int) {
 
 	x.sendNetlinkDumpRequest(fd, x.nlRequest)
 	// x.SendNetlinkDumpRequestPtr(x.socketFD, x.socketAddress, x.nlRequest)
-	//x.SendNetlinkDumpRequestPtrIOUring(x.socketFD, x.nlRequest)
+	// x.SendNetlinkDumpRequestPtrIOUring(x.socketFD, x.nlRequest)
 
 	x.pC.WithLabelValues("poller", "poll", "count").Inc()
 	if x.debugLevel > 10 {

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -1,3 +1,9 @@
+// Package xtcp is the long-running daemon that streams TCP socket state
+// out of the kernel via netlink inet_diag, deserialises the responses, and
+// fans them out to configurable destinations (unixgram, unix, udp, kafka,
+// nats, nsq, valkey, null). The package owns the netlinker, deserializer,
+// poller, namespace-watcher, marshaller, and destination registries; cmd
+// binaries wire them together.
 package xtcp
 
 import (

--- a/pkg/xtcpnl/xtcpnl.go
+++ b/pkg/xtcpnl/xtcpnl.go
@@ -1,14 +1,15 @@
+// Package xtcpnl owns the low-level netlink machinery: opening netlink
+// sockets, building netlink_sock_diag request payloads, sending them, and
+// deserialising the responses into XtcpFlatRecord fields.
 //
-// This package contains netlink related functions for opening netlinks sockets,
-// building netlink messages, and sending netlink messages
+// Entry points:
+//   - openNetlinkSocketWithTimeout — opens a netlink socket via syscalls
+//   - buildNetlinkSockDiagRequest  — builds the binary blob to send (unsafe)
+//   - sendNetlinkDumpRequest       — sends an inet_diag dump request
 //
-// openNetlinkSocketWithTimeout - opens netlink socket using syscalls
-// buildNetlinkSockDiagRequest - builds binary blobs to send to the netlink socket (unsafe)
-// sendNetlinkDumpRequest - sends a netlink inetdiag dump request
-//
-// These functions will log.Fatalf if they fail
-// pretty horrible has happened if you can't get a netlink socket or send to it.
-
+// Failure modes are aggressive: these functions log.Fatalf if they cannot
+// obtain or send on a netlink socket — if you cannot reach the kernel
+// you usually cannot recover.
 package xtcpnl
 
 // import "github.com/randomizedcoder/xtcp2/xtcpnl" // netlink related functions

--- a/pkg/xtcpnl/xtcpnl.go
+++ b/pkg/xtcpnl/xtcpnl.go
@@ -43,7 +43,7 @@ func NativeEndian() binary.ByteOrder {
 	return nativeEndian
 }
 
-// Byte swap a 16 bit value if we aren't big endian
+// Swap16 byte-swaps a 16 bit value when we are not on a big-endian host.
 func Swap16(i uint16) uint16 {
 	if NativeEndian() == binary.BigEndian {
 		return i

--- a/pkg/xtcpnl/xtcpnl_RTAttr.go
+++ b/pkg/xtcpnl/xtcpnl_RTAttr.go
@@ -6,21 +6,18 @@ import (
 	"errors"
 )
 
-// Wireshark's netlink disector
-// https://github.com/wireshark/wireshark/blob/b24016e0b27bcbc43ba2a269e465eb0f03751b1f/epan/dissectors/packet-netlink-sock_diag.c#L24
-
-// https://github.com/torvalds/linux/blob/bd2463ac7d7ec51d432f23bf0e893fb371a908cd/include/uapi/linux/rtnetlink.h#L195
-// /*
+// RTAttr mirrors the kernel's `struct rtattr` — the generic encapsulation
+// header for optional route attributes. It is reminiscent of sockaddr,
+// but with sa_family replaced by attribute type.
 //
-//	   Generic structure for encapsulation of optional route information.
-//	   It is reminiscent of sockaddr, but with sa_family replaced
-//	   with attribute type.
-//	 */
+//	struct rtattr {
+//		unsigned short	rta_len;
+//		unsigned short	rta_type;
+//	};
 //
-//		struct rtattr {
-//			unsigned short	rta_len;
-//			unsigned short	rta_type;
-//		};
+// References:
+//   - Wireshark netlink dissector: https://github.com/wireshark/wireshark/blob/b24016e0b27bcbc43ba2a269e465eb0f03751b1f/epan/dissectors/packet-netlink-sock_diag.c#L24
+//   - Linux kernel:                https://github.com/torvalds/linux/blob/bd2463ac7d7ec51d432f23bf0e893fb371a908cd/include/uapi/linux/rtnetlink.h#L195
 type RTAttr struct {
 	Len  uint16 // 2
 	Type uint16 // 2 = 4 ( 4 / 4 = 1 )

--- a/pkg/xtcpnl/xtcpnl_inet_diag_conginfo.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_conginfo.go
@@ -64,7 +64,7 @@ func DeserializeCongInfo(data []byte, ci *CongInfo) (n int, err error) {
 	// for i := 0; i < len(data); i++ {
 	// 	ci.Cong[i] = data[i]
 	// }
-	//ci.Cong = *((*[6]byte)(data[0:6]))
+	// ci.Cong = *((*[6]byte)(data[0:6]))
 	n = len(data)
 
 	return n, nil

--- a/pkg/xtcpnl/xtcpnl_inet_diag_meminfo.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_meminfo.go
@@ -36,9 +36,9 @@ import (
 // 23
 // __INET_DIAG_MAX 24
 
-// INET_DIAG_MEMINFO 1
+// MemInfo mirrors the kernel's `struct inet_diag_meminfo` (INET_DIAG_MEMINFO=1).
+//
 // https://github.com/torvalds/linux/blob/29d9f30d4ce6c7a38745a54a8cddface10013490/include/uapi/linux/inet_diag.h#L174
-// /* INET_DIAG_MEM */
 //
 //	struct inet_diag_meminfo {
 //		__u32	idiag_rmem;

--- a/pkg/xtcpnl/xtcpnl_inet_diag_msg.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_msg.go
@@ -155,8 +155,9 @@ var (
 	ErrInetDiagSockIDSmall = errors.New("data too small for InetDiagSockID")
 )
 
-// DeserializeInetDiagReqV2 does a binary read of a InetDiagReqV2
-// It does a basic length check
+// DeserializeInetDiagSockID does a binary read of an InetDiagSockID with a
+// basic length check.
+//
 // https://github.com/wireshark/wireshark/blob/b24016e0b27bcbc43ba2a269e465eb0f03751b1f/epan/dissectors/packet-netlink-sock_diag.c#L24
 func DeserializeInetDiagSockID(data []byte, sockid *InetDiagSockID) (n int, err error) {
 

--- a/pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_msg_test.go
@@ -350,7 +350,7 @@ func TestDeserializeInetDiagMsg(t *testing.T) {
 		s := new(InetDiagSockID)
 
 		// _, errD := DeserializeInetDiagMsgViaReflection(buf, idm, s)
-		//_, errD := DeserializeInetDiagMsg(buf, idm, s)
+		// _, errD := DeserializeInetDiagMsg(buf, idm, s)
 		_, errD := test.Func(buf, idm, s)
 		if errD != nil {
 			t.Fatal("Test Failed DeserializeInetDiagMsg err", errD)

--- a/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go
@@ -36,11 +36,11 @@ import (
 // 23
 // __INET_DIAG_MAX 24
 
-// INET_DIAG_SKMEMINFO 7
-
+// SkMemInfo mirrors the kernel's `struct sk_meminfo` (INET_DIAG_SKMEMINFO=7).
+//
 // Described here:
-// http://man7.org/linux/man-pages/man7/sock_diag.7.html
-// https://github.com/torvalds/linux/blob/a811c1fa0a02c062555b54651065899437bacdbe/net/core/sock.c#L3226
+//   - http://man7.org/linux/man-pages/man7/sock_diag.7.html
+//   - https://github.com/torvalds/linux/blob/a811c1fa0a02c062555b54651065899437bacdbe/net/core/sock.c#L3226
 //
 //	struct sk_meminfo {
 //	    __u32   rmem_alloc; //The amount of data in receive queue

--- a/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_skmeminfo.go
@@ -39,20 +39,22 @@ import (
 // SkMemInfo mirrors the kernel's `struct sk_meminfo` (INET_DIAG_SKMEMINFO=7).
 //
 // Described here:
+//
 //   - http://man7.org/linux/man-pages/man7/sock_diag.7.html
+//
 //   - https://github.com/torvalds/linux/blob/a811c1fa0a02c062555b54651065899437bacdbe/net/core/sock.c#L3226
 //
-//	struct sk_meminfo {
-//	    __u32   rmem_alloc; //The amount of data in receive queue
-//	    __u32   rcv_buf;    //The receive socket buffer as set by SO_RCVBUF.
-//	    __u32   wmem_alloc; //The amount of data in send queue.
-//	    __u32   snd_buf;    //The send socket buffer as set by SO_SNDBUF.
-//	    __u32   fwd_alloc;  //The amount of memory scheduled for future use (TCP only).
-//	    __u32   wmem_queued;//The amount of data queued by TCP, but not yet sent.
-//	    __u32   optmem;     //The amount of memory allocated for the sockets service needs
-//	    __u32   backlog;    //The amount of packets in the backlog (not yet processed).
-//	    __u32   drops;
-//	};
+//     struct sk_meminfo {
+//     __u32   rmem_alloc; //The amount of data in receive queue
+//     __u32   rcv_buf;    //The receive socket buffer as set by SO_RCVBUF.
+//     __u32   wmem_alloc; //The amount of data in send queue.
+//     __u32   snd_buf;    //The send socket buffer as set by SO_SNDBUF.
+//     __u32   fwd_alloc;  //The amount of memory scheduled for future use (TCP only).
+//     __u32   wmem_queued;//The amount of data queued by TCP, but not yet sent.
+//     __u32   optmem;     //The amount of memory allocated for the sockets service needs
+//     __u32   backlog;    //The amount of packets in the backlog (not yet processed).
+//     __u32   drops;
+//     };
 type SkMemInfo struct {
 	RmemAlloc  uint32 // 4 = 4
 	RcvBuf     uint32 // 4 = 8

--- a/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo.go
+++ b/pkg/xtcpnl/xtcpnl_inet_diag_tcpinfo.go
@@ -135,8 +135,10 @@ import (
 
 type TCPInfo TCPInfo6_10_3
 
+// TCPInfo6_10_3 mirrors the kernel's `struct tcp_info` for Linux 6.10.3
+// (tcp_info_for kernel 6.5+).
+//
 // https://github.com/torvalds/linux/blob/master/include/uapi/linux/tcp.h#L222
-// tcp_info_for kernel 6.5+
 type TCPInfo6_10_3 struct {
 	State                  uint8 // bytes:1 [0:1]
 	CaState                uint8 // bytes:1 [1:2]
@@ -225,8 +227,10 @@ type TCPInfo6_10_3 struct {
 	TotalRTOTime       uint32 // bytes:4 [244:248] // Total time spent in RTO recoveries in milliseconds, including any unfinished recovery
 }
 
+// TCPInfo6_8_12 mirrors the kernel's `struct tcp_info` for Linux 6.8.12
+// (tcp_info_for kernel 6.5+).
+//
 // https://github.com/torvalds/linux/blob/v6.8-rc7/include/uapi/linux/tcp.h#L220
-// tcp_info_for kernel 6.5+
 type TCPInfo6_8_12 struct {
 	State                  uint8 // bytes:1 [0:1]
 	CaState                uint8 // bytes:1 [1:2]
@@ -314,8 +318,10 @@ type TCPInfo6_8_12 struct {
 	TotalRTOTime       uint32 // bytes:4 [244:248] // Total time spent in RTO recoveries in milliseconds, including any unfinished recovery
 }
 
+// TCPInfo6_6_44 mirrors the kernel's `struct tcp_info` for Linux 6.6.44
+// (tcp_info_for kernel 6.6+).
+//
 // https://github.com/torvalds/linux/blob/v6.6-rc7/include/uapi/linux/tcp.h#L214
-// tcp_info_for kernel 6.6+
 type TCPInfo6_6_44 struct {
 	State                  uint8 // bytes:1 [0:1]
 	CaState                uint8 // bytes:1 [1:2]
@@ -399,8 +405,10 @@ type TCPInfo6_6_44 struct {
 	Rehash uint32 // bytes:4 [236:240] // PLB or timeout triggered rehash attempts
 }
 
+// TCPInfo5_4_281 mirrors the kernel's `struct tcp_info` for Linux 5.4.281
+// (tcp_info_for kernel 5.4+).
+//
 // https://github.com/torvalds/linux/blob/v5.4-rc8/include/uapi/linux/tcp.h#L206
-// tcp_info_for kernel 5.4+
 type TCPInfo5_4_281 struct {
 	State                  uint8
 	CaState                uint8
@@ -480,10 +488,11 @@ type TCPInfo5_4_281 struct {
 	SndWnd uint32 // bytes:4 [228:232] // peer's advertised receive window after scaling (bytes)
 }
 
-// note that the exported bytes are 236, because it includes the RTA header
-
-// https://github.com/torvalds/linux/blob/v4.19-rc8/include/uapi/linux/tcp.h#L176
-// https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/xenial/tree/include/uapi/linux/tcp.h?h=Ubuntu-hwe-4.15.0-107.108_16.04.1#n168
+// TCPInfo4_19_219 mirrors the kernel's `struct tcp_info` for Linux 4.19.219.
+// Note that the exported bytes are 236, because it includes the RTA header.
+//
+//   - https://github.com/torvalds/linux/blob/v4.19-rc8/include/uapi/linux/tcp.h#L176
+//   - https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/xenial/tree/include/uapi/linux/tcp.h?h=Ubuntu-hwe-4.15.0-107.108_16.04.1#n168
 type TCPInfo4_19_219 struct {
 	State                  uint8
 	CaState                uint8
@@ -557,8 +566,9 @@ type TCPInfo4_19_219 struct {
 	ReordSeen    uint32 // bytes:4 [220:224] // reordering events seen
 }
 
-// note that the exported bytes are 228, because it includes the RTA header
-
+// TCPInfo4_15 mirrors the kernel's `struct tcp_info` for Linux 4.15.
+// Note that the exported bytes are 228, because it includes the RTA header.
+//
 // https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/xenial/tree/include/uapi/linux/tcp.h?h=Ubuntu-hwe-4.15.0-107.108_16.04.1#n168
 type TCPInfo4_15 struct {
 	State                  uint8

--- a/pkg/xtcpnl/xtcpnl_nl_msg_hdr.go
+++ b/pkg/xtcpnl/xtcpnl_nl_msg_hdr.go
@@ -38,8 +38,8 @@ var (
 	ErrNlMsgHdrSmall = errors.New("data too small for NlMsgHdr")
 )
 
-// DeserializeNlMsgHdrLengthAndType does a binary read of Length and Type
-// It does a basic length check
+// DeserializeNlMsgHdr does a binary read of an NlMsgHdr with a basic
+// length check.
 func DeserializeNlMsgHdr(data []byte, nlmsghr *NlMsgHdr) (n int, err error) {
 
 	if len(data) < NlMsgHdrSizeCst {

--- a/pkg/xtcpnl/xtcpnl_pcap.go
+++ b/pkg/xtcpnl/xtcpnl_pcap.go
@@ -36,8 +36,9 @@ const (
 	PcapInetDiagSockIDOffsetCst = PcapNetlinkOffsetCst + NlMsgHdrSizeCst + InetDiagMsgBytesBeforeSocketIDCst
 )
 
+// PcapHeader represents the global header in a pcap file.
+//
 // https://www.ietf.org/archive/id/draft-gharris-opsawg-pcap-01.html#name-file-header
-// A Header represents the global header in a pcap file.
 type PcapHeader struct {
 	Magic        uint32 // 4 = 4
 	VersionMajor uint16 // 2 = 6
@@ -92,8 +93,9 @@ func DeserializePcapHeaderReflection(data []byte, ph *PcapHeader) (n int, err er
 // 	bpf_u_int32 len;	/* length of this packet prior to any slicing */
 // };
 
+// PcapRecordHeader represents a record header in a pcap file.
+//
 // https://www.ietf.org/archive/id/draft-gharris-opsawg-pcap-01.html#name-packet-record
-// A RecordHeader represents a record header in a pcap file.
 type PcapRecordHeader struct {
 	TsSec  uint32 // 4 = 4
 	TsXsec uint32 // 4 = 8 // micro or nano depends on magic
@@ -105,8 +107,8 @@ var (
 	ErrPcapRecordHeaderSmall = errors.New("data too small for PcapRecordHeader")
 )
 
-// DeserializePcapHeader does a binary read of a PcapHeader
-// It does a basic length check
+// DeserializePcapRecordHeader does a binary read of a PcapRecordHeader
+// with a basic length check.
 func DeserializePcapRecordHeader(data []byte, prh *PcapRecordHeader) (n int, err error) {
 
 	if len(data) < PcapRecordHeaderSizeCst {


### PR DESCRIPTION
## Summary

Ninth slice (after #8–#15). The `gocritic-cleanup` layer — documentation-comment hygiene:

- **gocritic commentFormatting**: auto-fixes on previously-missed sites
- **staticcheck ST1000**: add package-doc comments to `xtcp` and `xtcpnl`
- **staticcheck ST1020 + ST1021**: rewrite exported doc comments to start with the symbol name
- `docs/quality-report.md` refresh

## Testing

- `go vet ./...` — clean (go 1.25).
- `gofmt -l .` — clean repo-wide.
- `go test ./pkg/xtcp/ ./pkg/xtcpnl/` — only the pre-existing `TestReconcileMaps` known-failure remains (identical to `main`, on the allowlist).

Note: as in #14, one `gofmt` reflow (`skmeminfo` doc comment) was pulled forward from the next layer so this PR is independently gofmt-clean — the ST1020 rewrite reflowed a struct doc block into a non-gofmt form that the stack only tidies a layer later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
