### PR TITLE
PR #22a: golangci-lint → green (errcheck/noctx/forbidigo/gosec/…, real handling)

### DIFF
--- a/cmd/nsTest/nsTest.go
+++ b/cmd/nsTest/nsTest.go
@@ -60,7 +60,7 @@ func runMain(ctx context.Context, args []string, stderr io.Writer) int {
 		ns := namespaceName(i)
 		createNamespace(ctx, ns)
 		if *traffic {
-			injectLoopbackTraffic(ns)
+			injectLoopbackTraffic(ctx, ns)
 		}
 		if *conns > 0 {
 			startPersistentTraffic(ctx, ns, *conns)
@@ -83,7 +83,7 @@ func churn(ctx context.Context, initial int, sleep time.Duration, traffic bool, 
 		newNamespace := namespaceName(j + initial)
 		createNamespace(ctx, newNamespace)
 		if traffic {
-			injectLoopbackTraffic(newNamespace)
+			injectLoopbackTraffic(ctx, newNamespace)
 		}
 		if conns > 0 {
 			startPersistentTraffic(ctx, newNamespace, conns)
@@ -123,7 +123,7 @@ func churn(ctx context.Context, initial int, sleep time.Duration, traffic bool, 
 //
 // Errors are logged but non-fatal — the surrounding churn loop must
 // keep running regardless of a single ns's setup failing.
-func injectLoopbackTraffic(nsName string) {
+func injectLoopbackTraffic(ctx context.Context, nsName string) {
 	runtime.LockOSThread()
 	// NB: NO unconditional defer UnlockOSThread — same pattern as
 	// xtcp2's netNamespaceInstance. If the Setns restore fails the
@@ -142,7 +142,7 @@ func injectLoopbackTraffic(nsName string) {
 			log.Printf("injectLoopbackTraffic %s: restore ns: %v (keeping thread locked → runtime will terminate it)", nsName, rerr)
 			return
 		}
-		runtime.UnlockOSThread()
+		runtime.UnlockOSThread() //nolint:forbidigo // safe: only fires after Setns restore returned nil
 	}()
 
 	// Open the target netns and setns into it.
@@ -161,7 +161,7 @@ func injectLoopbackTraffic(nsName string) {
 	// Bring up lo so 127.0.0.1 is routable. Shelling out is slower
 	// than a direct SIOCSIFFLAGS ioctl, but at the soak's churn rate
 	// (~10/s) the cost is negligible and the code is much simpler.
-	if err := exec.Command("ip", "link", "set", "lo", "up").Run(); err != nil {
+	if err := exec.CommandContext(ctx, "ip", "link", "set", "lo", "up").Run(); err != nil {
 		log.Printf("injectLoopbackTraffic %s: ip link set lo up: %v", nsName, err)
 		return
 	}
@@ -171,12 +171,12 @@ func injectLoopbackTraffic(nsName string) {
 	// payload, close. The kernel keeps TIME_WAIT entries for ~60s
 	// per Linux's default tcp_fin_timeout/timewait — well within the
 	// ~20s ns lifetime under the soak's 100 ms churn cadence.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
 		log.Printf("injectLoopbackTraffic %s: listen: %v", nsName, err)
 		return
 	}
-	defer listener.Close()
+	defer closeOrLog(listener, "injectLoopbackTraffic listener")
 	addr := listener.Addr().String()
 
 	// Accept the connection in a goroutine so the dialer can connect.
@@ -190,8 +190,11 @@ func injectLoopbackTraffic(nsName string) {
 		// Drain a few bytes so the connection actually flows + the
 		// kernel records segs-in/out (visible via inet_diag's TCPInfo).
 		var buf [16]byte
-		_, _ = c.Read(buf[:]) //nolint:errcheck // best-effort drain
-		c.Close()
+		if _, rerr := c.Read(buf[:]); rerr != nil {
+			// best-effort drain; nothing actionable
+			log.Printf("injectLoopbackTraffic %s: drain read: %v", nsName, rerr)
+		}
+		closeOrLog(c, "injectLoopbackTraffic accepted conn")
 	}()
 
 	// Dial + send. 200 ms total timeout so a setns race or other
@@ -202,8 +205,10 @@ func injectLoopbackTraffic(nsName string) {
 		log.Printf("injectLoopbackTraffic %s: dial: %v", nsName, err)
 		return
 	}
-	_, _ = conn.Write([]byte("xtcp2-soak\n")) //nolint:errcheck // best-effort
-	conn.Close()
+	if _, werr := conn.Write([]byte("xtcp2-soak\n")); werr != nil {
+		log.Printf("injectLoopbackTraffic %s: write: %v", nsName, werr)
+	}
+	closeOrLog(conn, "injectLoopbackTraffic dial conn")
 
 	select {
 	case <-acceptDone:
@@ -218,6 +223,15 @@ func injectLoopbackTraffic(nsName string) {
 type nsTrafficState struct {
 	cancel context.CancelFunc
 	done   chan struct{}
+}
+
+// pair holds one loopback listener+dialer connection pair (server +
+// client side) plus its per-conn io profile index. Package-scoped so
+// the openTrafficPairs / runTrafficPairs helpers can share the type.
+type pair struct {
+	server  net.Conn
+	client  net.Conn
+	profile int
 }
 
 // nsTrafficStates: ns name → state. Stored separately from the churn
@@ -266,7 +280,10 @@ func stopPersistentTraffic(nsName string) {
 	if !ok {
 		return
 	}
-	state, _ := v.(*nsTrafficState)
+	state, ok := v.(*nsTrafficState)
+	if !ok {
+		return
+	}
 	state.cancel()
 	// Bounded wait: io goroutines may be in mid-Read/Write when the
 	// cancel fires. Closing the connection from the runner side
@@ -308,25 +325,29 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 			// rather than recycling an M with a non-host netns.
 			return
 		}
-		runtime.UnlockOSThread()
+		runtime.UnlockOSThread() //nolint:forbidigo // safe: only fires after Setns restore returned nil
 	}()
 
 	target, err := os.Open("/run/netns/" + nsName)
 	if err != nil {
 		// Race: ns deleted between createNamespace and here.
-		_ = unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET)
+		if serr := unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET); serr != nil {
+			log.Printf("runPersistentTraffic %s: restore ns: %v", nsName, serr)
+		}
 		restoredOK = true
 		return
 	}
 	defer target.Close()
 	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
 		log.Printf("runPersistentTraffic %s: setns: %v", nsName, err)
-		_ = unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET)
+		if serr := unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET); serr != nil {
+			log.Printf("runPersistentTraffic %s: restore ns: %v", nsName, serr)
+		}
 		restoredOK = true
 		return
 	}
 
-	if err := exec.Command("ip", "link", "set", "lo", "up").Run(); err != nil {
+	if err := exec.CommandContext(nsCtx, "ip", "link", "set", "lo", "up").Run(); err != nil {
 		log.Printf("runPersistentTraffic %s: ip link set lo up: %v", nsName, err)
 		// Try to restore + return
 		if unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET) == nil {
@@ -335,11 +356,24 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 		return
 	}
 
-	type pair struct {
-		server  net.Conn
-		client  net.Conn
-		profile int
+	pairs := openTrafficPairs(nsCtx, nsName, count)
+
+	// Restore the host netns + conditionally unlock the OS thread.
+	if rerr := unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET); rerr != nil {
+		log.Printf("runPersistentTraffic %s: restore ns: %v (keeping thread locked → runtime will terminate it)", nsName, rerr)
+	} else {
+		restoredOK = true
 	}
+
+	runTrafficPairs(nsCtx, pairs)
+}
+
+// openTrafficPairs opens `count` loopback listener+dialer pairs inside
+// the current (already-entered) netns and returns the resulting server/
+// client conn pairs. Must be called on the LockOSThread'd goroutine that
+// has setns'd into nsName. Errors are non-fatal: a failed listen breaks
+// the loop, a failed dial skips that pair.
+func openTrafficPairs(ctx context.Context, nsName string, count int) []pair {
 	pairs := make([]pair, 0, count)
 
 	// Open all pairs. A single listener per port is sufficient; we
@@ -353,7 +387,7 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 	// (one new ns / 100 ms) doesn't come anywhere near this.
 	const dialTimeout = 2 * time.Second
 	for i := 0; i < count; i++ {
-		l, lerr := net.Listen("tcp", "127.0.0.1:0")
+		l, lerr := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 		if lerr != nil {
 			// Listen failures are rare and usually mean fd exhaustion
 			// or netns going away — surface once per ns, then break.
@@ -378,25 +412,24 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 			// and the kernel sheds some load. Silent retry-or-skip
 			// keeps the journal readable. Steady-state churn doesn't
 			// hit this path.
-			l.Close()
+			closeOrLog(l, "openTrafficPairs listener")
 			continue
 		}
 		server := <-acceptCh
-		_ = l.Close() // listener no longer needed; accept returned
+		closeOrLog(l, "openTrafficPairs listener") // listener no longer needed; accept returned
 		if server == nil {
-			client.Close()
+			closeOrLog(client, "openTrafficPairs client")
 			continue
 		}
 		pairs = append(pairs, pair{server: server, client: client, profile: i})
 	}
+	return pairs
+}
 
-	// Restore the host netns + conditionally unlock the OS thread.
-	if rerr := unix.Setns(int(origNs.Fd()), unix.CLONE_NEWNET); rerr != nil {
-		log.Printf("runPersistentTraffic %s: restore ns: %v (keeping thread locked → runtime will terminate it)", nsName, rerr)
-	} else {
-		restoredOK = true
-	}
-
+// runTrafficPairs spawns the echo-server + varied-client io goroutines
+// for each pair, blocks until nsCtx is canceled, then closes every
+// socket to unblock the io goroutines and waits for them to return.
+func runTrafficPairs(nsCtx context.Context, pairs []pair) {
 	if len(pairs) == 0 {
 		return
 	}
@@ -414,8 +447,8 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 	<-nsCtx.Done()
 	// Close all sockets so blocked Read/Write calls return.
 	for _, p := range pairs {
-		_ = p.server.Close()
-		_ = p.client.Close()
+		closeOrLog(p.server, "runTrafficPairs server")
+		closeOrLog(p.client, "runTrafficPairs client")
 	}
 	wg.Wait()
 }
@@ -424,7 +457,7 @@ func runPersistentTraffic(nsCtx context.Context, nsName string, count int, done 
 // Returns on ctx cancel (the connection is closed by the parent
 // goroutine, which unblocks Read).
 func runEchoServer(_ context.Context, c net.Conn) {
-	defer c.Close()
+	defer closeOrLog(c, "runEchoServer conn")
 	buf := make([]byte, 64*1024)
 	for {
 		n, err := c.Read(buf)
@@ -442,7 +475,7 @@ func runEchoServer(_ context.Context, c net.Conn) {
 // the ns; consecutive conns get different sizes AND intervals so the
 // inet_diag readout shows real spread in TCPInfo segs/bytes/rtt.
 func runVariedClient(ctx context.Context, c net.Conn, profileIdx int) {
-	defer c.Close()
+	defer closeOrLog(c, "runVariedClient conn")
 
 	payloadSize := trafficPayloadSizes[profileIdx%len(trafficPayloadSizes)]
 	sendInterval := trafficSendIntervals[(profileIdx/len(trafficPayloadSizes))%len(trafficSendIntervals)]
@@ -495,5 +528,13 @@ func removeNamespace(ctx context.Context, name string) {
 	cmd := exec.CommandContext(ctx, "ip", "netns", "del", name)
 	if err := cmd.Run(); err != nil {
 		log.Printf("Failed to remove namespace %s: %v", name, err)
+	}
+}
+
+// closeOrLog closes c and logs a non-nil error under label. Used by the
+// soak tool's best-effort teardown paths so every Close is handled.
+func closeOrLog(c io.Closer, label string) {
+	if err := c.Close(); err != nil {
+		log.Printf("%s: close: %v", label, err)
 	}
 }

--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -69,7 +69,7 @@ const (
 	marshalCst = "protobufList"
 
 	// envelopeFlushBytesCst caps the in-flight protobufList Envelope's
-	// uncompressed marshalled byte size before deserialize.go triggers
+	// uncompressed marshaled byte size before deserialize.go triggers
 	// an early mid-poll flush. Use as a safety net against pathological
 	// per-record sizes; for everyday batch sizing prefer the row cap
 	// below. 0 = use daemon's compile-time default
@@ -414,7 +414,7 @@ func startPyroscope(url, appName string, sampleHz, uploadSec uint, debugLevel ui
 		return func() {}
 	}
 	if appName == "" {
-		appName = "xtcp2"
+		appName = pyroscopeAppNameCst
 	}
 	if sampleHz == 0 {
 		sampleHz = 100

--- a/pkg/xtcp/deserialize.go
+++ b/pkg/xtcp/deserialize.go
@@ -196,7 +196,7 @@ func (x *XTCP) processInetDiagRecord(
 	x.flatRecordServiceSend(xtcpRecord)
 
 	// ProtobufList: record is owned by currentEnvelope until flushEnvelope
-	// at cycle end marshals and pool-returns it. The mutex serialises
+	// at cycle end marshals and pool-returns it. The mutex serializes
 	// appends from N×K parallel netlinkers (one per netns × Netlinkers).
 	// A nil currentEnvelope means a flush has already run (shutdown race);
 	// return the record to its pool so it doesn't leak.

--- a/pkg/xtcp/deserialize_corner_cases_test.go
+++ b/pkg/xtcp/deserialize_corner_cases_test.go
@@ -134,7 +134,7 @@ func runDeserialize(t *testing.T, x *XTCP, buf []byte) (rec *recordingDest, n ui
 
 	// Phase 1 ProtobufList: processInetDiagRecord appends to
 	// x.currentEnvelope under envelopeMu instead of calling dest.Send
-	// per-record. Initialise a fresh envelope so the append path has
+	// per-record. Initialize a fresh envelope so the append path has
 	// somewhere to write; the test then asserts on rec.EnvelopeRows().
 	x.currentEnvelope = &xtcp_flat_record.Envelope{}
 

--- a/pkg/xtcp/init_capabilities.go
+++ b/pkg/xtcp/init_capabilities.go
@@ -81,7 +81,7 @@ func scanCapabilities() (capabilityCheckResult, uint32, error) {
 
 	var caps unix.CapUserData
 	if err := capgetFunc(&hdr, &caps); err != nil {
-		return capabilityCheckResult{}, 0, fmt.Errorf("Capget: %w", err)
+		return capabilityCheckResult{}, 0, fmt.Errorf("capget: %w", err)
 	}
 
 	var res capabilityCheckResult

--- a/pkg/xtcp/ns_net_namespace.go
+++ b/pkg/xtcp/ns_net_namespace.go
@@ -66,7 +66,7 @@ func (x *XTCP) netNamespaceInstance(ctx context.Context, nsName *string) {
 	// restore succeeding*. If restore fails we leave the goroutine
 	// holding the lock — when this function returns the Go runtime
 	// terminates the OS thread instead of reusing it (documented
-	// behaviour of runtime.LockOSThread). The cost is one OS thread
+	// behavior of runtime.LockOSThread). The cost is one OS thread
 	// creation per failed restore (~10 µs) instead of an unbounded
 	// accumulation of tainted Ms.
 	origNs, errOrig := os.Open("/proc/thread-self/ns/net")

--- a/pkg/xtcp/ns_thread_leak_test.go
+++ b/pkg/xtcp/ns_thread_leak_test.go
@@ -105,8 +105,8 @@ func TestNamespaceChurn_threadBoundedUnderRestoreFailure(t *testing.T) {
 	delta := end - baseline
 
 	// Bound is generous to avoid flakes from Go's M-pool warm-up
-	// scheduling. The leaky behaviour grows linearly with N (e.g.
-	// 400 iterations → delta ≥ 300); the fixed behaviour holds
+	// scheduling. The leaky behavior grows linearly with N (e.g.
+	// 400 iterations → delta ≥ 300); the fixed behavior holds
 	// delta < 50 in practice.
 	const maxDelta = 80
 	if delta > maxDelta {

--- a/pkg/xtcp/ns_watch.go
+++ b/pkg/xtcp/ns_watch.go
@@ -162,7 +162,7 @@ func (x *XTCP) createNetworkNamespace(netnsDir string, newNetNSName string) erro
 	// back to Go's scheduler leaks OS threads up to SetMaxThreads. On
 	// restore failure the goroutine exits with the lock still held;
 	// Go's runtime then terminates the OS thread (documented
-	// LockOSThread behaviour) rather than recycling a tainted M.
+	// LockOSThread behavior) rather than recycling a tainted M.
 
 	// Snapshot the calling thread's current netns so we can restore
 	// after the unshare+bind-mount. Otherwise this goroutine's thread

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -21,7 +21,7 @@ func (x *XTCP) Poller(ctx context.Context, wg *sync.WaitGroup) {
 	// return), and a canceled ctx would short-circuit Send and lose the
 	// in-flight envelope. The destination's own Close() drains pending
 	// produces with a 5s flush window.
-	defer x.flushEnvelope(context.Background(), "shutdown")
+	defer x.flushEnvelope(context.WithoutCancel(ctx), "shutdown")
 
 	if x.debugLevel > 10 {
 		log.Printf("Poller started")


### PR DESCRIPTION
## Summary

**PR #22a — golangci-lint → green.** First of the final cleanup series. Drives the whole tree to a clean `golangci-lint` (both the standard and comprehensive tiers) **for the first time** — fixing the findings that `go vet`+`gofmt` never surfaced (errcheck/noctx/forbidigo/contextcheck/gosec/goconst/staticcheck/misspell), with **real handling, not suppression**.

These were all pre-existing on `main` (2 findings) + faithfully carried by the s3parquet layer (the rest) — confirmed present at the original `s3parquet` tip.

### cmd/nsTest (the soak/stress tool — bulk of the findings)
- **errcheck** (13): new `closeOrLog` helper — every `net.Listener`/`net.Conn` `Close` and the best-effort `unix.Setns` restores now log on error. No `//nolint:errcheck`, no blank discards.
- **noctx** (4): `exec.Command`→`CommandContext`, `net.Listen`→`(*net.ListenConfig).Listen` (threaded `ctx`).
- **forbidigo** (2): the conditional `runtime.UnlockOSThread` sites get the codebase-standard `//nolint:forbidigo` justification (they only fire after a successful `Setns` restore — same convention as `pkg/xtcp/ns_net_namespace.go`).
- **funlen** (1): split `runPersistentTraffic` into `openTrafficPairs`/`runTrafficPairs`, preserving the LockOSThread/Setns-restore/conditional-unlock safety skeleton.

### pkg/xtcp + cmd/xtcp2
- **contextcheck + gosec G118** (one root cause): `Poller`'s shutdown-flush `context.Background()` → `context.WithoutCancel(ctx)` — keeps the detached-from-cancellation semantics (the reason the final flush exists) while inheriting values; clears both findings.
- **goconst**: `"xtcp2"` literal → existing `pyroscopeAppNameCst`.
- **staticcheck ST1005**: lowercase the `"Capget:"` wrapped-error string.
- **misspell**: US spelling in comments.

## Testing

- **`nix build .#checks…golangci-lint` AND `…golangci-lint-comprehensive` both PASS** (the headline — main is lint-green now).
- Binary-blob guard: clean. `go vet ./...` + `gofmt -l .`: clean.
- `go test -ldflags=-checklinkname=0 -tags 'dest_kafka dest_nats dest_nsq dest_valkey dest_s3parquet' ./...` — **entire suite green** (no behavior change; the soak-tool split + ctx threading preserve semantics).

The only `//nolint` added is `:forbidigo` (codebase convention for the conditional OS-thread unlock). **Zero `//nolint:errcheck`** added — and removing the *existing* errcheck nolints (via typed `xsync` wrappers + real handling) is the next sub-PR, #22b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
