### PR TITLE
docs: jsonl/csv/tsv formats + stdout/stderr/file/tcp/http sinks

### DIFF
--- a/docs/output-and-destinations.md
+++ b/docs/output-and-destinations.md
@@ -10,6 +10,7 @@ Once an [Envelope](polling-and-batching.md#envelopes) is flushed, xtcp2 serializ
 - [Kafka and the schema registry](#kafka-and-the-schema-registry)
 - [S3 and Parquet](#s3-and-parquet)
 - [The record schema](#the-record-schema)
+- [Quick recipes](#quick-recipes)
 - [Configuration](#configuration)
 - [See also](#see-also)
 
@@ -20,11 +21,20 @@ Once an [Envelope](polling-and-batching.md#envelopes) is flushed, xtcp2 serializ
 | Value | Format | Use |
 |---|---|---|
 | `protobufList` | Length-delimited protobuf Envelopes | Production; what Kafka → ClickHouse consumes. |
-| `protoJson` | Protobuf JSON | Human-readable debugging. |
+| `protoJson` | Protobuf JSON (one object per Envelope) | Human-readable debugging. |
 | `protoText` | Protobuf text | Human-readable debugging. |
 | `msgpack` | MessagePack | Alternative compact debug format. |
+| `jsonl` | JSON Lines / NDJSON (one record per line) | Pipe to `jq`, ingest into ClickHouse `JSONEachRow`, Loki, Vector. |
+| `csv` | Comma-separated, header once, humanized | R / pandas / DuckDB / Excel. |
+| `tsv` | Tab-separated, header once, humanized | Same, `awk`/`cut`-friendly. |
 
-The `protobufList` format is the important one: it frames each Envelope as a length-delimited protobuf message, which ClickHouse's `ProtobufList` input format reads directly. The format and its rationale are covered in depth in [protobufList migration](protobuflist-migration.md).
+The `protobufList` format is the production wire format: it frames each Envelope as a length-delimited protobuf message, which ClickHouse's `ProtobufList` input format reads directly. The format and its rationale are covered in depth in [protobufList migration](protobuflist-migration.md).
+
+**Tabular formats (`csv`/`tsv`).** Columns are generated from the `XtcpFlatRecord` protobuf descriptor via reflection, so they always match the schema. By default every field is emitted; restrict and order them with `-columns` (a comma-separated list of the camelCase json field names, e.g. `-columns hostname,inetDiagMsgSocketSource,inetDiagMsgState,tcpInfoRtt`). The header is written once per process.
+
+**Humanizing.** `csv` and `tsv` render machine values human-readably: IP addresses as dotted-quad / RFC-5952 (the kernel returns them as raw bytes), the congestion enum as its short name (`CUBIC`, `BBR3`), TCP state as a name (`LISTEN`, `ESTABLISHED`), and `timestamp_ns` as RFC3339. `protoJson` and `jsonl` keep the raw machine values (addresses base64, state/enum numeric) for lossless downstream parsing.
+
+**Framing.** The text formats (`protoJson`, `jsonl`, `csv`, `tsv`) terminate each flush with a newline; the binary formats (`protobufList`, `msgpack`) do not. The newline is the marshaller's responsibility, so the same format frames correctly on every sink — `jsonl` over `tcp` is newline-delimited for log shippers, while `protobufList` over Kafka stays a clean length-delimited stream.
 
 ## The destination registry
 
@@ -39,12 +49,23 @@ The `protobufList` format is the important one: it frames each Envelope as a len
 | `nsq` | `nsq:nsqd:4150` | `dest_nsq` | `destinations_nsq.go` |
 | `valkey` | `valkey:valkey:6379` | `dest_valkey` | `destinations_valkey.go` |
 | `s3parquet` | `s3parquet:...` | `dest_s3parquet` | `destinations_s3parquet.go` |
+| `stdout` | `stdout` | *(always built)* | `destinations_stdout.go` |
+| `stderr` | `stderr` | *(always built)* | `destinations_file.go` |
+| `file` | `file:/var/log/xtcp.jsonl` | *(always built)* | `destinations_file.go` |
+| `tcp` | `tcp:127.0.0.1:9000` | *(always built)* | `destinations_tcp.go` |
+| `http` / `https` | `http://host:8080/ingest` | *(always built)* | `destinations_http.go` |
 | `udp` | `udp:127.0.0.1:13000` | *(always built)* | `destinations_udp.go` |
 | `unix` | `unix:/tmp/xtcp.sock` | *(always built)* | `destinations_unix.go` |
 | `unixgram` | `unixgram:/tmp/xtcp.sock` | *(always built)* | `destinations_unixgram.go` |
 | `null` | `null` | *(always built)* | `destinations_null.go` |
 
-The stdlib destinations (`udp`, `unix`, `unixgram`, `null`) are always compiled in; the library-backed ones (`kafka`, `nats`, `nsq`, `valkey`, `s3parquet`) are only present when their build tag is set. `null` discards output and is handy for benchmarking the collection path in isolation.
+The stdlib destinations (`stdout`, `stderr`, `file`, `tcp`, `http`/`https`, `udp`, `unix`, `unixgram`, `null`) are always compiled in; the library-backed ones (`kafka`, `nats`, `nsq`, `valkey`, `s3parquet`) are only present when their build tag is set. `null` discards output and is handy for benchmarking the collection path in isolation.
+
+Notes on the stream sinks:
+
+- **`stdout` / `stderr` / `file`** share a small `io.Writer`-backed core and write the marshalled bytes verbatim. `stdout` is the easiest way to look at data — pair it with `-marshal jsonl|csv|tsv`; the daemon's logs go to stderr, so stdout carries only records (and in Docker they land in `docker logs`). `file` appends (creating the file `0600`).
+- **`tcp`** is the reliable, ordered transport most log/metric shippers (Vector, Logstash, Fluentd, `nc`) expect — xtcp2 has UDP too, but TCP is usually what you want for line-delimited text.
+- **`http` / `https`** POSTs each flushed batch to the URL; the `Content-Type` is derived from the marshaller (`application/x-ndjson` for `jsonl`, `text/csv`, `text/tab-separated-values`, `application/json`, else `application/octet-stream`). Non-2xx responses are treated as errors. The POST timeout reuses `-produceTimeout` (default 10s).
 
 ## Kafka and the schema registry
 
@@ -67,12 +88,51 @@ The per-socket record and its batch wrapper are defined in `proto/xtcp_flat_reco
 
 Generated Go types live in `pkg/xtcp_flat_record/`.
 
+## Quick recipes
+
+These exercise the analysis-friendly formats and sinks. xtcp2 needs `CAP_NET_ADMIN` + `CAP_SYS_ADMIN` (run as root / `sudo`) and at least one namespace directory to exist (see [network namespaces](network-namespaces.md)); use a low non-zero `-d` (e.g. `-d 1`) so logs stay quiet on stderr while records go to the chosen sink.
+
+**Local binary:**
+
+```sh
+# JSON Lines to stdout, piped to jq
+sudo ./result/bin/xtcp2 -dest stdout -marshal jsonl -d 1 | jq .
+
+# CSV of just the columns you care about, into a file → open in DuckDB/R
+sudo ./result/bin/xtcp2 -dest file:/tmp/socks.csv -marshal csv -d 1 \
+  -columns hostname,inetDiagMsgSocketSource,inetDiagMsgSocketSourcePort,inetDiagMsgState,congestionAlgorithmEnum,tcpInfoRtt
+duckdb -c "select inetDiagMsgState, count(*) from '/tmp/socks.csv' group by 1"
+
+# Stream NDJSON over TCP to a log shipper / nc
+sudo ./result/bin/xtcp2 -dest tcp:127.0.0.1:9000 -marshal jsonl -d 1
+
+# POST batches to an HTTP ingest endpoint
+sudo ./result/bin/xtcp2 -dest http://127.0.0.1:8080/ingest -marshal jsonl -d 1
+```
+
+**In Docker** (mount the host namespace dirs so the daemon sees real sockets; records on `stdout`/`stderr` appear in `docker logs`):
+
+```sh
+# one-time: expose the host root netns as a named netns
+sudo mkdir -p /run/netns && sudo ip netns attach xtcp2host 1
+
+# CSV to docker logs
+docker run -d --name xtcp2 \
+  --cap-add NET_ADMIN --cap-add SYS_ADMIN \
+  -v /run/netns:/run/netns:ro -v /run/docker/netns:/run/docker/netns:ro \
+  xtcp2:min -dest stdout -marshal csv -d 1 -columns hostname,inetDiagMsgSocketSource,inetDiagMsgState
+docker logs xtcp2            # header + humanized rows
+```
+
+> **Caveat for short-interval demos:** `-frequency` (poll interval, default `10s`) must stay **greater than** `-timeout` (per-namespace poll timeout, default `5s`) — config validation rejects e.g. `-frequency 2s` against the default `-timeout 5s`. To flush quickly for a `tcp`/`http` demo use a valid pair like `-frequency 3s -timeout 1s`. The first batch only ships at the first flush (≈ one `-frequency` interval), so a receiver must stay open at least that long.
+
 ## Configuration
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `-marshal` | `protobufList` | Output format: `protobufList`, `protoJson`, `protoText`, `msgpack`. |
-| `-dest` | `kafka:redpanda-0:9092` | Destination `scheme:address`. |
+| `-marshal` | `protobufList` | Output format: `protobufList`, `protoJson`, `protoText`, `msgpack`, `jsonl`, `csv`, `tsv`. |
+| `-columns` | — | `csv`/`tsv` only: comma-separated subset of `XtcpFlatRecord` json field names; empty = all. |
+| `-dest` | `kafka:redpanda-0:9092` | Destination `scheme:address` (see the [destinations](#destinations) table). |
 | `-topic` | `xtcp` | Kafka / NSQ topic. |
 | `-kafkaCompression` | `auto` | Kafka compression codec or negotiation list. |
 | `-kafkaSchemaUrl` | `http://localhost:18081` | Confluent schema registry URL. |


### PR DESCRIPTION
Documents the new output features in `docs/output-and-destinations.md`, including copy-paste run recipes.

## What's added
- **Marshallers table** — `jsonl`, `csv`, `tsv`, plus notes on:
  - reflection-generated CSV/TSV columns + the `-columns` selector
  - humanizing (IPs → dotted-quad/v6, congestion → name, TCP state → name, timestamp → RFC3339); `jsonl`/`protoJson` stay raw
  - the marshaller-owns-newline framing model (text formats newline-terminated; binary not)
- **Destinations table** — `stdout`, `stderr`, `file`, `tcp`, `http`/`https`, with per-sink usage notes (Content-Type derivation for HTTP, `file` append/0600, etc.)
- **Quick recipes** — copy-paste commands per mode, local and in Docker (`jsonl | jq`, `csv` → DuckDB, `tcp`, `http`, `stdout` → `docker logs`), including the capability/namespace prerequisites and the **`-frequency` must be > `-timeout`** caveat for short-interval demos.
- **Configuration** — updated `-marshal` options, new `-columns`.

## Notes
- Documents features delivered by **#35** (stdout) and **#36** (jsonl/csv/tsv + tcp/file/stderr/http). Best merged alongside/after those so `main` docs match `main` code.
- Branched off `main` (not stacked on #35/#36) because the doc file already exists on `main` from #34 — editing it here avoids a merge conflict.
- Verified: no dead relative links, no broken intra-doc anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)