### PR TITLE
PR #22d: strip redundant test-file nolints → zero nolint:errcheck tree-wide

### DIFF
--- a/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist_test.go
+++ b/cmd/clickhouse_http_insert_protobuflist/clickhouse_http_insert_protobuflist_test.go
@@ -143,7 +143,7 @@ func TestInsertIntoCHAt_success(t *testing.T) {
 func TestInsertIntoCHAt_serverError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte("oops")) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte("oops"))
 	}))
 	defer srv.Close()
 	err := insertIntoCHAt(t.Context(), srv.Client(), srv.URL, []byte("payload"), true)

--- a/cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db_test.go
+++ b/cmd/clickhouse_protobuflist_db/clickhouse_protobuflist_db_test.go
@@ -43,7 +43,7 @@ func TestWriteDataToFile(t *testing.T) {
 	if err := writeDataToFile(p, []byte("xyz")); err != nil {
 		t.Fatal(err)
 	}
-	b, _ := os.ReadFile(p) //nolint:errcheck // test plumbing
+	b, _ := os.ReadFile(p)
 	if string(b) != "xyz" {
 		t.Errorf("got %q, want xyz", b)
 	}

--- a/cmd/kafka_to_clickhouse/kafka_to_clickhouse_test.go
+++ b/cmd/kafka_to_clickhouse/kafka_to_clickhouse_test.go
@@ -82,7 +82,7 @@ func TestWriteDataToFile_badPath(t *testing.T) {
 
 func TestGetLatestSchemaIDAt_happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"id":99}`)) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte(`{"id":99}`))
 	}))
 	defer srv.Close()
 	got, err := getLatestSchemaIDAt(context.Background(), srv.Client(), srv.URL, "subj")
@@ -96,7 +96,7 @@ func TestGetLatestSchemaIDAt_happy(t *testing.T) {
 
 func TestGetLatestSchemaIDAt_badJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("not json")) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte("not json"))
 	}))
 	defer srv.Close()
 	if _, err := getLatestSchemaIDAt(context.Background(), srv.Client(), srv.URL, "subj"); err == nil {
@@ -116,7 +116,7 @@ func TestGetLatestSchemaIDAt_connRefused(t *testing.T) {
 func TestGetLatestSchemaIDAt_ctxCancel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(50 * time.Millisecond)
-		_, _ = w.Write([]byte(`{"id":1}`)) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte(`{"id":1}`))
 	}))
 	defer srv.Close()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -290,7 +290,7 @@ func TestDestKafka_unreachable(t *testing.T) {
 
 	payload := []byte("payload")
 	c := config{topic: "test-topic", debugLevel: 11}
-	n, _ := destKafka(ctx, c, &payload) //nolint:errcheck // err is logged inside the callback
+	n, _ := destKafka(ctx, c, &payload)
 	if n != 1 {
 		t.Errorf("n = %d, want 1 (Produce was attempted)", n)
 	}

--- a/cmd/ns/ns_test.go
+++ b/cmd/ns/ns_test.go
@@ -189,11 +189,11 @@ func TestRunMain_profileMode(t *testing.T) {
 	// Profile mode "cpu" sets a deferred stopper. Run from tempdir so
 	// the .pprof file ends up there.
 	dir := t.TempDir()
-	wd, _ := os.Getwd() //nolint:errcheck // test plumbing
+	wd, _ := os.Getwd()
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(wd) }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = os.Chdir(wd) })
 	rc := runMain(t.Context(), []string{"-profile.mode", "cpu"}, &strings.Builder{}, &strings.Builder{})
 	if rc != 0 {
 		t.Errorf("rc = %d, want 0", rc)
@@ -223,11 +223,11 @@ func TestStartProfile_eachMode(t *testing.T) {
 	// to ProfilePath("."). Run from a tempdir + stop immediately so the
 	// .pprof files end up in t.TempDir() and clean up with the test.
 	dir := t.TempDir()
-	wd, _ := os.Getwd() //nolint:errcheck // test plumbing
+	wd, _ := os.Getwd()
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(wd) }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = os.Chdir(wd) })
 
 	// Iterate every supported mode. Each pass starts the profile and
 	// immediately stops it before the next mode begins.

--- a/cmd/register_schema/register_schema_test.go
+++ b/cmd/register_schema/register_schema_test.go
@@ -37,7 +37,7 @@ func TestReadProtobufFromFile_missing(t *testing.T) {
 func TestRegisterProtobufSchemaAt_happy(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body) //nolint:errcheck // test plumbing
+		body, _ := io.ReadAll(r.Body)
 		gotBody = string(body)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -76,7 +76,7 @@ func TestRegisterProtobufSchemaAt_connRefused(t *testing.T) {
 
 func TestGetLatestSchemaIDAt_happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"id":42}`)) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte(`{"id":42}`))
 	}))
 	defer srv.Close()
 	got, err := getLatestSchemaIDAt(srv.Client(), srv.URL, "subject")
@@ -90,7 +90,7 @@ func TestGetLatestSchemaIDAt_happy(t *testing.T) {
 
 func TestGetLatestSchemaIDAt_badJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("not json")) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte("not json"))
 	}))
 	defer srv.Close()
 	if _, err := getLatestSchemaIDAt(srv.Client(), srv.URL, "subject"); err == nil {
@@ -133,7 +133,7 @@ func TestRunMain_getOnly(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":7}`)) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte(`{"id":7}`))
 	}))
 	defer srv.Close()
 
@@ -155,7 +155,7 @@ func TestRunMain_registerThenGet(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_, _ = w.Write([]byte(`{"id":42}`)) //nolint:errcheck // test plumbing
+			_, _ = w.Write([]byte(`{"id":42}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -193,7 +193,7 @@ func TestRunMain_getError(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("not json")) //nolint:errcheck // test plumbing
+		_, _ = w.Write([]byte("not json"))
 	}))
 	defer srv.Close()
 

--- a/cmd/xtcp2/xtcp2_test.go
+++ b/cmd/xtcp2/xtcp2_test.go
@@ -539,7 +539,7 @@ func TestGetDeserializers(t *testing.T) {
 			if tc.envSet {
 				t.Setenv("DESERIALIZERS", tc.envOverride)
 			} else {
-				os.Unsetenv("DESERIALIZERS") //nolint:errcheck // test cleanup; t.Setenv reverts after the test
+				os.Unsetenv("DESERIALIZERS")
 			}
 			got := getDeserializers(tc.input)
 			if got == nil {
@@ -580,11 +580,11 @@ func TestPrintConfig(t *testing.T) {
 	done := make(chan struct{})
 	var out strings.Builder
 	go func() {
-		_, _ = io.Copy(&out, r) //nolint:errcheck // test plumbing
+		_, _ = io.Copy(&out, r)
 		close(done)
 	}()
 	printConfig(c, "test snapshot")
-	_ = w.Close() //nolint:errcheck // test plumbing
+	_ = w.Close()
 	<-done
 	if !strings.Contains(out.String(), "test snapshot") || !strings.Contains(out.String(), "protobufList") {
 		t.Errorf("printConfig should include comment + fields; got %q", out.String())
@@ -658,11 +658,11 @@ func TestPrintFlags(t *testing.T) {
 	sink.Add(1)
 	go func() {
 		defer sink.Done()
-		_, _ = io.Copy(io.Discard, r) //nolint:errcheck // test plumbing
+		_, _ = io.Copy(io.Discard, r)
 		close(done)
 	}()
 	printFlags(f)
-	_ = w.Close() //nolint:errcheck // test plumbing
+	_ = w.Close()
 	<-done
 }
 

--- a/cmd/xtcp2client/xtcp2client_test.go
+++ b/cmd/xtcp2client/xtcp2client_test.go
@@ -20,7 +20,7 @@ func TestNewGRPCClient(t *testing.T) {
 	if conn == nil {
 		t.Fatal("newGRPCClient returned nil")
 	}
-	_ = conn.Close() //nolint:errcheck // test plumbing
+	_ = conn.Close()
 }
 
 func TestPrintFlatRecordsResponse_silent(t *testing.T) {
@@ -184,11 +184,11 @@ func startRecordingGRPC(t *testing.T) (addr string, cleanup func()) {
 	srv := grpc.NewServer()
 	xtcp_flat_record.RegisterXTCPFlatRecordServiceServer(srv, &recordingFRServer{})
 	go func() {
-		_ = srv.Serve(lis) //nolint:errcheck // test plumbing
+		_ = srv.Serve(lis)
 	}()
 	return lis.Addr().String(), func() {
 		srv.Stop()
-		_ = lis.Close() //nolint:errcheck // test plumbing
+		_ = lis.Close()
 	}
 }
 
@@ -201,11 +201,11 @@ func startTestGRPC(t *testing.T) (addr string, cleanup func()) {
 	srv := grpc.NewServer()
 	xtcp_flat_record.RegisterXTCPFlatRecordServiceServer(srv, &noopFRServer{})
 	go func() {
-		_ = srv.Serve(lis) //nolint:errcheck // test plumbing
+		_ = srv.Serve(lis)
 	}()
 	return lis.Addr().String(), func() {
 		srv.Stop()
-		_ = lis.Close() //nolint:errcheck // test plumbing
+		_ = lis.Close()
 	}
 }
 
@@ -310,7 +310,7 @@ func TestStream_recordingServer(t *testing.T) {
 	defer cancel()
 
 	conn := newGRPCClient(addr)
-	defer func() { _ = conn.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = conn.Close() }()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -393,7 +393,7 @@ func TestStream_dialAndCancel(t *testing.T) {
 	defer cancel()
 
 	conn := newGRPCClient(addr)
-	defer func() { _ = conn.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = conn.Close() }()
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)

--- a/pkg/misc/misc_misc_test.go
+++ b/pkg/misc/misc_misc_test.go
@@ -168,11 +168,11 @@ func TestPrintMemUsage(t *testing.T) {
 	var out strings.Builder
 	done := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(&out, r) //nolint:errcheck // test plumbing
+		_, _ = io.Copy(&out, r)
 		close(done)
 	}()
 	PrintMemUsage()
-	_ = w.Close() //nolint:errcheck // test plumbing
+	_ = w.Close()
 	<-done
 	if !strings.Contains(out.String(), "Alloc") {
 		t.Errorf("PrintMemUsage should print Alloc; got %q", out.String())

--- a/pkg/xsync/pool.go
+++ b/pkg/xsync/pool.go
@@ -1,8 +1,8 @@
 // Package xsync provides thin, generic, type-safe wrappers over the
 // standard library's sync.Pool (and, later, sync.Map). The point is to
 // move the single unavoidable type assertion into one provably-correct
-// place so call sites get a typed value back and need no scattered
-// `v, _ := p.Get().(*T) //nolint:errcheck`.
+// place so call sites get a typed value back instead of a scattered
+// `v, _ := p.Get().(*T)` plus an errcheck suppression at every site.
 package xsync
 
 import "sync"

--- a/pkg/xtcp/destinations_test.go
+++ b/pkg/xtcp/destinations_test.go
@@ -539,7 +539,7 @@ func TestUDPDest_SendIoUringHappy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newUDPDest: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = d.Close() })
 
 	// Build a real io_uring ring + stash it in ctx via ringCtxKey.
 	ring, err := xioRingNew(t)
@@ -571,7 +571,7 @@ func TestUDPDest_SendIoUringNoRing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newUDPDest: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = d.Close() })
 
 	buf := []byte("ioring")
 	// Pass a bare ctx (no ring stashed) → expect errNoRingInCtx.
@@ -681,7 +681,7 @@ func TestUnixDest_SendIoUringNoRing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newUnixDest: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = d.Close() })
 	buf := []byte("ioring")
 	if _, err := d.Send(context.Background(), &buf); err == nil {
 		t.Error("expected errNoRingInCtx when no ring in context")
@@ -701,7 +701,7 @@ func TestUnixDest_SendIoUringHappy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newUnixDest: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = d.Close() })
 
 	ring, err := xioRingNew(t)
 	if err != nil {
@@ -732,7 +732,7 @@ func TestUnixGramDest_SendIoUringNoRing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newUnixGramDest: %v", err)
 	}
-	t.Cleanup(func() { _ = d.Close() }) //nolint:errcheck // test plumbing
+	t.Cleanup(func() { _ = d.Close() })
 
 	buf := []byte("ioring")
 	if _, err := d.Send(context.Background(), &buf); err == nil {

--- a/pkg/xtcp/grpc_flatRecordService_test.go
+++ b/pkg/xtcp/grpc_flatRecordService_test.go
@@ -107,7 +107,7 @@ func setupBufconnServer(t *testing.T, s *xtcpFlatRecordService) (*grpc.ClientCon
 	srv := grpc.NewServer()
 	xtcp_flat_record.RegisterXTCPFlatRecordServiceServer(srv, s)
 	go func() {
-		_ = srv.Serve(lis) //nolint:errcheck // test plumbing
+		_ = srv.Serve(lis)
 	}()
 	dialer := func(_ context.Context, _ string) (net.Conn, error) {
 		return lis.Dial()
@@ -120,7 +120,7 @@ func setupBufconnServer(t *testing.T, s *xtcpFlatRecordService) (*grpc.ClientCon
 		t.Fatal(err)
 	}
 	cleanup := func() {
-		_ = conn.Close() //nolint:errcheck // test plumbing
+		_ = conn.Close()
 		srv.Stop()
 	}
 	return conn, cleanup
@@ -167,7 +167,7 @@ func TestFlatRecords_bufconnCancelExits(t *testing.T) {
 	}
 
 	cancel()
-	_, _ = stream.Recv() //nolint:errcheck // test plumbing
+	_, _ = stream.Recv()
 	time.Sleep(50 * time.Millisecond)
 	if got := srvSvc.frMapCount(); got != 0 {
 		t.Errorf("frMapCount = %d, want 0 after close", got)

--- a/pkg/xtcp/init_capabilities_test.go
+++ b/pkg/xtcp/init_capabilities_test.go
@@ -28,12 +28,12 @@ func withCapMask(t *testing.T, eff uint32, body func()) {
 // doesn't panic.
 func TestCheckCapabilities_doesntPanic(t *testing.T) {
 	x := &XTCP{}
-	_ = x.checkCapabilities() //nolint:errcheck // result is environment-dependent
+	_ = x.checkCapabilities()
 }
 
 func TestCheckCapabilities_debugLog(t *testing.T) {
 	x := &XTCP{debugLevel: 11}
-	_ = x.checkCapabilities() //nolint:errcheck // result is environment-dependent
+	_ = x.checkCapabilities()
 }
 
 // Both hard-required caps present → checkCapabilities returns nil.

--- a/pkg/xtcp/ns_extra_test.go
+++ b/pkg/xtcp/ns_extra_test.go
@@ -63,8 +63,8 @@ func TestCreateNetlinkersAndStore_zeroNetlinkers(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 
 	x := newNsExtraFixture(t)
@@ -121,8 +121,8 @@ func TestCreateNetlinkersAndStore_spawnsNetlinkers(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 
 	x := newNsExtraFixture(t)

--- a/pkg/xtcp/ns_net_namespace_test.go
+++ b/pkg/xtcp/ns_net_namespace_test.go
@@ -29,7 +29,7 @@ func TestCloseSocket_success(t *testing.T) {
 	if err != nil {
 		t.Skipf("socketpair: %v", err)
 	}
-	defer func() { _ = unix.Close(fds[1]) }() //nolint:errcheck // test plumbing
+	defer func() { _ = unix.Close(fds[1]) }()
 	x := newCloseFixture(t)
 	x.closeSocket(fds[0])
 }
@@ -44,7 +44,7 @@ func TestCloseFD_success(t *testing.T) {
 	if err != nil {
 		t.Skipf("socketpair: %v", err)
 	}
-	defer func() { _ = unix.Close(fds[1]) }() //nolint:errcheck // test plumbing
+	defer func() { _ = unix.Close(fds[1]) }()
 	x := newCloseFixture(t)
 	x.closeFD(fds[0])
 }
@@ -62,8 +62,8 @@ func TestSetSocketTimeoutViaSyscall_success(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 	x := newCloseFixture(t)
 	// Also need pH for the histogram observation.
@@ -91,8 +91,8 @@ func TestSetSocketTimeoutViaSyscall_seconds(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 	x := newCloseFixture(t)
 	x.setSocketTimeoutViaSyscall(2000, fds[0]) // >= 1000 → seconds path
@@ -129,7 +129,7 @@ func TestCheckMountInfo_debugLog(t *testing.T) {
 	x := newCloseFixture(t)
 	x.debugLevel = 11 // hit log.Printf branch
 	nsName := "/"
-	_, _ = x.checkMountInfo(&nsName) //nolint:errcheck // test plumbing
+	_, _ = x.checkMountInfo(&nsName)
 }
 
 // checkMountInfoWithRetries: retry wrapper. Found-on-first-try and
@@ -153,7 +153,7 @@ func TestCheckMountInfoWithRetries_neverFound(t *testing.T) {
 	x := newCloseFixture(t)
 	x.debugLevel = 11 // hit the log branch
 	nsName := "ridiculously-unlikely-namespace-suffix-xq44"
-	found, _ := x.checkMountInfoWithRetries(&nsName) //nolint:errcheck // test plumbing
+	found, _ := x.checkMountInfoWithRetries(&nsName)
 	if found {
 		t.Error("expected not-found for synthetic nsName")
 	}

--- a/pkg/xtcpnl/xtcpnl_extra_test.go
+++ b/pkg/xtcpnl/xtcpnl_extra_test.go
@@ -154,7 +154,7 @@ func TestDeserializeInetDiagMsgWG(t *testing.T) {
 	wg.Add(1)
 	idm := new(InetDiagMsg)
 	sock := new(InetDiagSockID)
-	_, _ = DeserializeInetDiagMsgWG(wg, make([]byte, InetDiagMsgSizeCst), idm, sock) //nolint:errcheck // test plumbing
+	_, _ = DeserializeInetDiagMsgWG(wg, make([]byte, InetDiagMsgSizeCst), idm, sock)
 	wg.Wait()
 }
 
@@ -162,7 +162,7 @@ func TestDeserializeInetDiagMsgXTCPWG(t *testing.T) {
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 	x := &xtcp_flat_record.XtcpFlatRecord{}
-	_ = DeserializeInetDiagMsgXTCPWG(wg, make([]byte, InetDiagMsgSizeCst), x) //nolint:errcheck // test plumbing
+	_ = DeserializeInetDiagMsgXTCPWG(wg, make([]byte, InetDiagMsgSizeCst), x)
 	wg.Wait()
 }
 

--- a/pkg/xtcpnl/xtcpnl_fatalf_test.go
+++ b/pkg/xtcpnl/xtcpnl_fatalf_test.go
@@ -37,8 +37,8 @@ func TestSetSocketTimeoutViaSyscall_seconds(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 	if err := SetSocketTimeoutViaSyscall(2000, fds[0]); err != nil {
 		t.Errorf("err = %v", err)
@@ -51,8 +51,8 @@ func TestSetSocketTimeoutViaSyscall_milliseconds(t *testing.T) {
 		t.Skipf("socketpair: %v", err)
 	}
 	defer func() {
-		_ = unix.Close(fds[0]) //nolint:errcheck // test plumbing
-		_ = unix.Close(fds[1]) //nolint:errcheck // test plumbing
+		_ = unix.Close(fds[0])
+		_ = unix.Close(fds[1])
 	}()
 	if err := SetSocketTimeoutViaSyscall(500, fds[0]); err != nil {
 		t.Errorf("err = %v", err)
@@ -126,7 +126,7 @@ func TestOpenNetlinkSocketWithTimeout_smokes(t *testing.T) {
 	captured := withFatalf(t)
 	fd := OpenNetlinkSocketWithTimeout(1000)
 	if fd >= 0 {
-		_ = unix.Close(fd) //nolint:errcheck // test plumbing
+		_ = unix.Close(fd)
 	}
 	_ = captured // tolerate either outcome
 }

--- a/tools/tcp_client/tcp_client_test.go
+++ b/tools/tcp_client/tcp_client_test.go
@@ -33,19 +33,19 @@ func TestDialWithRetry_happy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = ln.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
 	go func() {
-		c, _ := ln.Accept() //nolint:errcheck // test plumbing
+		c, _ := ln.Accept()
 		if c != nil {
-			_ = c.Close() //nolint:errcheck // test plumbing
+			_ = c.Close()
 		}
 	}()
 	conn, err := dialWithRetry("127.0.0.1", port, 3, 200*time.Millisecond)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	_ = conn.Close() //nolint:errcheck // test plumbing
+	_ = conn.Close()
 }
 
 func TestDialWithRetry_connRefused(t *testing.T) {
@@ -55,7 +55,7 @@ func TestDialWithRetry_connRefused(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close() //nolint:errcheck // test plumbing
+	_ = ln.Close()
 
 	_, err = dialWithRetry("127.0.0.1", port, 2, 100*time.Millisecond)
 	if err == nil {
@@ -99,7 +99,7 @@ func TestDialWithRetry_attemptsOne(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close() //nolint:errcheck // test plumbing
+	_ = ln.Close()
 
 	// Conn-refused on attempts=1 must return a real error, not nil-wrapped.
 	_, err = dialWithRetry("127.0.0.1", port, 1, 50*time.Millisecond)
@@ -113,14 +113,14 @@ func TestDialWithRetry_attemptsOne(t *testing.T) {
 
 func TestClientOnce_happy(t *testing.T) {
 	a, b := net.Pipe()
-	defer func() { _ = a.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = b.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
 
 	// Echo server side.
 	go func() {
 		buf := make([]byte, 64)
-		n, _ := b.Read(buf)     //nolint:errcheck // test plumbing
-		_, _ = b.Write(buf[:n]) //nolint:errcheck // test plumbing
+		n, _ := b.Read(buf)
+		_, _ = b.Write(buf[:n])
 	}()
 
 	reply := make([]byte, 32)
@@ -132,13 +132,13 @@ func TestClientOnce_happy(t *testing.T) {
 
 func TestClientOnce_readTimeout(t *testing.T) {
 	a, b := net.Pipe()
-	defer func() { _ = a.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = b.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
 
 	// Drain the write so it doesn't block, but never reply.
 	go func() {
 		buf := make([]byte, 64)
-		_, _ = b.Read(buf) //nolint:errcheck // test plumbing
+		_, _ = b.Read(buf)
 	}()
 
 	reply := make([]byte, 16)
@@ -150,7 +150,7 @@ func TestClientOnce_readTimeout(t *testing.T) {
 
 func TestClientOnce_writeError(t *testing.T) {
 	a, b := net.Pipe()
-	_ = b.Close() //nolint:errcheck // close the far end before Write
+	_ = b.Close()
 
 	err := clientOnce(a, []byte("x"), make([]byte, 16), time.Second, time.Second)
 	if err == nil {
@@ -159,7 +159,7 @@ func TestClientOnce_writeError(t *testing.T) {
 	if errors.Is(err, ErrTimeout) {
 		t.Error("write error should NOT be ErrTimeout")
 	}
-	_ = a.Close() //nolint:errcheck // test plumbing
+	_ = a.Close()
 }
 
 // clientOnce write-timeout path: connect to a pipe with no reader,
@@ -169,8 +169,8 @@ func TestClientOnce_writeError(t *testing.T) {
 // deadline.
 func TestClientOnce_writeTimeout(t *testing.T) {
 	a, b := net.Pipe()
-	defer func() { _ = a.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = b.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
 
 	// Don't read from b → a.Write blocks until deadline.
 	buf := []byte("x")
@@ -220,7 +220,7 @@ func TestClient_dialFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close() //nolint:errcheck // test plumbing
+	_ = ln.Close()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -245,14 +245,14 @@ func TestClient_serverCloses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = ln.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	// Accept one connection, close it immediately.
 	go func() {
-		c, _ := ln.Accept() //nolint:errcheck // test plumbing
+		c, _ := ln.Accept()
 		if c != nil {
-			_ = c.Close() //nolint:errcheck // test plumbing
+			_ = c.Close()
 		}
 	}()
 
@@ -284,13 +284,13 @@ func TestRunMain_oneClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = ln.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = ln.Close() }()
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	go func() {
-		c, _ := ln.Accept() //nolint:errcheck // test plumbing
+		c, _ := ln.Accept()
 		if c != nil {
-			_ = c.Close() //nolint:errcheck // test plumbing
+			_ = c.Close()
 		}
 	}()
 
@@ -320,13 +320,13 @@ func TestRunMain_oneClient(t *testing.T) {
 
 func TestClientOnce_readError(t *testing.T) {
 	a, b := net.Pipe()
-	defer func() { _ = a.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = a.Close() }()
 
 	// Drain the write, then close the remote side so the Read returns EOF.
 	go func() {
 		buf := make([]byte, 64)
-		_, _ = b.Read(buf) //nolint:errcheck // test plumbing
-		_ = b.Close()      //nolint:errcheck // test plumbing
+		_, _ = b.Read(buf)
+		_ = b.Close()
 	}()
 
 	err := clientOnce(a, []byte("x"), make([]byte, 16), time.Second, time.Second)

--- a/tools/tcp_server/tcp_server_test.go
+++ b/tools/tcp_server/tcp_server_test.go
@@ -18,7 +18,7 @@ func TestRunServer_echoAndShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := probe.Addr().(*net.TCPAddr).Port
-	_ = probe.Close() //nolint:errcheck // test plumbing
+	_ = probe.Close()
 
 	srvDone := make(chan error, 1)
 	go func() {
@@ -38,7 +38,7 @@ func TestRunServer_echoAndShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial %s: %v", addr, err)
 	}
-	defer func() { _ = conn.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = conn.Close() }()
 
 	// Echo round-trip.
 	if _, werr := conn.Write([]byte("hello")); werr != nil {
@@ -54,7 +54,7 @@ func TestRunServer_echoAndShutdown(t *testing.T) {
 	if string(buf) != "hello" {
 		t.Errorf("got %q, want hello", buf)
 	}
-	_ = conn.Close() //nolint:errcheck // test plumbing
+	_ = conn.Close()
 
 	cancel()
 	select {
@@ -145,7 +145,7 @@ func TestHandleConn_eof(t *testing.T) {
 	if string(buf) != "ping" {
 		t.Errorf("echo: got %q, want ping", buf)
 	}
-	_ = b.Close() //nolint:errcheck // test plumbing
+	_ = b.Close()
 	select {
 	case <-done:
 	case <-time.After(time.Second):

--- a/tools/udp_receiver_server/udp_receiver_server_test.go
+++ b/tools/udp_receiver_server/udp_receiver_server_test.go
@@ -25,7 +25,7 @@ func loopbackUDP(t *testing.T) (server *net.UDPConn, client *net.UDPConn) {
 	}
 	cli, err := net.DialUDP("udp", nil, caddr)
 	if err != nil {
-		_ = srv.Close() //nolint:errcheck // test plumbing
+		_ = srv.Close()
 		t.Fatal(err)
 	}
 	return srv, cli
@@ -33,8 +33,8 @@ func loopbackUDP(t *testing.T) (server *net.UDPConn, client *net.UDPConn) {
 
 func TestRunReceiver_happy(t *testing.T) {
 	srv, cli := loopbackUDP(t)
-	defer func() { _ = srv.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = cli.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = srv.Close() }()
+	defer func() { _ = cli.Close() }()
 
 	rec := &xtcp_flat_record.XtcpFlatRecord{Hostname: "udp-test"}
 	encoded, err := proto.Marshal(rec)
@@ -48,9 +48,9 @@ func TestRunReceiver_happy(t *testing.T) {
 	rdone := make(chan error, 1)
 	go func() {
 		// Send one frame then cancel to break the loop.
-		_, _ = cli.Write(encoded) //nolint:errcheck // test plumbing
+		_, _ = cli.Write(encoded)
 		time.Sleep(50 * time.Millisecond)
-		_ = srv.SetReadDeadline(time.Now()) //nolint:errcheck // unblock the read
+		_ = srv.SetReadDeadline(time.Now())
 	}()
 	go func() {
 		rdone <- runReceiver(ctx, srv)
@@ -68,8 +68,8 @@ func TestRunReceiver_happy(t *testing.T) {
 
 func TestRunReceiver_decodeError(t *testing.T) {
 	srv, cli := loopbackUDP(t)
-	defer func() { _ = srv.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = cli.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = srv.Close() }()
+	defer func() { _ = cli.Close() }()
 
 	rdone := make(chan error, 1)
 	go func() {
@@ -77,7 +77,7 @@ func TestRunReceiver_decodeError(t *testing.T) {
 	}()
 
 	// 0xFF varint header is malformed → proto.Unmarshal returns error.
-	_, _ = cli.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF}) //nolint:errcheck // test plumbing
+	_, _ = cli.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF})
 
 	select {
 	case err := <-rdone:
@@ -91,8 +91,8 @@ func TestRunReceiver_decodeError(t *testing.T) {
 
 func TestRunReceiver_ctxCancel(t *testing.T) {
 	srv, cli := loopbackUDP(t)
-	defer func() { _ = srv.Close() }() //nolint:errcheck // test plumbing
-	defer func() { _ = cli.Close() }() //nolint:errcheck // test plumbing
+	defer func() { _ = srv.Close() }()
+	defer func() { _ = cli.Close() }()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	rdone := make(chan error, 1)
@@ -100,7 +100,7 @@ func TestRunReceiver_ctxCancel(t *testing.T) {
 		rdone <- runReceiver(ctx, srv)
 	}()
 	cancel()
-	_ = srv.SetReadDeadline(time.Now()) //nolint:errcheck // unblock the read so ctx is observed
+	_ = srv.SetReadDeadline(time.Now())
 
 	select {
 	case err := <-rdone:
@@ -144,7 +144,7 @@ func TestRunMain_cancellable(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := probe.LocalAddr().(*net.UDPAddr).Port
-	_ = probe.Close() //nolint:errcheck // test plumbing
+	_ = probe.Close()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan int, 1)
@@ -157,8 +157,8 @@ func TestRunMain_cancellable(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	cli, derr := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if derr == nil {
-		_, _ = cli.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF}) //nolint:errcheck // test plumbing
-		_ = cli.Close()                                  //nolint:errcheck // test plumbing
+		_, _ = cli.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF})
+		_ = cli.Close()
 	}
 	cancel()
 	select {
@@ -190,7 +190,7 @@ func TestRunMain_returnZeroAfterClean(t *testing.T) {
 		t.Fatal(err)
 	}
 	port := probe.LocalAddr().(*net.UDPAddr).Port
-	_ = probe.Close() //nolint:errcheck // test plumbing
+	_ = probe.Close()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan int, 1)
@@ -204,18 +204,18 @@ func TestRunMain_returnZeroAfterClean(t *testing.T) {
 	// the next iter takes the ctx.Done branch.
 	cli, derr := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if derr == nil {
-		buf, _ := proto.Marshal(&xtcp_flat_record.XtcpFlatRecord{Hostname: "h"}) //nolint:errcheck // test plumbing
-		_, _ = cli.Write(buf)                                                    //nolint:errcheck // test plumbing
-		_ = cli.Close()                                                          //nolint:errcheck // test plumbing
+		buf, _ := proto.Marshal(&xtcp_flat_record.XtcpFlatRecord{Hostname: "h"})
+		_, _ = cli.Write(buf)
+		_ = cli.Close()
 	}
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 	// Send a second valid record + close the socket via SetReadDeadline
 	// so ReadFromUDP returns and the loop observes ctx.Done().
-	if cli2, _ := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}); cli2 != nil { //nolint:errcheck // test plumbing
-		buf2, _ := proto.Marshal(&xtcp_flat_record.XtcpFlatRecord{Hostname: "h2"}) //nolint:errcheck // test plumbing
-		_, _ = cli2.Write(buf2)                                                    //nolint:errcheck // test plumbing
-		_ = cli2.Close()                                                           //nolint:errcheck // test plumbing
+	if cli2, _ := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}); cli2 != nil {
+		buf2, _ := proto.Marshal(&xtcp_flat_record.XtcpFlatRecord{Hostname: "h2"})
+		_, _ = cli2.Write(buf2)
+		_ = cli2.Close()
 	}
 	select {
 	case rc := <-done:
@@ -229,15 +229,15 @@ func TestRunMain_returnZeroAfterClean(t *testing.T) {
 
 func TestRunReceiver_readError(t *testing.T) {
 	srv, cli := loopbackUDP(t)
-	_ = cli.Close()                    //nolint:errcheck // test plumbing
-	defer func() { _ = srv.Close() }() //nolint:errcheck // test plumbing
+	_ = cli.Close()
+	defer func() { _ = srv.Close() }()
 
 	// Force a read error by closing the socket from another goroutine before
 	// any data arrives. ReadFromUDP returns ErrClosed (not a timeout-style
 	// "use of closed network connection" wrap on all kernels).
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		_ = srv.Close() //nolint:errcheck // test plumbing
+		_ = srv.Close()
 	}()
 	err := runReceiver(t.Context(), srv)
 	// Either ctx wasn't canceled (=> err non-nil) or the cancel-race made


### PR DESCRIPTION
## Summary

**PR #22d — strip the last redundant `//nolint:errcheck`** (the finale of the #22 cleanup).

`errcheck` is excluded for `_test.go` in `.golangci.yml` / `.golangci-comprehensive.yml` (`path: "_test\.go"` → `errcheck`), so the ~115 `//nolint:errcheck` directives scattered across 18 test files were **pure noise** — they suppressed a linter that never runs there. Stripped them all (the explicit `_ =` discards stay; they're fine with errcheck off in tests). Also reworded `pkg/xsync/pool.go`'s package doc so it no longer quotes the literal directive.

## The acceptance gate

```
$ grep -rn 'nolint:errcheck' --include='*.go' . | grep -v vendor
(no output)
```

**Zero `nolint:errcheck` anywhere in the tree.**

## Testing

- `go vet` + `gofmt -l .` clean; binary-blob guard clean.
- `go test … -tags 'dest_kafka dest_nats dest_nsq dest_valkey dest_s3parquet' ./...` — **entire suite green**.
- **Both `golangci-lint` tiers PASS.**

---

### This completes the whole effort
- **Stack decomposition (#12–#21):** the full advanced `s3parquet-destination` stack — destinations, lint sweeps, ~260-commit coverage+bug-fix wave, complexity/integration-test infra, ProtobufList migration, s3parquet — landed on `main` one reviewable PR at a time, with several pre-existing bugs/flakes/test-gaps fixed along the way.
- **Lint-green + nolint-free (#22a–d):** `main` now passes both `golangci-lint` tiers, every error is checked (typed `xsync.Pool[T]` for the hot pools, checked assertions + real handling elsewhere), and there is **no `//nolint:errcheck` left**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
