### PR TITLE
microvms/soak: dedicated 3072 MiB budget (fix nsTest OOM-loop)

### DIFF
--- a/nix/microvms/constants.nix
+++ b/nix/microvms/constants.nix
@@ -34,6 +34,13 @@
       # 20 containers + Prometheus's ~150 MiB RSS + 12h of TSDB working
       # set, 3072 MiB leaves clear headroom for a long-running session.
       memTcpStress = 3072;
+      # memSoak is used by sink="soak". The flavor runs nsTest (which holds
+      # ~200 namespaces × ~100 persistent connections — anon-rss grows to
+      # ~320 MiB) alongside tcp_server/tcp_client and xtcp2. At the 1024 MiB
+      # baseline the kernel OOM-killer repeatedly kills nsTest (~6×/min),
+      # degrading the intended sustained churn. 3072 MiB leaves clear headroom
+      # for nsTest + the tcp population + xtcp2 over a multi-hour soak.
+      memSoak = 3072;
       # memClickPipe is used by sink="clickhouse-pipeline". ClickHouse
       # 25.x easily consumes 2 GiB just to handle the kafka-engine
       # consume + parse + materialize-view path during a soak. With

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -85,6 +85,10 @@ let
       cfg.memClickPipe
     else if isTcpStress then
       cfg.memTcpStress
+    else if isSoak then
+      # nsTest's churn working set (~320 MiB) OOM-loops at the 1024 MiB
+      # baseline; give the soak its own larger budget.
+      cfg.memSoak
     else
       cfg.mem;
 


### PR DESCRIPTION
## Summary

The `soak` flavor fell through to the **1024 MiB baseline** (shared with the lifecycle smoke test). Its `nsTest` churn driver holds ~200 namespaces × ~100 persistent connections (`anon-rss` ~320 MiB), so at 1024 MiB the kernel OOM-killer **repeatedly kills `nsTest`** — ~6×/min, **~365 kills in the first hour** of a 10 h soak — which degrades the intended *sustained* churn (the driver keeps dying/restarting instead of running steadily).

Found while running a 10 h soak. Notably, **xtcp2 itself was never the OOM victim** (0 panics, 0 restarts) — its `sync.Pool`-based memory stays bounded, so the OOM-killer always picked the ballooning `nsTest`. So this is a test-harness sizing bug, not an xtcp2 bug — but it means the soak wasn't exercising the workload as designed.

## Change
- `nix/microvms/constants.nix` — add `memSoak = 3072` (with rationale).
- `nix/microvms/mkVm.nix` — select `cfg.memSoak` for `sink == "soak"` in `effectiveMem`.

The 1024 MiB baseline for lifecycle/coverage smoke tests is unchanged; this mirrors the existing `memTcpStress` treatment.

## Verification
`nix eval .#apps.x86_64-linux.microvm-x86_64-soak` succeeds. Re-running the 10 h soak on the bumped budget to confirm `nsTest` survives and the churn runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)