### PR TITLE
feat(s3parquet): support S3_ACCESS_KEY_FILE / S3_SECRET_KEY_FILE

### DIFF
--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -239,8 +239,8 @@ func defineFlags() *mainFlags {
 	f.s3Endpoint = flag.String("s3Endpoint", s3EndpointCst, "s3parquet: S3-compatible endpoint URL (e.g. http://127.0.0.1:9000 for MinIO). Falls back to S3_ENDPOINT env, or the address after `s3parquet:` in -dest. Required when -dest s3parquet:...")
 	f.s3Bucket = flag.String("s3Bucket", s3BucketCst, "s3parquet: target bucket name. Falls back to S3_BUCKET env. Bucket must already exist; daemon does not auto-create.")
 	f.s3Prefix = flag.String("s3Prefix", s3PrefixCst, "s3parquet: optional key prefix within the bucket. Combined with Hive-style partitioning host=…/date=…/hour=…/<file>.parquet.")
-	f.s3AccessKey = flag.String("s3AccessKey", s3AccessKeyCst, "s3parquet: S3 access key. Falls back to S3_ACCESS_KEY env. Never logged.")
-	f.s3SecretKey = flag.String("s3SecretKey", s3SecretKeyCst, "s3parquet: S3 secret key. Falls back to S3_SECRET_KEY env. Never logged.")
+	f.s3AccessKey = flag.String("s3AccessKey", s3AccessKeyCst, "s3parquet: S3 access key. Falls back to S3_ACCESS_KEY env, or S3_ACCESS_KEY_FILE (path to a file holding the key). Never logged.")
+	f.s3SecretKey = flag.String("s3SecretKey", s3SecretKeyCst, "s3parquet: S3 secret key. Falls back to S3_SECRET_KEY env, or S3_SECRET_KEY_FILE (path to a file holding the key). Never logged.")
 	f.s3Region = flag.String("s3Region", s3RegionCst, "s3parquet: S3 region. Defaults to 'us-east-1' when empty; required by AWS, ignored by most MinIO setups.")
 	f.s3ParquetFlushBytes = flag.Uint("s3ParquetFlushBytes", s3ParquetFlushThresholdBytesCst, "s3parquet: soft cap on the in-memory Parquet builder's uncompressed row bytes before finalize+upload. 0 = daemon default (63 MiB).")
 	f.dest = flag.String("dest", destCst, "scheme:addr — kafka:host:9092, nats:..., nsq:..., valkey:..., udp:host:13000, tcp:host:9000, unix:/path, unixgram:/path, file:/path, http(s)://host/ingest, s3parquet:..., stdout, stderr, null (pair stdout/file/tcp with -marshal jsonl|csv|tsv)")
@@ -805,6 +805,31 @@ func envString(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
+// envStringFromFile reads a secret from the file whose path is the value of
+// the `key` env var (the Docker `_FILE` convention, e.g.
+// S3_SECRET_KEY_FILE=/run/secrets/s3). This keeps the secret out of the
+// process environment (visible via `docker inspect` / /proc/<pid>/environ)
+// and out of argv — the env only names a path, the bytes live in a file.
+//
+// The file contents are trimmed of surrounding whitespace (handles a trailing
+// newline from `echo`/`aws ssm get-parameter`). Returns ("", false) when the
+// env var is unset/empty, or when the named file can't be read — in the latter
+// case it logs a non-secret error so a misconfiguration is visible, and the
+// downstream destination fails fast on the resulting empty credential rather
+// than running half-configured. The file's contents are never logged.
+func envStringFromFile(key string) (string, bool) {
+	path, ok := os.LookupEnv(key)
+	if !ok || path == "" {
+		return "", false
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("key:%s error reading secret file: %v", key, err)
+		return "", false
+	}
+	return strings.TrimSpace(string(b)), true
+}
+
 func logEnv(key, msg string, debugLevel uint) {
 	if debugLevel > 10 {
 		log.Printf("key:%s, %s", key, msg)
@@ -906,6 +931,18 @@ func envOverrideMarshalAndDest(c *xtcp_config.XtcpConfig, debugLevel uint) {
 	if v, ok := envString("S3_SECRET_KEY"); ok {
 		c.S3SecretKey = v
 		logEnv("S3_SECRET_KEY", "set", debugLevel)
+	}
+	// File-based variants (Docker `_FILE` convention). Applied after the
+	// inline S3_ACCESS_KEY / S3_SECRET_KEY blocks so a mounted/baked secret
+	// file wins when both are set. The env var holds only the path; the
+	// credential bytes live in the file. Value is never logged.
+	if v, ok := envStringFromFile("S3_ACCESS_KEY_FILE"); ok {
+		c.S3AccessKey = v
+		logEnv("S3_ACCESS_KEY_FILE", "set", debugLevel)
+	}
+	if v, ok := envStringFromFile("S3_SECRET_KEY_FILE"); ok {
+		c.S3SecretKey = v
+		logEnv("S3_SECRET_KEY_FILE", "set", debugLevel)
 	}
 	if v, ok := envString("S3_REGION"); ok {
 		c.S3Region = v

--- a/cmd/xtcp2/xtcp2_test.go
+++ b/cmd/xtcp2/xtcp2_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -211,6 +212,51 @@ func TestEnvOverrideMarshalAndDest(t *testing.T) {
 	if c.MarshalTo != "protoJson" ||
 		c.Dest != "null" || c.DestWriteFiles != 3 {
 		t.Errorf("envOverrideMarshalAndDest mismatch: %+v", c)
+	}
+}
+
+// TestEnvOverrideS3SecretFile covers the Docker `_FILE` convention: the S3
+// credential is read from a file named by S3_ACCESS_KEY_FILE /
+// S3_SECRET_KEY_FILE, the contents are trimmed, and the file form wins over
+// the inline S3_ACCESS_KEY / S3_SECRET_KEY env when both are set.
+func TestEnvOverrideS3SecretFile(t *testing.T) {
+	dir := t.TempDir()
+	accessPath := filepath.Join(dir, "access")
+	secretPath := filepath.Join(dir, "secret")
+	// Trailing newline is intentional — mimics `echo`/`aws ssm get-parameter`
+	// output; envStringFromFile must trim it.
+	if err := os.WriteFile(accessPath, []byte("AKIAFROMFILE\n"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secretPath, []byte("  secretFromFile  \n"), 0o400); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &xtcp_config.XtcpConfig{}
+	// Inline env set too — the _FILE form should override it.
+	t.Setenv("S3_ACCESS_KEY", "inlineAccess")
+	t.Setenv("S3_SECRET_KEY", "inlineSecret")
+	t.Setenv("S3_ACCESS_KEY_FILE", accessPath)
+	t.Setenv("S3_SECRET_KEY_FILE", secretPath)
+	envOverrideMarshalAndDest(c, 0)
+	if c.S3AccessKey != "AKIAFROMFILE" {
+		t.Errorf("S3AccessKey = %q, want trimmed file contents", c.S3AccessKey)
+	}
+	if c.S3SecretKey != "secretFromFile" {
+		t.Errorf("S3SecretKey = %q, want trimmed file contents", c.S3SecretKey)
+	}
+}
+
+// TestEnvStringFromFileMissing: an unset env var, or a path that can't be
+// read, yields (_, false) and leaves config untouched (fail-fast downstream
+// rather than running with an empty credential silently overwriting a good one).
+func TestEnvStringFromFileMissing(t *testing.T) {
+	if v, ok := envStringFromFile("S3_SECRET_KEY_FILE_UNSET_FOR_TEST"); ok || v != "" {
+		t.Errorf("unset env: got (%q, %v), want (\"\", false)", v, ok)
+	}
+	t.Setenv("S3_SECRET_KEY_FILE_BADPATH", filepath.Join(t.TempDir(), "does-not-exist"))
+	if v, ok := envStringFromFile("S3_SECRET_KEY_FILE_BADPATH"); ok || v != "" {
+		t.Errorf("missing file: got (%q, %v), want (\"\", false)", v, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the Docker `_FILE` convention for the S3 credentials: the access/secret key can be read from a file whose path is given by `S3_ACCESS_KEY_FILE` / `S3_SECRET_KEY_FILE`, instead of an inline `S3_ACCESS_KEY` / `S3_SECRET_KEY` env value. Keeps the secret out of the process environment (`docker inspect`, `/proc/<pid>/environ`) and out of argv — the env only names a path; the credential bytes live in a file.

## Change
- New `envStringFromFile` helper: reads the path-valued env var, reads + `TrimSpace`s the file (handles a trailing newline from `echo`/SSM), logs a **non-secret** error on a set-but-unreadable path, returns `("", false)` so the destination fails fast on an empty credential.
- Applied **after** the inline `S3_ACCESS_KEY` / `S3_SECRET_KEY` blocks, so the file form wins when both are set (documented).
- Flag help updated; secret values remain unlogged.
- Tests: file contents trimmed + file-overrides-inline precedence; unset and unreadable-path both return `("", false)`.

## Review notes (verified)
- `nix build .#test-cmd-xtcp2 .#checks.x86_64-linux.golangci-lint` — green.
- Secret never logged; only the env *key name* and "set" appear at debug.
- Sits cleanly on top of the merged #55, so it diffs against `main` as just the `cmd/xtcp2` change (no stacking).

### Minor (non-blocking)
An *empty* secret file currently wins over a valid inline value (`("", true)` → empties the cred), which the "fail fast on empty" intent covers but is a slight footgun. If you'd prefer, a one-line guard could treat an empty/whitespace-only file as "not set" (fall back to inline). Happy to add it or leave as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)