### PR TITLE
pkg/xtcp: fix OS-thread leak under namespace churn (thread exhaustion crash)

### DIFF
--- a/pkg/xtcp/ns_add.go
+++ b/pkg/xtcp/ns_add.go
@@ -5,10 +5,24 @@ import (
 	"log"
 )
 
-// add checks if the namespace already has an open netlink socket
-// if not, starts a new goroutine netNamespaceInstance, which will
-// open a netlink socket in the target network namespace, and
-// store the socketFD in the nsMap
+// nsAdd reserves the namespace's slot and starts its netNamespaceInstance
+// goroutine.
+//
+// The per-ns context + cancel are created HERE and stored in nsMap *before*
+// the goroutine is launched. Previously the cancel was created deep inside
+// netNamespaceInstance — only after LockOSThread + setns + socket bind (which
+// can take milliseconds, or up to seconds when setns retries). A namespace
+// deleted during that init window (trivial under heavy `ip netns add/del`
+// churn) found no nsMap entry, so nsDelete never called cancel(); the instance
+// then blocked forever on <-nsCtx.Done() holding a locked OS thread. Those
+// leaked threads accumulate to the SetMaxThreads (-maxThreads, default 2000)
+// ceiling and crash the daemon with "fatal error: thread exhaustion".
+// Reserving the cancel up front guarantees nsDelete can always reach it, so a
+// delete-during-init reliably unblocks the instance.
+//
+// LoadOrStore makes the "already present?" check and the slot reservation
+// atomic, closing a second race where two adds for the same name could both
+// pass a Load() check and launch duplicate goroutines.
 func (x *XTCP) nsAdd(ctx context.Context, nsName *string) {
 
 	x.pC.WithLabelValues("add", "store", "counter").Inc()
@@ -17,8 +31,20 @@ func (x *XTCP) nsAdd(ctx context.Context, nsName *string) {
 		log.Printf("add: %s\n", *nsName)
 	}
 
-	_, ok := x.nsMap.Load(*nsName)
-	if ok {
+	// Copy the name: callers (the fsnotify watch loop) reuse the backing
+	// string variable, so we must not retain their pointer across the
+	// goroutine's lifetime.
+	name := *nsName
+	nsCtx, nsCancel := context.WithCancel(ctx)
+
+	if _, loaded := x.nsMap.LoadOrStore(name, netNSitem{
+		name:     &name,
+		ctx:      nsCtx,
+		cancel:   nsCancel,
+		socketFD: -1, // not opened yet; netNamespaceInstance fills it in
+	}); loaded {
+		// Already tracked — release the context we just made and bail.
+		nsCancel()
 		x.pC.WithLabelValues("add", "duplicate", "counter").Inc()
 		if x.debugLevel > 10 {
 			log.Printf("add duplicate: %s\n", *nsName)
@@ -26,5 +52,5 @@ func (x *XTCP) nsAdd(ctx context.Context, nsName *string) {
 		return
 	}
 
-	go x.netNamespaceInstance(ctx, nsName)
+	go x.netNamespaceInstance(nsCtx, nsCancel, &name)
 }

--- a/pkg/xtcp/ns_churn_race_test.go
+++ b/pkg/xtcp/ns_churn_race_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package xtcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"golang.org/x/sys/unix"
+
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
+)
+
+// TestNsChurn_deleteDuringInit_doesNotLeakThread is the regression test for the
+// thread-exhaustion crash found in the 10 h soak: a namespace deleted *while*
+// its netNamespaceInstance goroutine is still doing setns/socket init.
+//
+// The bug: the per-ns cancel was created deep inside netNamespaceInstance
+// (after the setns + socket setup). A delete arriving during that window found
+// no nsMap entry, so nsDelete never called cancel(); the instance then blocked
+// forever on <-nsCtx.Done() holding a locked OS thread. Under churn these
+// leaked threads accumulate to the SetMaxThreads(2000) cap and crash the daemon
+// with "fatal error: thread exhaustion".
+//
+// The fix creates+stores the cancel in nsAdd before launching the goroutine, so
+// nsDelete can always reach it, and netNamespaceInstance aborts its init when
+// the context is already cancelled. This test forces the race deterministically
+// by blocking the openAndSetnsSyscalls.open seam mid-init, deleting the ns, then
+// releasing the seam, and asserts the goroutine actually exits (no leak).
+func TestNsChurn_deleteDuringInit_doesNotLeakThread(t *testing.T) {
+	// Block the open seam mid-init so we can delete the ns while the
+	// instance goroutine is still initializing.
+	openEntered := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	var once sync.Once
+
+	devNull, err := unix.Open("/dev/null", unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Skipf("open /dev/null: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(devNull) })
+
+	origSyscalls := openAndSetnsSyscalls
+	origRestore := restoreNsSetns
+	openAndSetnsSyscalls = openAndSetnsSyscallsT{
+		open: func(_ string, _ int, _ uint32) (int, error) {
+			once.Do(func() { close(openEntered) })
+			<-releaseOpen // block until the test deletes the ns
+			return devNull, nil
+		},
+		setns: func(_ int, _ int) error { return nil },
+		close: func(_ int) error { return nil },
+	}
+	restoreNsSetns = func(_ int, _ int) error { return nil } // clean UnlockOSThread
+	t.Cleanup(func() {
+		openAndSetnsSyscalls = origSyscalls
+		restoreNsSetns = origRestore
+	})
+
+	x := newNsExtraFixture(t)
+	x.config = &xtcp_config.XtcpConfig{Netlinkers: 0}
+	x.Netlinker = func(_ context.Context, _ *sync.WaitGroup, _ *string, _ int, _ uint32) {}
+
+	name := "race-ns"
+
+	// Make checkMountInfo pass (it just scans mountInfoDir for the name), so
+	// init reaches the (blocked) open seam rather than bailing early.
+	mi := filepath.Join(t.TempDir(), "mountinfo")
+	if werr := os.WriteFile(mi, []byte("36 35 0:32 / /run/netns/"+name+" rw - nsfs nsfs rw\n"), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	origMountInfoDir := mountInfoDir
+	mountInfoDir = mi
+	t.Cleanup(func() { mountInfoDir = origMountInfoDir })
+
+	// nsAdd reserves the cancel in nsMap and launches netNamespaceInstance,
+	// which blocks in the open seam.
+	x.nsAdd(context.Background(), &name)
+
+	select {
+	case <-openEntered:
+	case <-time.After(5 * time.Second):
+		close(releaseOpen)
+		t.Fatal("netNamespaceInstance never reached the open seam")
+	}
+
+	// The fix's key property: the cancel is reachable *during* init.
+	if _, ok := x.nsMap.Load(name); !ok {
+		close(releaseOpen)
+		t.Fatal("nsAdd must store the per-ns entry (with cancel) before init completes")
+	}
+
+	// Delete while the instance is still initializing — this is the race.
+	x.nsDelete(&name)
+
+	// Let init proceed; the instance must observe the cancellation and exit
+	// (abort-during-init), not block forever on <-nsCtx.Done().
+	close(releaseOpen)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		ended := testutil.ToFloat64(x.pC.WithLabelValues("netNamespaceInstance", "end", "counter"))
+		if ended >= 1 {
+			break // goroutine exited — no leaked, forever-blocked thread
+		}
+		select {
+		case <-deadline:
+			t.Fatal("netNamespaceInstance did not exit after delete-during-init: the per-ns cancel was unreachable and the goroutine is blocked forever on <-nsCtx.Done() (the thread-leak regression)")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// And it took the abort path rather than fully setting up a doomed ns.
+	if aborted := testutil.ToFloat64(x.pC.WithLabelValues("netNamespaceInstance", "abortedDuringInit", "count")); aborted < 1 {
+		t.Errorf("expected abortedDuringInit counter ≥1, got %v", aborted)
+	}
+}

--- a/pkg/xtcp/ns_createNetlinkersAndStore.go
+++ b/pkg/xtcp/ns_createNetlinkersAndStore.go
@@ -17,6 +17,16 @@ func (x *XTCP) createNetlinkersAndStore(nsCtx context.Context, nsCancel context.
 
 	x.pC.WithLabelValues("createWorksAndStore", "start", "counter").Inc()
 
+	// The namespace may have been deleted while netNamespaceInstance was
+	// doing its setns/socket init — nsAdd made the cancel reachable, so
+	// nsDelete can have already fired. Don't start netlinkers or update the
+	// nsMap entry for a namespace that's gone; the caller's <-nsCtx.Done()
+	// returns immediately and its deferred closeSocket cleans up.
+	if nsCtx.Err() != nil {
+		x.pC.WithLabelValues("createWorksAndStore", "cancelledDuringInit", "count").Inc()
+		return
+	}
+
 	if x.config.NlTimeoutMilliseconds > 0 {
 		x.setSocketTimeoutViaSyscall(int64(x.config.NlTimeoutMilliseconds), fd)
 	}
@@ -33,9 +43,18 @@ func (x *XTCP) createNetlinkersAndStore(nsCtx context.Context, nsCancel context.
 	wg.Add(1)
 	go x.createNetlinkers(nsCtx, wg, nsName, fd, x.config.Netlinkers)
 
+	// Update the nsMap slot reserved by nsAdd with the real socketFD.
 	x.nsMap.Store(*nsName, nsi)
 	x.fdToNsMap.Store(fd, *nsName)
 	x.incrementStoreAndGenerationCounts()
+
+	// If a delete raced in between the guard above and the Store, undo it so
+	// we don't leave a stale entry (with a real fd) for a cancelled namespace.
+	if nsCtx.Err() != nil {
+		x.nsMap.Delete(*nsName)
+		x.fdToNsMap.Delete(fd)
+		x.pC.WithLabelValues("createWorksAndStore", "cancelRacedStore", "count").Inc()
+	}
 	if x.debugLevel > 10 {
 		log.Printf("createNetlinkersAndStore: ns:%s socketFD:%d Stored", *nsName, fd)
 	}

--- a/pkg/xtcp/ns_net_namespace.go
+++ b/pkg/xtcp/ns_net_namespace.go
@@ -28,7 +28,7 @@ var mountInfoDir = "/proc/self/mountinfo"
 // https://pkg.go.dev/github.com/vishvananda/netns#GetFromName
 // https://pkg.go.dev/github.com/vishvananda/netns#GetFromPath
 // https://tip.golang.org/doc/go1.10#runtime
-func (x *XTCP) netNamespaceInstance(ctx context.Context, nsName *string) {
+func (x *XTCP) netNamespaceInstance(nsCtx context.Context, nsCancel context.CancelFunc, nsName *string) {
 
 	startTime := time.Now()
 	x.pC.WithLabelValues("netNamespaceInstance", "start", "counter").Inc()
@@ -105,6 +105,19 @@ func (x *XTCP) netNamespaceInstance(ctx context.Context, nsName *string) {
 
 	fd := x.openAndSetNSWithRetries(nsName)
 
+	// If the namespace was deleted during the (possibly slow, retrying) setns
+	// above, nsDelete has already called cancel() — reachable because nsAdd
+	// stored it before this goroutine launched. Abort before opening a netlink
+	// socket we'd immediately close; the deferred restore + UnlockOSThread
+	// still run, so the OS thread is released/terminated cleanly instead of
+	// this goroutine blocking forever on <-nsCtx.Done() (the leak that
+	// exhausted the SetMaxThreads cap under churn).
+	if nsCtx.Err() != nil {
+		x.pC.WithLabelValues("netNamespaceInstance", "abortedDuringInit", "count").Inc()
+		x.closeFD(fd)
+		return
+	}
+
 	// if x.debugLevel > 10 {
 	// 	log.Printf("netNamespaceInstance after unix.Setns: %s", ns.name)
 	// }
@@ -142,12 +155,11 @@ func (x *XTCP) netNamespaceInstance(ctx context.Context, nsName *string) {
 		return
 	}
 
-	// Derive a per-ns context here so that nsDelete's cancel() reaches
-	// the <-nsCtx.Done() below; otherwise this goroutine blocks on the
-	// daemon's parent ctx and the deferred closeSocket(socketFD) never
-	// fires on a per-namespace removal — leaking one fd + one goroutine
-	// per nsDelete.
-	nsCtx, nsCancel := context.WithCancel(ctx)
+	// The per-ns context + cancel were created in nsAdd and stored in nsMap
+	// before this goroutine launched, so nsDelete can always reach cancel()
+	// (see nsAdd). createNetlinkersAndStore fills in the socketFD and starts
+	// the netlinkers; it no-ops if the namespace was already deleted during
+	// the setns/socket init above.
 	x.createNetlinkersAndStore(nsCtx, nsCancel, nsName, socketFD)
 
 	x.pH.WithLabelValues("netNamespaceInstance", "store", "counter").Observe(time.Since(startTime).Seconds())


### PR DESCRIPTION
## Summary

Fixes a crash found by an extended soak: under sustained namespace churn (~200 namespaces, `ip netns add/del` every ~100 ms), the daemon **crash-loops on `fatal error: thread exhaustion`** ("program exceeds 2000-thread limit", the `-maxThreads` `debug.SetMaxThreads` cap) within minutes.

## Root cause — a TOCTOU race

`nsAdd` launched `netNamespaceInstance`, but the per-ns `context`+`cancel` were created and stored in `nsMap` only **later**, inside the goroutine, *after* its `setns` + netlink-socket init (which takes ms — or seconds when `setns` retries). A namespace deleted during that init window found **no `nsMap` entry**, so `nsDelete` never called `cancel()`. The instance then blocked forever on `<-nsCtx.Done()` while holding its `runtime.LockOSThread()` thread. Under churn these forever-blocked threads accumulate to the 2000 cap and crash the daemon.

(The earlier conditional-`UnlockOSThread` work fixed a *different* manifestation — tainted-M recycling on restore failure. This is a separate, faster path that the 10 h soak exposed once the churn workload actually ran.)

## Fix
- **`nsAdd`** creates the per-ns `context`+`cancel` and reserves the `nsMap` slot via `LoadOrStore` **before** launching the goroutine, so `nsDelete` can always reach `cancel()`. (`LoadOrStore` also closes a duplicate-launch race the prior `Load`-then-`go` had.)
- **`netNamespaceInstance`** takes the ctx+cancel as params and **aborts init early** if the ns was already cancelled — releasing the thread via the existing restore+`UnlockOSThread` defer instead of blocking on `<-nsCtx.Done()`.
- **`createNetlinkersAndStore`** no-ops (and undoes a raced store) when the ns was cancelled during init, so no stale entry / netlinkers linger for a dead ns.

## Test
`ns_churn_race_test.go` drives the race deterministically: it blocks the `setns` `open` seam mid-init, deletes the ns, then releases the seam, and asserts the goroutine **exits** (abort-during-init) rather than leaking a forever-blocked thread. Without the fix it times out (the goroutine blocks forever). `pkg/xtcp` passes `go test -race`.

## Verification
`nix build .#xtcp2 .#checks.x86_64-linux.golangci-lint .#test-go-unit .#test-pkg-xtcp` — green. `pkg/xtcp` passes the race check.

> Note: `nix build .#test-go-race` currently fails on a **pre-existing, unrelated** data race in `cmd/kafka_to_clickhouse` (`TestFileOrKafka_kafkaMode`, `TestDestKafka_unreachable`) — reproduces consistently on `main`, a package this PR doesn't touch. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)