### PR TITLE
pkg/xtcp: O(1) envelope size-cap via running byte accumulator

### DIFF
--- a/pkg/xtcp/deserialize.go
+++ b/pkg/xtcp/deserialize.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/randomizedcoder/xtcp2/pkg/xsync"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
@@ -204,11 +203,12 @@ func (x *XTCP) processInetDiagRecord(
 	// return the record to its pool so it doesn't leak.
 	//
 	// Size-cap safety valves: row count (primary, cheap, predictable)
-	// + proto.Size (secondary safety net for pathological per-record
+	// + a byte cap (secondary safety net for pathological per-record
 	// sizes). Whichever trips first triggers an early flush so the
-	// next append lands in a fresh envelope. proto.Size is O(N) so we
-	// only call it every Nth append; the row check is O(1) so we
-	// check on every append.
+	// next append lands in a fresh envelope. The byte total is tracked
+	// incrementally — each append adds the row's exact wire contribution
+	// (envelopeRowBytes) to x.currentEnvelopeBytes — so both checks are
+	// O(1) per append (no proto.Size walk over the whole envelope).
 	x.envelopeMu.Lock()
 	if x.currentEnvelope == nil {
 		x.envelopeMu.Unlock()
@@ -218,22 +218,21 @@ func (x *XTCP) processInetDiagRecord(
 		return offset
 	}
 	x.currentEnvelope.Row = append(x.currentEnvelope.Row, xtcpRecord)
+	x.currentEnvelopeBytes += envelopeRowBytes(xtcpRecord)
 	rowCount := len(x.currentEnvelope.Row)
 	rowThreshold := int(x.config.EnvelopeFlushThresholdRows)
 	if rowThreshold == 0 {
 		rowThreshold = EnvelopeFlushThresholdRowsCst
 	}
+	byteThreshold := int(x.config.EnvelopeFlushThresholdBytes)
+	if byteThreshold == 0 {
+		byteThreshold = EnvelopeFlushThresholdBytesCst
+	}
 	flushReason := ""
 	if rowCount >= rowThreshold {
 		flushReason = "rows_cap"
-	} else if rowCount%envelopeSizeCheckModulus == 0 {
-		byteThreshold := int(x.config.EnvelopeFlushThresholdBytes)
-		if byteThreshold == 0 {
-			byteThreshold = EnvelopeFlushThresholdBytesCst
-		}
-		if proto.Size(x.currentEnvelope) > byteThreshold {
-			flushReason = "size_cap"
-		}
+	} else if x.currentEnvelopeBytes > byteThreshold {
+		flushReason = "size_cap"
 	}
 	x.envelopeMu.Unlock()
 	d.pC.WithLabelValues("Deserialize", "envelopeAppend", "count").Inc()

--- a/pkg/xtcp/marshallers.go
+++ b/pkg/xtcp/marshallers.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/randomizedcoder/xtcp2/pkg/recordfmt"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 )
@@ -26,22 +29,37 @@ const (
 
 // Envelope-size safety valves. Two independent thresholds — the
 // first to trip wins. Row count is the primary knob: cheap (O(1) per
-// append) and predictable. proto.Size is a secondary safety net for
+// append) and predictable. The byte cap is a secondary safety net for
 // pathological per-record sizes (a record with a huge bytes field)
 // because the row count alone won't catch those.
 //
-// Note: proto.Size measures the UNCOMPRESSED serialized bytes.
+// Note: the byte cap measures the UNCOMPRESSED serialized bytes.
 // franz-go applies ZSTD/LZ4/Snappy after handoff, so the actual
 // on-wire Kafka message is typically 3-8x smaller. Treat the bytes
 // cap as a conservative upper bound, not the wire size.
 //
-// proto.Size is O(message size) so we only call it every Nth append,
-// mirroring the `Modulus` pattern used elsewhere in this package.
+// The byte total is tracked incrementally (see envelopeRowBytes /
+// XTCP.currentEnvelopeBytes): each append adds the row's exact
+// contribution, so the cap is O(1) per append instead of an
+// O(message size) proto.Size walk over the whole growing envelope.
 const (
 	EnvelopeFlushThresholdBytesCst = 768 * 1024
 	EnvelopeFlushThresholdRowsCst  = 10000
-	envelopeSizeCheckModulus       = 64
+
+	// envelopeRowFieldNumber is the field number of `repeated XtcpFlatRecord
+	// row = 10` in the Envelope message. Used to compute each row's wire
+	// contribution to proto.Size(Envelope).
+	envelopeRowFieldNumber = 10
 )
+
+// envelopeRowBytes returns one row's exact contribution to
+// proto.Size(Envelope): the repeated-field tag + the length prefix + the
+// row's own serialized size. Because Envelope has only the `row` field,
+// summing this over all rows equals proto.Size(Envelope) exactly, so the
+// running total drives the byte-cap with no per-check reflection walk.
+func envelopeRowBytes(r *xtcp_flat_record.XtcpFlatRecord) int {
+	return protowire.SizeTag(envelopeRowFieldNumber) + protowire.SizeBytes(proto.Size(r))
+}
 
 var (
 	// validMarshallersMap is the union of per-record (protoJson, protoText,

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -89,6 +89,7 @@ func (x *XTCP) flushEnvelope(ctx context.Context, reason string) {
 	x.envelopeMu.Lock()
 	e := x.currentEnvelope
 	x.currentEnvelope = nil
+	x.currentEnvelopeBytes = 0
 	x.envelopeMu.Unlock()
 
 	if e == nil {
@@ -246,6 +247,7 @@ func (x *XTCP) pollAllNetlinkSockets(pollingLoops uint64) (count int) {
 
 	x.envelopeMu.Lock()
 	x.currentEnvelope = x.xtcpEnvelopePool.Get()
+	x.currentEnvelopeBytes = 0
 	x.pollStartTime = startTime
 	x.envelopeMu.Unlock()
 

--- a/pkg/xtcp/size_cap_test.go
+++ b/pkg/xtcp/size_cap_test.go
@@ -1,0 +1,117 @@
+package xtcp
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
+)
+
+// sizeCapRecord builds a record whose serialized size varies with i, so the
+// per-row length prefix exercises multiple varint widths (small records → 1
+// byte, large bytes field → 2-byte length prefix).
+func sizeCapRecord(i int) *xtcp_flat_record.XtcpFlatRecord {
+	return &xtcp_flat_record.XtcpFlatRecord{
+		Hostname:                "host-" + strings.Repeat("x", i%200),
+		Netns:                   "/run/netns/ns",
+		SocketFd:                uint64(i),
+		RecordCounter:           uint64(i),
+		TcpInfoRtt:              uint32(1000 + i),
+		InetDiagMsgSocketSource: []byte(strings.Repeat("b", i%300)),
+	}
+}
+
+// TestEnvelopeRowBytes_exact proves the incremental accumulator is exact:
+// summing envelopeRowBytes over every row equals proto.Size(envelope). This is
+// the invariant the byte-cap relies on — Envelope has only the `row` field, so
+// the running total reproduces proto.Size(Envelope) with no per-check walk.
+func TestEnvelopeRowBytes_exact(t *testing.T) {
+	for _, n := range []int{0, 1, 5, 64, 65, 500} {
+		env := &xtcp_flat_record.Envelope{}
+		sum := 0
+		for i := range n {
+			r := sizeCapRecord(i)
+			env.Row = append(env.Row, r)
+			sum += envelopeRowBytes(r)
+		}
+		if got := proto.Size(env); got != sum {
+			t.Errorf("n=%d: sum(envelopeRowBytes)=%d, proto.Size(envelope)=%d", n, sum, got)
+		}
+	}
+}
+
+// TestEnvelopeRowBytes_byteCapParity confirms the accumulator trips the byte
+// cap at the same row at which the old proto.Size(envelope) > threshold check
+// would have, for a representative threshold.
+func TestEnvelopeRowBytes_byteCapParity(t *testing.T) {
+	const threshold = 4096
+	env := &xtcp_flat_record.Envelope{}
+	acc := 0
+	accTrip, oldTrip := -1, -1
+	for i := range 1000 {
+		r := sizeCapRecord(i)
+		env.Row = append(env.Row, r)
+		acc += envelopeRowBytes(r)
+		if accTrip == -1 && acc > threshold {
+			accTrip = i
+		}
+		if oldTrip == -1 && proto.Size(env) > threshold {
+			oldTrip = i
+		}
+	}
+	if accTrip != oldTrip {
+		t.Errorf("byte-cap trip row mismatch: accumulator=%d, proto.Size=%d", accTrip, oldTrip)
+	}
+	if accTrip == -1 {
+		t.Fatal("threshold never tripped — pick a smaller threshold")
+	}
+}
+
+// BenchmarkEnvelopeSizeCapProtoSize is the OLD path: proto.Size over the whole
+// growing envelope every envelopeRowFieldNumber-independent 64 appends.
+func BenchmarkEnvelopeSizeCapProtoSize(b *testing.B) {
+	const rows = 10000
+	const modulus = 64
+	const threshold = 768 * 1024
+	recs := make([]*xtcp_flat_record.XtcpFlatRecord, rows)
+	for i := range recs {
+		recs[i] = sizeCapRecord(i)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		env := &xtcp_flat_record.Envelope{Row: make([]*xtcp_flat_record.XtcpFlatRecord, 0, rows)}
+		for i, r := range recs {
+			env.Row = append(env.Row, r)
+			if (i+1)%modulus == 0 {
+				if proto.Size(env) > threshold {
+					_ = env
+				}
+			}
+		}
+	}
+}
+
+// BenchmarkEnvelopeSizeCapAccumulator is the NEW path: an exact running byte
+// total updated once per append, checked every append.
+func BenchmarkEnvelopeSizeCapAccumulator(b *testing.B) {
+	const rows = 10000
+	const threshold = 768 * 1024
+	recs := make([]*xtcp_flat_record.XtcpFlatRecord, rows)
+	for i := range recs {
+		recs[i] = sizeCapRecord(i)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		env := &xtcp_flat_record.Envelope{Row: make([]*xtcp_flat_record.XtcpFlatRecord, 0, rows)}
+		acc := 0
+		for _, r := range recs {
+			env.Row = append(env.Row, r)
+			acc += envelopeRowBytes(r)
+			if acc > threshold {
+				_ = env
+			}
+		}
+	}
+}

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -50,6 +50,7 @@ type XTCP struct {
 	destBytesPool    xsync.Pool[*[]byte]
 
 	currentEnvelope       *xtcp_flat_record.Envelope
+	currentEnvelopeBytes  int // running proto.Size(currentEnvelope); see envelopeRowBytes
 	pollStartTime         time.Time
 	envelopeMu            sync.Mutex
 	changePollFrequencyCh chan time.Duration


### PR DESCRIPTION
## Summary

Implements **P1** from the [optimization roadmap](https://github.com/randomizedcoder/xtcp2/blob/main/docs/performance-optimizations.md) — the biggest single win the PGO profile (PR #44) surfaced.

The batch-flush byte-cap called `proto.Size(x.currentEnvelope)` every 64 appends, re-walking the **entire** growing envelope each time — ~**O(rows²/64)** over a batch, which the profile attributed to **~40% of non-idle CPU** (`sizePointerSlow`).

This replaces it with an **exact** running byte accumulator:

- Each append adds the row's exact wire contribution — `envelopeRowBytes(r) = protowire.SizeTag(10) + protowire.SizeBytes(proto.Size(r))` — to a new `XTCP.currentEnvelopeBytes`, under the existing `envelopeMu`.
- The accumulator is reset in lockstep with `currentEnvelope` (in `flushEnvelope` and at poll start).
- Because `Envelope` has only `repeated XtcpFlatRecord row = 10`, this sum equals `proto.Size(Envelope)` **exactly** — the byte-cap behavior is unchanged, just computed in O(1) per append instead of an O(message) walk.

The check now runs every append (the compare is O(1)), so `size_cap` trips closer to the true threshold rather than only at multiples of 64; the now-unused `envelopeSizeCheckModulus` is removed.

## Why it's safe
- `TestEnvelopeRowBytes_exact` asserts `Σ envelopeRowBytes(row) == proto.Size(envelope)` across envelope sizes (0, 1, 5, 64, 65, 500) and varied per-row sizes (exercising multi-byte length varints).
- `TestEnvelopeRowBytes_byteCapParity` asserts the accumulator trips the cap at the same row the old `proto.Size` check would.
- Existing guards stay green: `TestFlushEnvelope_sizeCap_triggersMidPoll`, `TestFlushEnvelope_rowsCap_reason`, `TestFlushEnvelope_returnsRowsToPool`.

## Measured

`BenchmarkEnvelopeSizeCap*` — filling a 10,000-row envelope:

| Path | ns/op |
|---|---:|
| old (`proto.Size` every 64) | 365,688,551 |
| new (accumulator) | 4,969,634 |

≈ **74× faster** size-cap accounting on a full batch. (PGO's ~13% on the marshal path is separate and unaffected.)

## Verification
`nix build .#xtcp2 .#checks.x86_64-linux.golangci-lint .#test-go-unit .#test-pkg-xtcp` — all green.

## Notes
- Independent PR off `main`. P2 (vtprotobuf), which swaps the per-row `proto.Size(r)` for `SizeVT()` and the flush marshal for `MarshalVT`, is the planned follow-up branched off `main` after this merges.
- No flag/config changes; rows-cap default (10,000) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)