### PR TITLE
PR #22b: typed xsync.Pool[T] (value field) + convert all sync.Pool

### DIFF
--- a/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
+++ b/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/randomizedcoder/xtcp2/pkg/clickhouse_protolist"
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kprom"
 	"google.golang.org/protobuf/encoding/protodelim"
@@ -47,7 +48,7 @@ var (
 	version string
 
 	kClient       *kgo.Client
-	kgoRecordPool sync.Pool
+	kgoRecordPool *xsync.Pool[*kgo.Record]
 
 	// fatalf is the package-level abort handler. Defaults to log.Fatalf;
 	// tests swap this in for a capture so the dump-file write error
@@ -135,11 +136,9 @@ func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		debugLevel:   *d,
 	}
 
-	kgoRecordPool = sync.Pool{
-		New: func() any {
-			return new(kgo.Record)
-		},
-	}
+	kgoRecordPool = xsync.NewPool(func() *kgo.Record {
+		return new(kgo.Record)
+	})
 
 	if c.kafka {
 		if err := InitDestKafka(ctx, c); err != nil {
@@ -293,7 +292,7 @@ func destKafka(ctx context.Context, c config, xtcpRecordBinary *[]byte) (n int, 
 		log.Println("destKafka start")
 	}
 
-	kgoRecord, _ := kgoRecordPool.Get().(*kgo.Record) //nolint:errcheck // pool.New returns *kgo.Record
+	kgoRecord := kgoRecordPool.Get()
 	// defer x.kgoRecordPool.Put(kgoRecord)
 
 	// Reset the pooled record to zero before re-populating. Without this

--- a/cmd/kafka_to_clickhouse/kafka_to_clickhouse_test.go
+++ b/cmd/kafka_to_clickhouse/kafka_to_clickhouse_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -247,12 +248,12 @@ func TestFileOrKafka_kafkaMode(t *testing.T) {
 	}
 	defer cl.Close()
 	prevClient := kClient
-	prevPoolNew := kgoRecordPool.New
+	prevPool := kgoRecordPool
 	kClient = cl
-	kgoRecordPool.New = func() any { return new(kgo.Record) }
+	kgoRecordPool = xsync.NewPool(func() *kgo.Record { return new(kgo.Record) })
 	t.Cleanup(func() {
 		kClient = prevClient
-		kgoRecordPool.New = prevPoolNew
+		kgoRecordPool = prevPool
 	})
 
 	data := []byte("payload")
@@ -276,12 +277,12 @@ func TestDestKafka_unreachable(t *testing.T) {
 	}
 	defer cl.Close()
 	prevClient := kClient
-	prevPoolNew := kgoRecordPool.New
+	prevPool := kgoRecordPool
 	kClient = cl
-	kgoRecordPool.New = func() any { return new(kgo.Record) }
+	kgoRecordPool = xsync.NewPool(func() *kgo.Record { return new(kgo.Record) })
 	t.Cleanup(func() {
 		kClient = prevClient
-		kgoRecordPool.New = prevPoolNew
+		kgoRecordPool = prevPool
 	})
 
 	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)

--- a/pkg/xsync/pool.go
+++ b/pkg/xsync/pool.go
@@ -1,0 +1,51 @@
+// Package xsync provides thin, generic, type-safe wrappers over the
+// standard library's sync.Pool (and, later, sync.Map). The point is to
+// move the single unavoidable type assertion into one provably-correct
+// place so call sites get a typed value back and need no scattered
+// `v, _ := p.Get().(*T) //nolint:errcheck`.
+package xsync
+
+import "sync"
+
+// Pool is a typed wrapper over sync.Pool. The zero value is usable as a
+// struct field once Init has set its New function — the wrapper embeds
+// sync.Pool by value, so a Pool field has the same memory layout (and
+// no extra indirection) as a plain sync.Pool field.
+//
+// A failed assertion in Get is unreachable by construction — New always
+// returns T and Put only accepts T — so the only way to trip the panic
+// is a programming error (the pool was miswired), never load or memory
+// pressure. Failing loud there is deliberate: a silent zero value would
+// surface later as a far harder-to-debug nil dereference.
+type Pool[T any] struct {
+	p sync.Pool
+}
+
+// Init sets the pool's New function. Call it once before first use on a
+// Pool used as a struct field (the zero value is otherwise New-less and
+// Get would panic). Pool must not be copied after Init.
+func (p *Pool[T]) Init(newFn func() T) {
+	p.p.New = func() any { return newFn() }
+}
+
+// NewPool returns an already-Init'd *Pool[T] — a convenience for
+// function-local pools that are naturally held by pointer.
+func NewPool[T any](newFn func() T) *Pool[T] {
+	p := &Pool[T]{}
+	p.Init(newFn)
+	return p
+}
+
+// Get returns a value from the pool, allocating via New if empty.
+func (p *Pool[T]) Get() T {
+	v, ok := p.p.Get().(T)
+	if !ok {
+		panic("xsync.Pool: Get returned a value of the wrong type — New/Put miswired")
+	}
+	return v
+}
+
+// Put returns v to the pool for reuse.
+func (p *Pool[T]) Put(v T) {
+	p.p.Put(v)
+}

--- a/pkg/xsync/pool_test.go
+++ b/pkg/xsync/pool_test.go
@@ -1,0 +1,66 @@
+package xsync
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestPool_GetReturnsNewValue(t *testing.T) {
+	calls := 0
+	p := NewPool(func() *int {
+		calls++
+		v := 42
+		return &v
+	})
+
+	got := p.Get()
+	if got == nil || *got != 42 {
+		t.Fatalf("Get() = %v, want pointer to 42", got)
+	}
+	if calls != 1 {
+		t.Fatalf("New called %d times, want 1", calls)
+	}
+}
+
+func TestPool_PutThenGetReuses(t *testing.T) {
+	p := NewPool(func() *[]byte {
+		b := make([]byte, 8)
+		return &b
+	})
+
+	a := p.Get()
+	*a = append((*a)[:0], 'x')
+	p.Put(a)
+
+	// After Put, the next Get should return the same backing pointer
+	// (sync.Pool is best-effort, but in a single goroutine with no GC
+	// in between it reliably hands the value straight back).
+	b := p.Get()
+	if b != a {
+		t.Fatalf("Get after Put returned a different pointer; pooling not wired")
+	}
+}
+
+func TestPool_GetType(t *testing.T) {
+	type rec struct{ n int }
+	p := NewPool(func() *rec { return &rec{n: 7} })
+	r := p.Get()
+	if r.n != 7 {
+		t.Fatalf("Get().n = %d, want 7", r.n)
+	}
+}
+
+func TestPool_ConcurrentGetPut(t *testing.T) {
+	p := NewPool(func() *int { v := 0; return &v })
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Go(func() {
+			for range 1000 {
+				v := p.Get()
+				*v++
+				p.Put(v)
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/pkg/xtcp/deserialize.go
+++ b/pkg/xtcp/deserialize.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"log"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcpnl"
 )
@@ -23,9 +23,9 @@ type DeserializeArgs struct {
 	ns             *string
 	fd             int
 	NLPacket       *[]byte
-	xtcpRecordPool *sync.Pool
-	nlhPool        *sync.Pool
-	rtaPool        *sync.Pool
+	xtcpRecordPool *xsync.Pool[*xtcp_flat_record.XtcpFlatRecord]
+	nlhPool        *xsync.Pool[*xtcpnl.NlMsgHdr]
+	rtaPool        *xsync.Pool[*xtcpnl.RTAttr]
 	pC             *prometheus.CounterVec
 	pH             *prometheus.SummaryVec
 	id             uint32
@@ -86,7 +86,7 @@ func (x *XTCP) Deserialize(ctx context.Context, d DeserializeArgs) (n uint64, er
 		}
 
 		nlPacketStartTime := time.Now()
-		xtcpRecord, _ := x.xtcpRecordPool.Get().(*xtcp_flat_record.XtcpFlatRecord) //nolint:errcheck // pool.New returns *XtcpFlatRecord
+		xtcpRecord := x.xtcpRecordPool.Get()
 
 		xtcpRecord.Hostname = x.hostname
 		xtcpRecord.TimestampNs = timestampNs
@@ -95,7 +95,7 @@ func (x *XTCP) Deserialize(ctx context.Context, d DeserializeArgs) (n uint64, er
 		xtcpRecord.SocketFd = uint64(d.fd)
 		xtcpRecord.NetlinkerId = uint64(d.id)
 
-		nlh, _ := d.nlhPool.Get().(*xtcpnl.NlMsgHdr) //nolint:errcheck // pool.New returns *NlMsgHdr
+		nlh := d.nlhPool.Get()
 
 		length = xtcpnl.NlMsgHdrSizeCst
 		if _, errD := xtcpnl.DeserializeNlMsgHdr((*d.NLPacket)[offset:offset+length], nlh); errD != nil {
@@ -291,7 +291,7 @@ type DeserializeAttributesArgs struct {
 	NLPacket   *[]byte
 	xtcpRecord *xtcp_flat_record.XtcpFlatRecord
 	// xtcpRecord *xtcp_flat_record.Envelope_XtcpFlatRecord
-	rtaPool *sync.Pool
+	rtaPool *xsync.Pool[*xtcpnl.RTAttr]
 	pC      *prometheus.CounterVec
 	pH      *prometheus.SummaryVec
 	id      uint32
@@ -321,7 +321,7 @@ func (x *XTCP) DeserializeAttributes(d DeserializeAttributesArgs) {
 			return
 		}
 
-		rta, _ := d.rtaPool.Get().(*xtcpnl.RTAttr) //nolint:errcheck // pool.New returns *RTAttr
+		rta := d.rtaPool.Get()
 
 		length := xtcpnl.RTAttrSizeCst
 		_, errD := xtcpnl.DeserializeRTAttr((*d.NLPacket)[d.offset:d.offset+length], rta)

--- a/pkg/xtcp/deserialize_test.go
+++ b/pkg/xtcp/deserialize_test.go
@@ -67,9 +67,9 @@ func newTestDeserializeXTCP(tb testing.TB) *XTCP {
 	}
 	x.debugLevel = 0
 	x.hostname = misc.GetHostname()
-	x.xtcpRecordPool = sync.Pool{New: func() any { return new(xtcp_flat_record.XtcpFlatRecord) }}
-	x.nlhPool = sync.Pool{New: func() any { return new(xtcpnl.NlMsgHdr) }}
-	x.rtaPool = sync.Pool{New: func() any { return new(xtcpnl.RTAttr) }}
+	x.xtcpRecordPool.Init(func() *xtcp_flat_record.XtcpFlatRecord { return new(xtcp_flat_record.XtcpFlatRecord) })
+	x.nlhPool.Init(func() *xtcpnl.NlMsgHdr { return new(xtcpnl.NlMsgHdr) })
+	x.rtaPool.Init(func() *xtcpnl.RTAttr { return new(xtcpnl.RTAttr) })
 	x.netlinkerDoneCh = make(chan netlinkerDone, 64)
 	x.pollRequestCh = make(chan struct{}, 1)
 	x.fatalf = tb.Fatalf
@@ -208,7 +208,7 @@ func TestDeserialize(t *testing.T) {
 		// one record by checking that field on a freshly-pooled struct
 		// after the run (the pool's reused entries will all carry
 		// x.hostname).
-		fresh := x.xtcpRecordPool.Get().(*xtcp_flat_record.XtcpFlatRecord)
+		fresh := x.xtcpRecordPool.Get()
 		if fresh.Hostname != "" && fresh.Hostname != test.xtcpRecord.Hostname {
 			t.Errorf("test %d %s: pooled record Hostname=%q want=%q",
 				i, test.description, fresh.Hostname, test.xtcpRecord.Hostname)
@@ -290,5 +290,5 @@ func DeserializeBoth(b *testing.B) {
 		}
 	}
 
-	resultXtcpFlatRecord = x.xtcpRecordPool.Get().(*xtcp_flat_record.XtcpFlatRecord)
+	resultXtcpFlatRecord = x.xtcpRecordPool.Get()
 }

--- a/pkg/xtcp/destinations_kafka.go
+++ b/pkg/xtcp/destinations_kafka.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 	"github.com/twmb/franz-go/plugin/kprom"
@@ -47,7 +47,7 @@ type kafkaDest struct {
 	client     kafkaProducer
 	regClient  *sr.Client
 	schemaID   int
-	recordPool sync.Pool
+	recordPool *xsync.Pool[*kgo.Record]
 }
 
 // newKafkaProducerFn is the factory tests swap to inject a fake
@@ -65,10 +65,8 @@ func newKafkaProducerReal(opts ...kgo.Opt) (kafkaProducer, error) {
 
 func newKafkaDest(ctx context.Context, x *XTCP) (Destination, error) {
 	d := &kafkaDest{
-		x: x,
-		recordPool: sync.Pool{
-			New: func() any { return new(kgo.Record) },
-		},
+		x:          x,
+		recordPool: xsync.NewPool(func() *kgo.Record { return new(kgo.Record) }),
 	}
 
 	// Schema-registry registration is informational only — ClickHouse
@@ -144,7 +142,7 @@ func (d *kafkaDest) Send(ctx context.Context, b *[]byte) (int, error) {
 	// pinned to one partition; previous Timestamp stayed → every
 	// reused record claimed the time of the first send. Topic/Value
 	// overwrite below preserves the original intent.
-	rec := d.recordPool.Get().(*kgo.Record)
+	rec := d.recordPool.Get()
 	*rec = kgo.Record{
 		Topic: d.x.config.Topic,
 		Value: *b,

--- a/pkg/xtcp/destinations_kafka_test.go
+++ b/pkg/xtcp/destinations_kafka_test.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 )
 
 // destinations_kafka_test.go exercises pkg/xtcp/destinations_kafka.go
@@ -479,13 +480,11 @@ func newKafkaDestForTest(t *testing.T, fake *fakeKafkaProducer) *kafkaDest {
 	t.Helper()
 	x := newTestXTCP(t, "kafka:127.0.0.1:9092")
 	x.config.Topic = "xtcp-test"
-	x.destBytesPool = sync.Pool{New: func() any { b := make([]byte, 0, 128); return &b }}
+	x.destBytesPool.Init(func() *[]byte { b := make([]byte, 0, 128); return &b })
 	d := &kafkaDest{
-		x:      x,
-		client: fake,
-		recordPool: sync.Pool{
-			New: func() any { return new(kgo.Record) },
-		},
+		x:          x,
+		client:     fake,
+		recordPool: xsync.NewPool(func() *kgo.Record { return new(kgo.Record) }),
 	}
 	return d
 }
@@ -521,7 +520,7 @@ func TestKafkaDest_Send_table(t *testing.T) {
 			}
 			// destBytesPool.Put requires the caller to pass a *[]byte;
 			// allocate one here so Send's pool-return path runs.
-			buf := d.x.destBytesPool.Get().(*[]byte)
+			buf := d.x.destBytesPool.Get()
 			*buf = append((*buf)[:0], []byte("payload")...)
 			n, err := d.Send(context.Background(), buf)
 			if err != nil {
@@ -550,7 +549,7 @@ func TestKafkaDest_Send_debugLog(t *testing.T) {
 	fake := &fakeKafkaProducer{produceErr: errors.New("err")}
 	d := newKafkaDestForTest(t, fake)
 	d.x.debugLevel = 11
-	buf := d.x.destBytesPool.Get().(*[]byte)
+	buf := d.x.destBytesPool.Get()
 	*buf = append((*buf)[:0], []byte("x")...)
 	_, _ = d.Send(context.Background(), buf)
 }

--- a/pkg/xtcp/destinations_s3parquet_test.go
+++ b/pkg/xtcp/destinations_s3parquet_test.go
@@ -90,7 +90,7 @@ func newS3ParquetFixture(t *testing.T, threshold int, injectErr func(int) error)
 		prometheus.SummaryOpts{Subsystem: "xtcp_s3p_test", Name: promNameHistograms, Help: "test"},
 		promLabels,
 	)
-	x.destBytesPool = sync.Pool{New: func() any { b := make([]byte, 0, 1024); return &b }}
+	x.destBytesPool.Init(func() *[]byte { b := make([]byte, 0, 1024); return &b })
 
 	upl := &fakeUploader{injectErr: injectErr}
 	d := &s3ParquetDest{
@@ -111,7 +111,7 @@ func newS3ParquetFixture(t *testing.T, threshold int, injectErr func(int) error)
 // envelope ready for Send.
 func marshalEnvelopeBuf(t *testing.T, x *XTCP, env *xtcp_flat_record.Envelope) *[]byte {
 	t.Helper()
-	buf, _ := x.destBytesPool.Get().(*[]byte)
+	buf := x.destBytesPool.Get()
 	*buf = (*buf)[:0]
 	w := &ByteSliceWriter{Buf: buf}
 	if _, err := protodelim.MarshalTo(w, env); err != nil {
@@ -208,7 +208,7 @@ func TestS3ParquetDest_negative(t *testing.T) {
 			d, _, x := newS3ParquetFixture(t, 1<<30, tc.injectErr)
 			var buf *[]byte
 			if tc.body != nil {
-				got, _ := x.destBytesPool.Get().(*[]byte)
+				got := x.destBytesPool.Get()
 				*got = append((*got)[:0], tc.body...)
 				buf = got
 			} else {

--- a/pkg/xtcp/grpc_flatRecordService.go
+++ b/pkg/xtcp/grpc_flatRecordService.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 	"google.golang.org/grpc"
 )
@@ -27,7 +28,7 @@ type xtcpFlatRecordService struct {
 	pfrStoreCount          atomic.Uint64
 	pfrDeleteCount         atomic.Uint64
 
-	FlatRecordsResponsePool sync.Pool
+	FlatRecordsResponsePool *xsync.Pool[*xtcp_flat_record.FlatRecordsResponse]
 
 	pollRequestCh *chan struct{}
 
@@ -50,11 +51,9 @@ func NewXtcpFlatRecordService(ctx context.Context, reg prometheus.Registerer, po
 	s.debugLevel = debugLevel
 	s.ctx = ctx
 
-	s.FlatRecordsResponsePool = sync.Pool{
-		New: func() interface{} {
-			return new(xtcp_flat_record.FlatRecordsResponse)
-		},
-	}
+	s.FlatRecordsResponsePool = xsync.NewPool(func() *xtcp_flat_record.FlatRecordsResponse {
+		return new(xtcp_flat_record.FlatRecordsResponse)
+	})
 
 	s.pollRequestCh = pollRequestCh
 
@@ -248,7 +247,7 @@ func (x *XTCP) flatRecordServiceSend(xtcpRecord *xtcp_flat_record.XtcpFlatRecord
 		return
 	}
 
-	xtcpFlatRecordsResponse, _ := x.flatRecordService.FlatRecordsResponsePool.Get().(*xtcp_flat_record.FlatRecordsResponse) //nolint:errcheck // pool.New returns *FlatRecordsResponse
+	xtcpFlatRecordsResponse := x.flatRecordService.FlatRecordsResponsePool.Get()
 	// Reset the pooled response so its internal proto state (state,
 	// sizeCache, unknownFields) is cleared from the previous send. The
 	// per-record XtcpFlatRecord pointer assignment that follows is the

--- a/pkg/xtcp/grpc_flatRecordService_test.go
+++ b/pkg/xtcp/grpc_flatRecordService_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 )
 
@@ -39,9 +40,9 @@ func newFlatRecordServiceFixture(t *testing.T) *xtcpFlatRecordService {
 			promLabels,
 		),
 	}
-	s.FlatRecordsResponsePool.New = func() any {
+	s.FlatRecordsResponsePool = xsync.NewPool(func() *xtcp_flat_record.FlatRecordsResponse {
 		return new(xtcp_flat_record.FlatRecordsResponse)
-	}
+	})
 	return s
 }
 

--- a/pkg/xtcp/init_sync_pools.go
+++ b/pkg/xtcp/init_sync_pools.go
@@ -29,42 +29,30 @@ func (x *XTCP) InitSyncPools(wg *sync.WaitGroup) {
 		packetBufferSize = int(x.config.PacketSize * uint64(x.config.PacketSizeMply))
 	}
 
-	x.packetBufferPool = sync.Pool{
-		New: func() any {
-			b := make([]byte, packetBufferSize)
-			return &b
-		},
-	}
+	x.packetBufferPool.Init(func() *[]byte {
+		b := make([]byte, packetBufferSize)
+		return &b
+	})
 
-	x.xtcpEnvelopePool = sync.Pool{
-		New: func() any {
-			return new(xtcp_flat_record.Envelope)
-		},
-	}
+	x.xtcpEnvelopePool.Init(func() *xtcp_flat_record.Envelope {
+		return new(xtcp_flat_record.Envelope)
+	})
 
-	x.xtcpRecordPool = sync.Pool{
-		New: func() any {
-			return new(xtcp_flat_record.XtcpFlatRecord)
-			// return new(xtcp_flat_record.Envelope_XtcpFlatRecord)
-		},
-	}
+	x.xtcpRecordPool.Init(func() *xtcp_flat_record.XtcpFlatRecord {
+		return new(xtcp_flat_record.XtcpFlatRecord)
+		// return new(xtcp_flat_record.Envelope_XtcpFlatRecord)
+	})
 
-	x.nlhPool = sync.Pool{
-		New: func() any {
-			return new(xtcpnl.NlMsgHdr)
-		},
-	}
+	x.nlhPool.Init(func() *xtcpnl.NlMsgHdr {
+		return new(xtcpnl.NlMsgHdr)
+	})
 
-	x.rtaPool = sync.Pool{
-		New: func() any {
-			return new(xtcpnl.RTAttr)
-		},
-	}
+	x.rtaPool.Init(func() *xtcpnl.RTAttr {
+		return new(xtcpnl.RTAttr)
+	})
 
-	x.destBytesPool = sync.Pool{
-		New: func() any {
-			b := make([]byte, 0, destBytesMaxSizeCst)
-			return &b
-		},
-	}
+	x.destBytesPool.Init(func() *[]byte {
+		b := make([]byte, 0, destBytesMaxSizeCst)
+		return &b
+	})
 }

--- a/pkg/xtcp/init_test.go
+++ b/pkg/xtcp/init_test.go
@@ -263,7 +263,7 @@ func TestInitSyncPools_defaults(t *testing.T) {
 		t.Errorf("PacketSizeMply = %d, want 8", x.config.PacketSizeMply)
 	}
 	// Pools should yield buffers via their New funcs.
-	pb, _ := x.packetBufferPool.Get().(*[]byte)
+	pb := x.packetBufferPool.Get()
 	if pb == nil || cap(*pb) != syscall.Getpagesize()*8 {
 		t.Errorf("packetBufferPool New() produced cap=%d, want %d",
 			cap(*pb), syscall.Getpagesize()*8)
@@ -289,7 +289,7 @@ func TestInitSyncPools_explicitPacketSize(t *testing.T) {
 	wg.Add(1)
 	x.InitSyncPools(&wg)
 	wg.Wait()
-	pb, _ := x.packetBufferPool.Get().(*[]byte)
+	pb := x.packetBufferPool.Get()
 	if cap(*pb) != 8192 {
 		t.Errorf("packet buffer cap = %d, want 8192 (4096 * 2)", cap(*pb))
 	}
@@ -307,7 +307,7 @@ func TestInitSyncPools_envelopeAndDestPools(t *testing.T) {
 	if x.xtcpEnvelopePool.Get() == nil {
 		t.Error("xtcpEnvelopePool.Get returned nil")
 	}
-	db, _ := x.destBytesPool.Get().(*[]byte)
+	db := x.destBytesPool.Get()
 	if db == nil || cap(*db) != destBytesMaxSizeCst {
 		t.Errorf("destBytesPool New cap = %d, want %d", cap(*db), destBytesMaxSizeCst)
 	}

--- a/pkg/xtcp/marshallers.go
+++ b/pkg/xtcp/marshallers.go
@@ -120,8 +120,7 @@ func (x *XTCP) InitEnvelopeMarshallers(wg *sync.WaitGroup) {
 // https://clickhouse.com/docs/en/interfaces/formats#protobuflist
 func (x *XTCP) protobufListMarshal(e *xtcp_flat_record.Envelope) (buf *[]byte) {
 
-	got, _ := x.destBytesPool.Get().(*[]byte) //nolint:errcheck // pool.New returns *[]byte
-	buf = got
+	buf = x.destBytesPool.Get()
 	*buf = (*buf)[:0]
 
 	writer := &ByteSliceWriter{Buf: buf}

--- a/pkg/xtcp/marshallers_test.go
+++ b/pkg/xtcp/marshallers_test.go
@@ -165,7 +165,7 @@ func TestInitMarshallers_validNames(t *testing.T) {
 // end expects exactly this byte layout: varint(envelope_size) || envelope.
 func TestProtobufListMarshal_roundtrip(t *testing.T) {
 	x, _ := newMarshalFixture(t)
-	x.destBytesPool = sync.Pool{New: func() any { b := make([]byte, 0, 1024); return &b }}
+	x.destBytesPool.Init(func() *[]byte { b := make([]byte, 0, 1024); return &b })
 
 	env := &xtcp_flat_record.Envelope{
 		Row: []*xtcp_flat_record.XtcpFlatRecord{

--- a/pkg/xtcp/netlinker.go
+++ b/pkg/xtcp/netlinker.go
@@ -147,7 +147,7 @@ func (x *XTCP) netlinkerSyscall(ctx context.Context, wg *sync.WaitGroup, nsName 
 
 	wf := x.config.WriteFiles
 
-	packetBuffer, _ := x.packetBufferPool.Get().(*[]byte) //nolint:errcheck // pool.New returns *[]byte
+	packetBuffer := x.packetBufferPool.Get()
 
 	for packets, netlinkerDone := 0, false; !netlinkerDone; packets++ {
 

--- a/pkg/xtcp/netlinker_iouring.go
+++ b/pkg/xtcp/netlinker_iouring.go
@@ -222,7 +222,7 @@ func (x *XTCP) netlinkerIoUring(ctx context.Context, wg *sync.WaitGroup, nsName 
 // in-flight map until its CQE fires.
 func (x *XTCP) iouringPrefillRecvs(ring *xio.Ring, fd int, n int) error {
 	for i := 0; i < n; i++ {
-		buf, _ := x.packetBufferPool.Get().(*[]byte) //nolint:errcheck // pool.New returns *[]byte
+		buf := x.packetBufferPool.Get()
 		// Restore full capacity so the kernel sees a writable buffer.
 		*buf = (*buf)[:cap(*buf)]
 		if _, err := ring.EnqueueRecvMsg(fd, buf); err != nil {

--- a/pkg/xtcp/netlinker_iouring_test.go
+++ b/pkg/xtcp/netlinker_iouring_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -27,8 +26,8 @@ func newIouringFixture(t *testing.T) *XTCP {
 			Name: promNameCounts, Help: "test counts"},
 		promLabels,
 	)
-	x.destBytesPool = sync.Pool{New: func() any { b := make([]byte, 64); return &b }}
-	x.packetBufferPool = sync.Pool{New: func() any { b := make([]byte, 64); return &b }}
+	x.destBytesPool.Init(func() *[]byte { b := make([]byte, 64); return &b })
+	x.packetBufferPool.Init(func() *[]byte { b := make([]byte, 64); return &b })
 	return x
 }
 
@@ -199,11 +198,11 @@ func TestIouringPrefillRecvs_enqueueErr(t *testing.T) {
 	t.Cleanup(func() { ring.Close(time.Second, nil) })
 
 	x := newIouringFixture(t)
-	x.packetBufferPool = sync.Pool{New: func() any {
+	x.packetBufferPool.Init(func() *[]byte {
 		// Empty slice — EnqueueRecvMsg rejects it.
 		b := make([]byte, 0)
 		return &b
-	}}
+	})
 	if err := x.iouringPrefillRecvs(ring, 3, 1); err == nil {
 		t.Error("empty buf should make EnqueueRecvMsg return an error")
 	}
@@ -264,9 +263,9 @@ func TestHandleRecvCQE_successPathTruncated(t *testing.T) {
 	x := newIouringFixture(t)
 	// Deserialize needs a usable config, pools, and pH on the args.
 	x.config = &xtcp_config.XtcpConfig{Modulus: 1}
-	x.xtcpRecordPool = sync.Pool{New: func() any { return new(xtcp_flat_record.XtcpFlatRecord) }}
-	x.nlhPool = sync.Pool{New: func() any { return new(xtcpnl.NlMsgHdr) }}
-	x.rtaPool = sync.Pool{New: func() any { return new(xtcpnl.RTAttr) }}
+	x.xtcpRecordPool.Init(func() *xtcp_flat_record.XtcpFlatRecord { return new(xtcp_flat_record.XtcpFlatRecord) })
+	x.nlhPool.Init(func() *xtcpnl.NlMsgHdr { return new(xtcpnl.NlMsgHdr) })
+	x.rtaPool.Init(func() *xtcpnl.RTAttr { return new(xtcpnl.RTAttr) })
 	reg := prometheus.NewRegistry()
 	x.pH = promauto.With(reg).NewSummaryVec(
 		prometheus.SummaryOpts{Subsystem: "xtcp_iouring_recv_test",

--- a/pkg/xtcp/netlinker_test.go
+++ b/pkg/xtcp/netlinker_test.go
@@ -34,9 +34,7 @@ func TestNetlinkerSyscall_earlyExit(t *testing.T) {
 		},
 		promLabels,
 	)
-	x.packetBufferPool = sync.Pool{
-		New: func() any { b := make([]byte, 4096); return &b },
-	}
+	x.packetBufferPool.Init(func() *[]byte { b := make([]byte, 4096); return &b })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-canceled → first checkDoneNonBlocking returns true

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/randomizedcoder/xtcp2/pkg/misc"
-	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 	"golang.org/x/sys/unix"
 )
 
@@ -242,7 +241,7 @@ func (x *XTCP) pollAllNetlinkSockets(pollingLoops uint64) (count int) {
 	startTime := time.Now()
 
 	x.envelopeMu.Lock()
-	x.currentEnvelope, _ = x.xtcpEnvelopePool.Get().(*xtcp_flat_record.Envelope) //nolint:errcheck // pool.New returns *Envelope
+	x.currentEnvelope = x.xtcpEnvelopePool.Get()
 	x.pollStartTime = startTime
 	x.envelopeMu.Unlock()
 

--- a/pkg/xtcp/poller_pure_test.go
+++ b/pkg/xtcp/poller_pure_test.go
@@ -40,15 +40,9 @@ func newPollerFixture(t *testing.T) *XTCP {
 		},
 		promLabels,
 	)
-	x.xtcpEnvelopePool = sync.Pool{
-		New: func() any { return new(xtcp_flat_record.Envelope) },
-	}
-	x.xtcpRecordPool = sync.Pool{
-		New: func() any { return new(xtcp_flat_record.XtcpFlatRecord) },
-	}
-	x.destBytesPool = sync.Pool{
-		New: func() any { b := make([]byte, 0, 1024); return &b },
-	}
+	x.xtcpEnvelopePool.Init(func() *xtcp_flat_record.Envelope { return new(xtcp_flat_record.Envelope) })
+	x.xtcpRecordPool.Init(func() *xtcp_flat_record.XtcpFlatRecord { return new(xtcp_flat_record.XtcpFlatRecord) })
+	x.destBytesPool.Init(func() *[]byte { b := make([]byte, 0, 1024); return &b })
 	// 16-byte netlink request header (the slice that
 	// updateNetlinkRequestSequenceNumber mutates).
 	nl := make([]byte, 16)

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -14,8 +14,10 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
+	"github.com/randomizedcoder/xtcp2/pkg/xtcpnl"
 )
 
 const (
@@ -40,12 +42,12 @@ type XTCP struct {
 	deleteCount atomic.Uint64
 	generation  atomic.Uint64
 
-	packetBufferPool sync.Pool
-	xtcpEnvelopePool sync.Pool
-	xtcpRecordPool   sync.Pool
-	nlhPool          sync.Pool
-	rtaPool          sync.Pool
-	destBytesPool    sync.Pool
+	packetBufferPool xsync.Pool[*[]byte]
+	xtcpEnvelopePool xsync.Pool[*xtcp_flat_record.Envelope]
+	xtcpRecordPool   xsync.Pool[*xtcp_flat_record.XtcpFlatRecord]
+	nlhPool          xsync.Pool[*xtcpnl.NlMsgHdr]
+	rtaPool          xsync.Pool[*xtcpnl.RTAttr]
+	destBytesPool    xsync.Pool[*[]byte]
 
 	currentEnvelope       *xtcp_flat_record.Envelope
 	pollStartTime         time.Time

--- a/tools/kafka_topic_reader/kafka_topic_reader.go
+++ b/tools/kafka_topic_reader/kafka_topic_reader.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"log"
 	"os"
-	"sync"
 	"time"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"google.golang.org/protobuf/proto"
@@ -92,20 +92,16 @@ type kafkaFetcher interface {
 }
 
 func pollLoop(ctx context.Context, client kafkaFetcher, consumeTimeout time.Duration) {
-	kgoFetchesPool := sync.Pool{
-		New: func() any {
-			return new(kgo.Fetches)
-		},
-	}
-	kgoFetches, _ := kgoFetchesPool.Get().(*kgo.Fetches) //nolint:errcheck // pool.Get returns the type from pool.New
+	kgoFetchesPool := xsync.NewPool(func() *kgo.Fetches {
+		return new(kgo.Fetches)
+	})
+	kgoFetches := kgoFetchesPool.Get()
 	defer kgoFetchesPool.Put(kgoFetches)
 
-	xtcpRecordPool := sync.Pool{
-		New: func() any {
-			return new(xtcp_flat_record.XtcpFlatRecord)
-		},
-	}
-	xtcpRecord, _ := xtcpRecordPool.Get().(*xtcp_flat_record.XtcpFlatRecord) //nolint:errcheck // pool.Get returns the type from pool.New
+	xtcpRecordPool := xsync.NewPool(func() *xtcp_flat_record.XtcpFlatRecord {
+		return new(xtcp_flat_record.XtcpFlatRecord)
+	})
+	xtcpRecord := xtcpRecordPool.Get()
 	defer xtcpRecordPool.Put(xtcpRecord)
 
 	records := 0

--- a/tools/udp_receiver_server/udp_receiver_server.go
+++ b/tools/udp_receiver_server/udp_receiver_server.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"net"
 	"os"
-	"sync"
 
+	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 	"google.golang.org/protobuf/proto"
 )
@@ -76,21 +76,17 @@ var ErrDecode = errors.New("proto decode")
 // gracefully). Extracted from main() so tests can drive it with a pair of
 // in-process UDP sockets.
 func runReceiver(ctx context.Context, conn *net.UDPConn) error {
-	packetBufferPool := sync.Pool{
-		New: func() any {
-			b := make([]byte, packetBufferSizeCst)
-			return &b
-		},
-	}
-	xtcpRecordPool := sync.Pool{
-		New: func() any {
-			return new(xtcp_flat_record.XtcpFlatRecord)
-		},
-	}
+	packetBufferPool := xsync.NewPool(func() *[]byte {
+		b := make([]byte, packetBufferSizeCst)
+		return &b
+	})
+	xtcpRecordPool := xsync.NewPool(func() *xtcp_flat_record.XtcpFlatRecord {
+		return new(xtcp_flat_record.XtcpFlatRecord)
+	})
 
-	packetBuffer, _ := packetBufferPool.Get().(*[]byte) //nolint:errcheck // pool.Get returns the type from pool.New
+	packetBuffer := packetBufferPool.Get()
 	defer packetBufferPool.Put(packetBuffer)
-	xtcpRecord, _ := xtcpRecordPool.Get().(*xtcp_flat_record.XtcpFlatRecord) //nolint:errcheck // pool.Get returns the type from pool.New
+	xtcpRecord := xtcpRecordPool.Get()
 	defer xtcpRecordPool.Put(xtcpRecord)
 
 	// Close the connection on ctx cancel so the blocking ReadFromUDP


### PR DESCRIPTION
## Summary

**PR #22b — typed `xsync.Pool[T]` + convert all `sync.Pool` sites** (value-field design).

Adds `pkg/xsync.Pool[T]`: a thin generic wrapper over `sync.Pool` whose single unavoidable type assertion lives in **one provably-correct place** — `New` always returns `T`, `Put` only accepts `T`, so a failed assertion can only mean a miswired pool (a programming error), never load/memory pressure; it panics loud instead of handing back a `nil` that nil-derefs later. Every `v, _ := pool.Get().(*T) //nolint:errcheck` collapses to a typed `v := pool.Get()` — **the entire pool type-assertion nolint class is gone**.

### Value-field, not pointer (per review)
`Pool[T]` embeds `sync.Pool` **by value** and is `Init`'d in place, so the six hot `XTCP` pool fields keep the **exact same memory layout** as the original `sync.Pool` (no extra pointer indirection), and the `&x.fooPool` threading through `Deserialize{,Attributes}Args` is **unchanged**. The non-hot pools that tests save/restore or build in struct literals (grpc response, kafka `recordPool`, `kgoRecordPool`, the tool-local pools) use the `NewPool()` `*Pool[T]` convenience.

### Benchmark (`BenchmarkDeserialize`, the pool-hot path, 8×)
| | mean ns/op | allocs/op |
|---|---|---|
| main (before) | 87,692 | 1 |
| **this PR (value field)** | **87,785 (+0.1%, noise)** | 1 |

No measurable performance impact and no extra allocation — confirmed empirically, not assumed.

## Testing
- `pkg/xsync` unit tests (Get/Put roundtrip, reuse, typed return, 64-goroutine concurrency).
- `go vet` + `gofmt -l .` clean; binary-blob guard clean.
- `go test … -tags 'dest_kafka dest_nats dest_nsq dest_valkey dest_s3parquet' ./...` — **entire suite green**.
- **Both `golangci-lint` tiers PASS.**

Next: **#22c** (typed `xsync.Map[K,V]` + the genuine error sites), **#22d** (strip the ~115 redundant test-file nolints). Series acceptance: `grep -rn nolint:errcheck` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
