### PR TITLE
microvms/tcp-stress: move host Prometheus forward off :9090 (→ :19090)

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -321,7 +321,7 @@ The **clickhouse-pipeline** flavor doesn't have a runner with assertions — boo
 |---|---|---|---|
 | `127.0.0.1:9088` | `:9088` | xtcp2 `/metrics` | tcp-stress, clickhouse-pipeline |
 | `127.0.0.1:8889` | `:8889` | xtcp2 gRPC | tcp-stress, clickhouse-pipeline |
-| `127.0.0.1:9090` | `:9090` | Prometheus UI | tcp-stress (clickhouse-pipeline reaches it internally) |
+| `127.0.0.1:19090` | `:9090` | Prometheus UI | tcp-stress (host port shifted off `:9090` to avoid clashing with a Prometheus on the dev box; clickhouse-pipeline reaches it internally) |
 | `127.0.0.1:18123` | `:18123` | ClickHouse HTTP (`-u default:xtcp`) | clickhouse-pipeline |
 | `127.0.0.1:19001` | `:19001` | ClickHouse native | clickhouse-pipeline |
 | `127.0.0.1:19092` | `:19092` | Redpanda Kafka external | clickhouse-pipeline |

--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -203,7 +203,7 @@ rec {
           echo "================================================"
           echo " --keep-alive: VM is still running."
           echo "   Serial console: nc 127.0.0.1 $SERIAL_PORT"
-          echo "   Prometheus (in-VM): curl 127.0.0.1:9090/api/v1/query?query=..."
+          echo "   Prometheus (host-forwarded): curl 127.0.0.1:19090/api/v1/query?query=..."
           echo "   Ctrl-C this runner to power the VM off."
           echo "================================================"
           wait "$vm_pid"

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -1085,10 +1085,14 @@ in
               }
             ]
             ++ lib.optionals isTcpStress [
-              # in-VM Prometheus server for the tcp-stress flavor.
+              # in-VM Prometheus server for the tcp-stress flavor. Host side
+              # shifted to 19090 (guest stays 9090) so it doesn't collide with
+              # a Prometheus already running on the dev box's :9090 — qemu
+              # refuses to start if the hostfwd port is taken. Matches the
+              # clickpipe convention (host :19090 → guest :9090).
               {
                 from = "host";
-                host.port = 9090;
+                host.port = 19090;
                 guest.port = 9090;
               }
             ]


### PR DESCRIPTION
## Summary

The `tcp-stress` microVM flavor hard-coded a qemu hostfwd of **host `:9090` → guest `:9090`** for its in-VM Prometheus. On any machine already running Prometheus on `:9090` (common on a dev/monitoring box), qemu refuses to start:

```
-netdev user,...,hostfwd=tcp::9090-:9090,: Could not set up host forwarding rule 'tcp::9090-:9090'
```

…and the VM never boots. Worse, the runner doesn't validate boot — it sleeps the full `--duration` against a dead VM, so a 3 h run silently does nothing.

This shifts the **host** side to `:19090` (guest stays `:9090`), matching the clickhouse-pipeline convention (which already uses `:19090` for the same reason). Docs + the runner's `--keep-alive` hint updated to match.

## Changes
- `nix/microvms/mkVm.nix` — tcp-stress `forwardPorts`: `host.port 9090 → 19090` (guest unchanged). Guest firewall opening of `9090` is unchanged (Prometheus still listens on `:9090` inside the VM).
- `docs/integration-testing.md` — port-forward table now lists `127.0.0.1:19090`.
- `nix/microvms/lib.nix` — `--keep-alive` hint points at `:19090`.

## How it was found / verified
Hit during an extended `tcp-stress` soak on a box running Prometheus. With the remap the VM boots and the run **passes**: `20/20` containers spawned + per-container netns discovered, ~10.7 M netlink packets parsed over 3 h, single process start (no restart), 0 panics. `nix eval` of the tcp-stress app succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)