### PR TITLE
PR #22c: handle all errors — remove every production nolint:errcheck (42 sites)

### DIFF
--- a/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go
+++ b/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist.go
@@ -211,7 +211,10 @@ func insertIntoCHAt(ctx context.Context, client *http.Client, baseURL string, bi
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body) //nolint:errcheck // best-effort body read for error context
+		body, rerr := io.ReadAll(resp.Body)
+		if rerr != nil {
+			body = []byte("<body read failed>")
+		}
 		return fmt.Errorf("%w: status %d: %s", ErrClickHouseHTTPPost, resp.StatusCode, string(body))
 	}
 	return nil

--- a/cmd/xtcp2_kafka_client/xtcp2_kafka_client.go
+++ b/cmd/xtcp2_kafka_client/xtcp2_kafka_client.go
@@ -92,7 +92,9 @@ func pollLoop(ctx context.Context, cl kafkaFetcher) {
 			continue
 		}
 		fetches.EachRecord(func(record *kgo.Record) {
-			_ = processRecord(record.Value, debugLevel) //nolint:errcheck // processRecord logs internally; nothing actionable here
+			if perr := processRecord(record.Value, debugLevel); perr != nil && debugLevel > 100 {
+				log.Printf("processRecord: %v", perr)
+			}
 		})
 	}
 }

--- a/cmd/xtcp2client/xtcp2client.go
+++ b/cmd/xtcp2client/xtcp2client.go
@@ -161,7 +161,11 @@ func pollMode(ctx context.Context, addr string, complete *chan struct{}, pollFre
 	// pollMode returned with both leaked — fine in a one-shot CLI run
 	// but the daemon-embedded usage (and the test harness) leaked one
 	// conn + one *time.Ticker per pollMode invocation.
-	defer func() { _ = conn.Close() }() //nolint:errcheck // already on the way out; Close err is non-actionable
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Printf("pollMode: conn close: %v", cerr)
+		}
+	}()
 
 	client := xtcp_flat_record.NewXTCPFlatRecordServiceClient(conn)
 
@@ -450,7 +454,11 @@ func handleRecvContinueErr(ctx context.Context, client any, err error) bool {
 func stream(ctx context.Context, wg *sync.WaitGroup, conn *grpc.ClientConn, json bool, id int) {
 
 	defer wg.Done()
-	defer func() { _ = conn.Close() }() //nolint:errcheck // streaming client teardown; conn.Close err is non-actionable
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Printf("stream: conn close: %v", cerr)
+		}
+	}()
 
 	req := &xtcp_flat_record.FlatRecordsRequest{}
 	client := xtcp_flat_record.NewXTCPFlatRecordServiceClient(conn)

--- a/pkg/xtcp/deserialize.go
+++ b/pkg/xtcp/deserialize.go
@@ -41,7 +41,9 @@ func (x *XTCP) Deserialize(ctx context.Context, d DeserializeArgs) (n uint64, er
 
 	var startPollTime time.Time
 	if s, ok := x.pollTime.Load(d.fd); ok {
-		startPollTime, _ = s.(time.Time) //nolint:errcheck // sync.Map Store sites all use time.Time
+		if t, isTime := s.(time.Time); isTime {
+			startPollTime = t
+		}
 	} else {
 		// pollTime entry missing — typically a race after nsDelete
 		// (bug 68 cleans up pollTime on delete; an in-flight netlinker
@@ -356,13 +358,22 @@ func (x *XTCP) DeserializeAttributes(d DeserializeAttributesArgs) {
 				end = bufEnd
 			}
 		}
-		_ = x.DeserializeAttribute(DeserializeAttributeArgs{ //nolint:errcheck // always returns nil today; signature reserves the option
+		if aerr := x.DeserializeAttribute(DeserializeAttributeArgs{
 			Type:       int(rta.Type),
 			buf:        (*d.NLPacket)[d.offset:end],
 			xtcpRecord: d.xtcpRecord,
 			pC:         d.pC,
 			pH:         d.pH,
-		})
+		}); aerr != nil {
+			// A per-attribute deserializer reported a problem. Today the
+			// deserializers always return nil, but surface it rather than
+			// swallow it: count + log and keep parsing the next attribute
+			// so one bad TLV doesn't drop the whole record.
+			d.pC.WithLabelValues("DeserializeAttributes", "attribute", "error").Inc()
+			if x.debugLevel > 100 {
+				log.Printf("DeserializeAttributes attribute type %d: %v", rta.Type, aerr)
+			}
+		}
 
 		d.offset += bodyLen
 		// Same overflow could push d.offset past d.end on the next
@@ -391,7 +402,13 @@ func (x *XTCP) DeserializeAttribute(d DeserializeAttributeArgs) error {
 	// pC.WithLabelValues("DeserializeAttribute", x.RTATypeDeserializerStr[Type], "count").Inc()
 
 	if Deserializer, ok := x.RTATypeDeserializer[d.Type]; ok {
-		_ = Deserializer(d.buf, d.xtcpRecord) //nolint:errcheck // per-attribute deserializers currently return nil; signature reserves the option
+		if derr := Deserializer(d.buf, d.xtcpRecord); derr != nil {
+			d.pC.WithLabelValues("DeserializeAttribute", "deserializer", "error").Inc()
+			if x.debugLevel > 100 {
+				log.Printf("DeserializeAttribute type %d deserializer: %v", d.Type, derr)
+			}
+			return derr
+		}
 		return nil
 	}
 

--- a/pkg/xtcp/destinations_udp.go
+++ b/pkg/xtcp/destinations_udp.go
@@ -72,7 +72,9 @@ func newUDPDest(ctx context.Context, x *XTCP) (Destination, error) {
 			// the fd leaks on every newUDPDest failure path (rare in
 			// practice, but with io_uring enabled an extractFD failure
 			// leaks one UDP socket per InitDests retry).
-			_ = conn.Close() //nolint:errcheck // already on the error path; Close err is non-actionable
+			if cerr := conn.Close(); cerr != nil {
+				log.Printf("InitDestUDP: conn close on error path: %v", cerr)
+			}
 			return nil, fmt.Errorf("InitDestUDP extractFD: %w", eerr)
 		}
 		d.fd = fd
@@ -113,7 +115,9 @@ func (d *udpDest) Send(ctx context.Context, b *[]byte) (int, error) {
 
 func (d *udpDest) closeFdFile() {
 	if d.fdFile != nil {
-		_ = d.fdFile.Close() //nolint:errcheck // teardown
+		if cerr := d.fdFile.Close(); cerr != nil {
+			log.Printf("udpDest: fdFile close: %v", cerr)
+		}
 		d.fdFile = nil
 	}
 }

--- a/pkg/xtcp/destinations_unix.go
+++ b/pkg/xtcp/destinations_unix.go
@@ -49,7 +49,9 @@ func newUnixDest(ctx context.Context, x *XTCP) (Destination, error) {
 			// Close the dialed conn before bailing; otherwise the
 			// extractFD failure path leaks one unix-stream fd. Same
 			// shape as the matching bug in destinations_udp.go.
-			_ = conn.Close() //nolint:errcheck // already on the error path
+			if cerr := conn.Close(); cerr != nil {
+				log.Printf("InitDestUnix: conn close on error path: %v", cerr)
+			}
 			return nil, fmt.Errorf("InitDestUnix extractFD: %w", eerr)
 		}
 		d.fd = fd
@@ -98,7 +100,9 @@ func (d *unixDest) Send(ctx context.Context, b *[]byte) (int, error) {
 
 func (d *unixDest) Close() error {
 	if d.fdFile != nil {
-		_ = d.fdFile.Close() //nolint:errcheck // teardown
+		if cerr := d.fdFile.Close(); cerr != nil {
+			log.Printf("unixDest: fdFile close: %v", cerr)
+		}
 		d.fdFile = nil
 	}
 	if d.conn != nil {

--- a/pkg/xtcp/destinations_unixgram.go
+++ b/pkg/xtcp/destinations_unixgram.go
@@ -45,7 +45,9 @@ func newUnixGramDest(ctx context.Context, x *XTCP) (Destination, error) {
 			// Close the dialed conn before bailing; otherwise the
 			// extractFD failure path leaks one unixgram fd. Same
 			// shape as the matching bug in destinations_udp.go.
-			_ = conn.Close() //nolint:errcheck // already on the error path
+			if cerr := conn.Close(); cerr != nil {
+				log.Printf("InitDestUnixGram: conn close on error path: %v", cerr)
+			}
 			return nil, fmt.Errorf("InitDestUnixGram extractFD: %w", eerr)
 		}
 		d.fd = fd
@@ -86,7 +88,9 @@ func (d *unixgramDest) Send(ctx context.Context, b *[]byte) (int, error) {
 
 func (d *unixgramDest) Close() error {
 	if d.fdFile != nil {
-		_ = d.fdFile.Close() //nolint:errcheck // teardown
+		if cerr := d.fdFile.Close(); cerr != nil {
+			log.Printf("unixgramDest: fdFile close: %v", cerr)
+		}
 		d.fdFile = nil
 	}
 	if d.conn != nil {

--- a/pkg/xtcp/grpc_flatRecordService.go
+++ b/pkg/xtcp/grpc_flatRecordService.go
@@ -264,8 +264,11 @@ func (x *XTCP) flatRecordServiceSend(xtcpRecord *xtcp_flat_record.XtcpFlatRecord
 	if frClientCount > 0 {
 		x.flatRecordService.FlatRecordsClients.Range(func(k, v interface{}) bool {
 
-			stream, _ := k.(*xtcp_flat_record.XTCPFlatRecordService_FlatRecordsServer) //nolint:errcheck // sync.Map Store sites all use this type
-			if err := (*stream).Send(xtcpFlatRecordsResponse); err != nil {            // <<------------------------- Send
+			stream, ok := k.(*xtcp_flat_record.XTCPFlatRecordService_FlatRecordsServer)
+			if !ok {
+				return true
+			}
+			if err := (*stream).Send(xtcpFlatRecordsResponse); err != nil { // <<------------------------- Send
 				x.pC.WithLabelValues("flatRecordServiceSend", "frSend", "error").Inc()
 			}
 			x.pC.WithLabelValues("flatRecordServiceSend", "frSent", "count").Inc()
@@ -291,8 +294,11 @@ func (x *XTCP) flatRecordServiceSend(xtcpRecord *xtcp_flat_record.XtcpFlatRecord
 		}
 		x.flatRecordService.PollFlatRecordsClients.Range(func(k, v interface{}) bool {
 
-			stream, _ := k.(*grpc.BidiStreamingServer[xtcp_flat_record.PollFlatRecordsRequest, xtcp_flat_record.PollFlatRecordsResponse]) //nolint:errcheck // sync.Map Store sites all use this type
-			if err := (*stream).Send(pollResp); err != nil {                                                                              // <<------------------------- Send
+			stream, ok := k.(*grpc.BidiStreamingServer[xtcp_flat_record.PollFlatRecordsRequest, xtcp_flat_record.PollFlatRecordsResponse])
+			if !ok {
+				return true
+			}
+			if err := (*stream).Send(pollResp); err != nil { // <<------------------------- Send
 				x.pC.WithLabelValues("flatRecordServiceSend", "pfrSend", "error").Inc()
 			}
 			x.pC.WithLabelValues("flatRecordServiceSend", "pfrSent", "count").Inc()

--- a/pkg/xtcp/init_netlinkers.go
+++ b/pkg/xtcp/init_netlinkers.go
@@ -36,7 +36,9 @@ func (x *XTCP) InitNetlinkers(ctx context.Context, wg *sync.WaitGroup) {
 		x.callFatalf("InitNetlinkers no variant registered for key:%s", key)
 		return
 	}
-	x.Netlinker, _ = f.(NetlinkerFunc) //nolint:errcheck // Netlinkers.Store sites all use NetlinkerFunc
+	if nf, ok2 := f.(NetlinkerFunc); ok2 {
+		x.Netlinker = nf
+	}
 
 	if x.debugLevel > 10 {
 		log.Printf("InitNetlinkers selected variant:%s", key)

--- a/pkg/xtcp/marshallers.go
+++ b/pkg/xtcp/marshallers.go
@@ -85,7 +85,9 @@ func (x *XTCP) InitMarshallers(wg *sync.WaitGroup) {
 	// protobufList is per-envelope, handled in InitEnvelopeMarshallers.
 	// A lookup miss here is expected and not an error.
 	if f, ok := x.Marshallers.Load(x.config.MarshalTo); ok {
-		x.Marshaller, _ = f.(func(r *xtcp_flat_record.XtcpFlatRecord) (buf *[]byte)) //nolint:errcheck // Marshallers.Store sites all use this signature
+		if m, ok2 := f.(func(r *xtcp_flat_record.XtcpFlatRecord) (buf *[]byte)); ok2 {
+			x.Marshaller = m
+		}
 	}
 }
 
@@ -107,7 +109,9 @@ func (x *XTCP) InitEnvelopeMarshallers(wg *sync.WaitGroup) {
 	})
 
 	if f, ok := x.EnvelopeMarshallers.Load(x.config.MarshalTo); ok {
-		x.EnvelopeMarshaller, _ = f.(func(e *xtcp_flat_record.Envelope) (buf *[]byte)) //nolint:errcheck // EnvelopeMarshallers.Store sites all use this signature
+		if m, ok2 := f.(func(e *xtcp_flat_record.Envelope) (buf *[]byte)); ok2 {
+			x.EnvelopeMarshaller = m
+		}
 	}
 }
 

--- a/pkg/xtcp/netlinker.go
+++ b/pkg/xtcp/netlinker.go
@@ -106,9 +106,10 @@ func (x *XTCP) logRecvDebug(id uint32, packets, n, fd int) {
 		return
 	}
 	if ns, ok := x.fdToNsMap.Load(fd); ok {
-		nsStr, _ := ns.(string) //nolint:errcheck // fdToNsMap Store sites all use string
-		log.Printf("Netlinker %d Recvfrom packets:%d, n:%d, fd:%d ns:%s", id, packets, n, fd, nsStr)
-		return
+		if nsStr, okStr := ns.(string); okStr {
+			log.Printf("Netlinker %d Recvfrom packets:%d, n:%d, fd:%d ns:%s", id, packets, n, fd, nsStr)
+			return
+		}
 	}
 	log.Printf("Netlinker %d Recvfrom packets:%d, n:%d, fd:%d Unknown FD!!", id, packets, n, fd)
 }
@@ -120,9 +121,10 @@ func (x *XTCP) logProcessedDebug(id uint32, packets, n int, p uint64, fd int) {
 		return
 	}
 	if ns, ok := x.fdToNsMap.Load(fd); ok {
-		nsStr, _ := ns.(string) //nolint:errcheck // fdToNsMap Store sites all use string
-		log.Printf("Netlinker %d packets:%d, n:%d, p:%d, fd:%d ns:%s", id, packets, n, p, fd, nsStr)
-		return
+		if nsStr, okStr := ns.(string); okStr {
+			log.Printf("Netlinker %d packets:%d, n:%d, p:%d, fd:%d ns:%s", id, packets, n, p, fd, nsStr)
+			return
+		}
 	}
 	log.Printf("Netlinker %d packets:%d, n:%d, p:%d, fd:%d", id, packets, n, p, fd)
 }

--- a/pkg/xtcp/netlinker_iouring.go
+++ b/pkg/xtcp/netlinker_iouring.go
@@ -26,7 +26,10 @@ func ringFromContext(ctx context.Context) *xio.Ring {
 	if v == nil {
 		return nil
 	}
-	ring, _ := v.(*xio.Ring) //nolint:errcheck // context.WithValue(ringCtxKey, ring) only writes *xio.Ring
+	ring, ok := v.(*xio.Ring)
+	if !ok {
+		return nil
+	}
 	return ring
 }
 

--- a/pkg/xtcp/ns_delete.go
+++ b/pkg/xtcp/ns_delete.go
@@ -19,7 +19,14 @@ func (x *XTCP) nsDelete(nsName *string) {
 		return
 	}
 
-	netNSItem, _ := value.(netNSitem) //nolint:errcheck // nsMap Store sites all use netNSitem
+	netNSItem, ok := value.(netNSitem)
+	if !ok {
+		x.pC.WithLabelValues("delete", "assert", "error").Inc()
+		if x.debugLevel > 10 {
+			log.Printf("delete x.nsMap value type assertion failed for %s", *nsName)
+		}
+		return
+	}
 
 	// signal the go routine to close
 	// ( i'm not really sure if it would automatically close )

--- a/pkg/xtcp/ns_discover.go
+++ b/pkg/xtcp/ns_discover.go
@@ -15,7 +15,10 @@ func (x *XTCP) discoverAllNamespaces() (nsMap *sync.Map) {
 
 	var nsMaps []*sync.Map
 	x.netNsDirs.Range(func(key, value interface{}) bool {
-		dir, _ := key.(string) //nolint:errcheck // netNsDirs Store sites all use string
+		dir, ok := key.(string)
+		if !ok {
+			return true
+		}
 		nm := x.discoverNamespaces(dir)
 		if x.debugLevel > 10 {
 			log.Printf("discoverALLNamespaces x.discoverNamespaces(netNsDir):%s", dir)

--- a/pkg/xtcp/ns_map_count.go
+++ b/pkg/xtcp/ns_map_count.go
@@ -90,7 +90,10 @@ func (x *XTCP) GetNetlinkSocketFDs() (fds []int) {
 // netlink file descriptors
 func getNetlinkSocketFDs(m *sync.Map) (fds []int) {
 	m.Range(func(k, v interface{}) bool {
-		item, _ := v.(netNSitem) //nolint:errcheck // nsMap values are netNSitem
+		item, ok := v.(netNSitem)
+		if !ok {
+			return true
+		}
 		fds = append(fds, item.socketFD)
 		return true
 	})

--- a/pkg/xtcp/ns_net_namespace.go
+++ b/pkg/xtcp/ns_net_namespace.go
@@ -78,7 +78,11 @@ func (x *XTCP) netNamespaceInstance(ctx context.Context, nsName *string) {
 		// No origNs → can't restore → keep the lock and let the runtime
 		// terminate this thread when the goroutine exits.
 	} else {
-		defer func() { _ = origNs.Close() }() //nolint:errcheck // restore-only fd
+		defer func() {
+			if cerr := origNs.Close(); cerr != nil {
+				log.Printf("netNamespaceInstance: origNs close: %v", cerr)
+			}
+		}()
 		defer func() {
 			if rerr := restoreNsSetns(int(origNs.Fd()), unix.CLONE_NEWNET); rerr != nil {
 				x.pC.WithLabelValues("netNamespaceInstance", "restoreNs", "error").Inc()

--- a/pkg/xtcp/ns_reconcile.go
+++ b/pkg/xtcp/ns_reconcile.go
@@ -104,7 +104,10 @@ func (x *XTCP) reconcileMaps(ctx context.Context, srcMap, destMap *sync.Map, tes
 			if testing {
 				destMap.Store(key, value)
 			} else {
-				nsName, _ := key.(string) //nolint:errcheck // sourceMap.Range keys are strings
+				nsName, ok := key.(string)
+				if !ok {
+					return true
+				}
 				x.nsAdd(ctx, &nsName)
 			}
 			storeCount++

--- a/pkg/xtcp/ns_watch.go
+++ b/pkg/xtcp/ns_watch.go
@@ -36,7 +36,11 @@ func (x *XTCP) watchNsNamespace(ctx context.Context, wg *sync.WaitGroup, netNsDi
 	if err != nil {
 		return fmt.Errorf("failed to create watcher: %w", err)
 	}
-	defer func() { _ = watcher.Close() }() //nolint:errcheck // watcher.Close teardown; err non-actionable
+	defer func() {
+		if cerr := watcher.Close(); cerr != nil {
+			log.Printf("watchNsNamespace: watcher close: %v", cerr)
+		}
+	}()
 
 	if err = watcher.Add(netNsDir); err != nil {
 		return fmt.Errorf("failed to watch directory %s: %w", netNsDir, err)
@@ -176,7 +180,11 @@ func (x *XTCP) createNetworkNamespace(netnsDir string, newNetNSName string) erro
 		// into a new netns with no way back.
 		return fmt.Errorf("failed to snapshot original netns: %w", errOrig)
 	}
-	defer func() { _ = origNs.Close() }() //nolint:errcheck // restore-only fd
+	defer func() {
+		if cerr := origNs.Close(); cerr != nil {
+			log.Printf("createNetworkNamespace: origNs close: %v", cerr)
+		}
+	}()
 	defer func() {
 		// Restore on the way out; conditionally unlock only if the
 		// restore actually succeeded.
@@ -214,7 +222,9 @@ func (x *XTCP) createNetworkNamespace(netnsDir string, newNetNSName string) erro
 		// real netns bind". Best-effort remove so the next attempt
 		// starts clean. We're already on the error path; Remove err is
 		// non-actionable.
-		_ = os.Remove(fd.Name()) //nolint:errcheck // cleanup on Mount failure
+		if rerr := os.Remove(fd.Name()); rerr != nil {
+			log.Printf("createNetworkNamespace: cleanup remove %s after mount failure: %v", fd.Name(), rerr)
+		}
 		return fmt.Errorf("failed to bind namespace: %w", err)
 	}
 

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -218,7 +218,10 @@ func (x *XTCP) observeNetlinkerDone(d netlinkerDone, count int) {
 	if !ok {
 		return
 	}
-	pt, _ := p.(time.Time) //nolint:errcheck // pollTime Store sites all use time.Time
+	pt, ok := p.(time.Time)
+	if !ok {
+		return
+	}
 	pTime := d.t.Sub(pt)
 	x.pH.WithLabelValues("Poller", "pollToDoneDuration", "count").Observe(pTime.Seconds())
 
@@ -226,10 +229,11 @@ func (x *XTCP) observeNetlinkerDone(d netlinkerDone, count int) {
 		return
 	}
 	if ns, okNs := x.fdToNsMap.Load(d.fd); okNs {
-		nsStr, _ := ns.(string) //nolint:errcheck // fdToNsMap values are strings
-		log.Printf("Poller <-x.netlinkerDoneCh, count:%d fd:%d ns:%s after: %0.3fs %dms",
-			count, d.fd, nsStr, pTime.Seconds(), pTime.Milliseconds())
-		return
+		if nsStr, okStr := ns.(string); okStr {
+			log.Printf("Poller <-x.netlinkerDoneCh, count:%d fd:%d ns:%s after: %0.3fs %dms",
+				count, d.fd, nsStr, pTime.Seconds(), pTime.Milliseconds())
+			return
+		}
 	}
 	x.pC.WithLabelValues("Poller", "fdToNsMap", "error").Inc()
 	log.Printf("Poller <-x.netlinkerDoneCh, count:%d fd:%d after: %0.3fs %dms",
@@ -251,9 +255,9 @@ func (x *XTCP) pollAllNetlinkSockets(pollingLoops uint64) (count int) {
 	polled := 0
 	for i, socketFD := range socketFDs {
 		if ns, ok := x.fdToNsMap.Load(socketFD); ok {
-			nsStr, _ := ns.(string) //nolint:errcheck // fdToNsMap values are strings
+			nsStr, okStr := ns.(string)
 			// "/run/netns/xtcpNS"
-			if nsStr == linuxNetNSDirCst+xtcpNSName {
+			if okStr && nsStr == linuxNetNSDirCst+xtcpNSName {
 				if x.debugLevel > 100 {
 					log.Printf("pollAllNetlinkSockets skip "+linuxNetNSDirCst+xtcpNSName+" Poll i:%d", i)
 				}

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -252,8 +252,11 @@ func (x *XTCP) Run(ctx context.Context, wg *sync.WaitGroup, runPoller bool) {
 	go x.nsMapCountReporter(ctx, wg)
 
 	x.netNsDirs.Range(func(key, value interface{}) bool {
+		dir, ok := key.(string)
+		if !ok {
+			return true
+		}
 		wg.Add(1)
-		dir, _ := key.(string) //nolint:errcheck // netNsDirs keys are strings
 		go func() {
 			if err := x.watchNsNamespace(ctx, wg, dir); err != nil {
 				log.Printf("watchNsNamespace(%s) err:%v", dir, err)

--- a/tools/quality-report/main.go
+++ b/tools/quality-report/main.go
@@ -962,7 +962,11 @@ func parseGoTest(path string, known map[string]bool) ([]TestResult, bool) {
 	if err != nil {
 		return nil, false
 	}
-	defer func() { _ = f.Close() }() //nolint:errcheck // read-only file; close error is non-actionable
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "parseGoTest: close %s: %v\n", path, cerr)
+		}
+	}()
 
 	failOutput := map[string]string{} // pkg/test -> accumulated output
 	results := map[string]*TestResult{}
@@ -1196,7 +1200,10 @@ func readExitCodes(path string) map[string]int {
 // values, etc.). Anywhere the upstream guarantees parseability, the
 // error is uninteresting.
 func atoiOr0(s string) int {
-	n, _ := strconv.Atoi(s) //nolint:errcheck // best-effort parse of pre-validated digits
+	n, aerr := strconv.Atoi(s)
+	if aerr != nil {
+		n = 0
+	}
 	return n
 }
 

--- a/tools/tcp_client/tcp_client.go
+++ b/tools/tcp_client/tcp_client.go
@@ -89,7 +89,11 @@ func client(wg *sync.WaitGroup,
 		return
 	}
 
-	defer func() { _ = conn.Close() }() //nolint:errcheck // demo client teardown
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Printf("client: conn close: %v", cerr)
+		}
+	}()
 
 	for i := 0; ; i++ {
 		if err := clientOnce(conn, buf, reply, wto, rto); err != nil {
@@ -155,7 +159,9 @@ func dialWithRetry(bind string, port, attempts int, baseTimeout time.Duration) (
 // applying separate write/read deadlines. Returns ErrTimeout on a deadline
 // hit (caller decides whether to retry) or the underlying I/O error.
 func clientOnce(conn net.Conn, buf, reply []byte, wto, rto time.Duration) error {
-	_ = conn.SetWriteDeadline(time.Now().Add(wto)) //nolint:errcheck // deadline err surfaces on next Write
+	if derr := conn.SetWriteDeadline(time.Now().Add(wto)); derr != nil {
+		return fmt.Errorf("set write deadline: %w", derr)
+	}
 	if _, err := conn.Write(buf); err != nil {
 		var ne net.Error
 		if errors.As(err, &ne) && ne.Timeout() {
@@ -164,7 +170,9 @@ func clientOnce(conn net.Conn, buf, reply []byte, wto, rto time.Duration) error 
 		return fmt.Errorf("write: %w", err)
 	}
 
-	_ = conn.SetReadDeadline(time.Now().Add(rto)) //nolint:errcheck // deadline err surfaces on next Read
+	if derr := conn.SetReadDeadline(time.Now().Add(rto)); derr != nil {
+		return fmt.Errorf("set read deadline: %w", derr)
+	}
 	if _, err := conn.Read(reply); err != nil {
 		var ne net.Error
 		if errors.As(err, &ne) && ne.Timeout() {

--- a/tools/tcp_server/tcp_server.go
+++ b/tools/tcp_server/tcp_server.go
@@ -59,7 +59,11 @@ func runServer(ctx context.Context, bind string, port int) error {
 	if err != nil {
 		return fmt.Errorf("listen %s:%d: %w", bind, port, err)
 	}
-	defer func() { _ = ln.Close() }() //nolint:errcheck // demo server teardown
+	defer func() {
+		if cerr := ln.Close(); cerr != nil {
+			log.Printf("runServer: listener close: %v", cerr)
+		}
+	}()
 
 	// Close the listener on ctx cancel so the blocking Accept returns.
 	// The stopCloseWatcher channel lets the watcher goroutine exit if
@@ -72,7 +76,9 @@ func runServer(ctx context.Context, bind string, port int) error {
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = ln.Close() //nolint:errcheck // shutdown path
+			if cerr := ln.Close(); cerr != nil {
+				log.Printf("runServer: listener close on ctx done: %v", cerr)
+			}
 		case <-stopCloseWatcher:
 		}
 	}()
@@ -91,6 +97,12 @@ func runServer(ctx context.Context, bind string, port int) error {
 
 // handleConn echoes bytes back to the connection until EOF or error.
 func handleConn(conn net.Conn) {
-	defer func() { _ = conn.Close() }() //nolint:errcheck // demo server teardown
-	_, _ = io.Copy(conn, conn)          //nolint:errcheck // demo server teardown
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Printf("handleConn: conn close: %v", cerr)
+		}
+	}()
+	if _, cerr := io.Copy(conn, conn); cerr != nil {
+		log.Printf("echo copy: %v", cerr)
+	}
 }

--- a/tools/udp_receiver_server/udp_receiver_server.go
+++ b/tools/udp_receiver_server/udp_receiver_server.go
@@ -57,7 +57,11 @@ func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "ListenUDP: %v\n", err)
 		return 1
 	}
-	defer func() { _ = conn.Close() }() //nolint:errcheck // demo server teardown
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			log.Printf("udp_receiver_server: conn close: %v", cerr)
+		}
+	}()
 
 	if err := runReceiver(ctx, conn); err != nil {
 		fmt.Fprintf(stderr, "runReceiver: %v\n", err)
@@ -99,7 +103,9 @@ func runReceiver(ctx context.Context, conn *net.UDPConn) error {
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = conn.Close() //nolint:errcheck // shutdown path
+			if cerr := conn.Close(); cerr != nil {
+				log.Printf("udp_receiver_server: conn close on ctx done: %v", cerr)
+			}
 		case <-stopCloseWatcher:
 		}
 	}()


### PR DESCRIPTION
## Summary

**PR #22c — handle all errors, remove every *production* `//nolint:errcheck`.** Removes all 42 production errcheck nolints by handling the error or assertion for real, not silencing it. No new wrapper (per the discussion — inline checks; the maps are merged/passed through `ns_discover`, which resists a clean `Map[K,V]` wrapper the way the pools didn't).

**Type assertions** (`sync.Map` `.Range`/`.Load`, one `context.WithValue`): checked comma-ok. `.Range` callbacks skip a never-reached wrong-typed entry via `if !ok { return true }`; `Load`-then-assert sites guard the use / fall through to the existing not-found path. (One nicety: in `xtcp.go` the guard now precedes `wg.Add(1)`, so an impossible bad assertion can't imbalance the WaitGroup.)

**`deserialize.go`** (the behavioral one): `DeserializeAttribute` / per-attribute `Deserializer` errors — `nil` today, but the signatures reserve the option — are now **counted + logged + parsing continues** to the next attribute, so a future non-nil surfaces instead of being swallowed (one bad TLV won't drop the whole record).

**Genuine errors**: `Close`/teardown defers, `SetReadDeadline`/`SetWriteDeadline`, `io.ReadAll`, `os.Remove`, `io.Copy`, `strconv.Atoi` now log on error (or fall back) instead of discarding.

## Testing

- `grep -rn nolint:errcheck` over non-test, non-vendor `.go` → **empty** (42 → 0).
- `go vet` + `gofmt -l .` clean; binary-blob guard clean.
- `go test … -tags 'dest_kafka dest_nats dest_nsq dest_valkey dest_s3parquet' ./...` — **entire suite green**.
- **Both `golangci-lint` tiers PASS.**

Final sub-PR **#22d** strips the ~115 redundant `//nolint:errcheck` in `*_test.go` (errcheck is config-disabled in tests) + the one prose mention in `pkg/xsync/pool.go`'s docstring — after which `grep -rn nolint:errcheck` returns nothing tree-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
