### PR TITLE
kafka_to_clickhouse: fix data race in produce-promise callback

### DIFF
--- a/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
+++ b/cmd/kafka_to_clickhouse/kafka_to_clickhouse.go
@@ -330,8 +330,17 @@ func destKafka(ctx context.Context, c config, xtcpRecordBinary *[]byte) (n int, 
 		kgoRecord,
 		func(kgoRecord *kgo.Record, err error) {
 			defer func() {
-				wg.Done()
+				// Return the record to the pool BEFORE signaling done.
+				// destKafka's wg.Wait() must not unblock (and the function
+				// return) until this promise callback has fully finished;
+				// otherwise destKafka returns while this goroutine is still
+				// running kgoRecordPool.Put, racing anything that reads or
+				// reassigns kgoRecordPool after destKafka returns (e.g. the
+				// franz-go promise fires on its own goroutine). Ordering the
+				// Put before wg.Done() establishes the happens-before that
+				// wg.Wait() relies on.
 				kgoRecordPool.Put(kgoRecord)
+				wg.Done()
 			}()
 
 			dur := time.Since(kafkaStartTime)


### PR DESCRIPTION
## Summary

Fixes a data race in `destKafka` that `go test -race` flags consistently (`TestDestKafka_unreachable`, `TestFileOrKafka_kafkaMode`) — it's been failing the `test-go-race` nix check on `main`, independent of any other work.

## Root cause

`destKafka` does an async `kClient.Produce(...)` with a promise callback and waits on a `WaitGroup` for it. But the callback's deferred cleanup ran in the wrong order:

```go
defer func() {
    wg.Done()                     // signals completion FIRST
    kgoRecordPool.Put(kgoRecord)  // ...then touches the pool
}()
```

`wg.Done()` releases `destKafka`'s `wg.Wait()`, so `destKafka` returns **while the callback goroutine is still executing `kgoRecordPool.Put()`**. Anything that reads or reassigns `kgoRecordPool` after `destKafka` returns then races that `Put` (which is exactly what the tests do — they restore the swapped-in global pool in `t.Cleanup`). The race detector's report:

```
Write  …_test.go:285  (t.Cleanup restoring kgoRecordPool)
Read   kafka_to_clickhouse.go:334  (kgoRecordPool.Put, on the franz-go promise goroutine)
```

## Fix

Reorder the deferred cleanup: `Put()` the record back to the pool **first**, then `wg.Done()`. This establishes the happens-before `wg.Wait()` relies on — the callback is fully finished (record pooled) before `destKafka` returns. It's the correct ordering regardless of the test: do the work, then signal completion.

## Verification
`go test -race -count=1 ./cmd/kafka_to_clickhouse` passes consistently (3/3 fresh runs; was 100% failing). Full `nix build .#test-go-race` is now **green**, along with `golangci-lint` and the `xtcp2` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)