### PR TITLE
docs: io_uring A/B findings — recommend leaving -ioUring off

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,7 +6,7 @@ Performance is the reason xtcp2 was rewritten. On a busy host with many namespac
 
 - [Pooled allocations (`pkg/xsync`)](#pooled-allocations-pkgxsync)
 - [Parallel netlink readers](#parallel-netlink-readers)
-- [io_uring fast path](#io_uring-fast-path)
+- [io_uring fast path (implemented, but not recommended)](#io_uring-fast-path-implemented-but-not-recommended)
 - [Runtime tuning](#runtime-tuning)
 - [PGO & profiling](#pgo--profiling)
 - [Configuration](#configuration)
@@ -20,19 +20,28 @@ The hot path recycles objects through `sync.Pool` rather than allocating per soc
 
 Each namespace runs `-netlinkers` reader goroutines (default 4) created by `pkg/xtcp/init_netlinkers.go`. Reads and deserialization happen in parallel, so a single namespace with many flows isn't bottlenecked on one goroutine draining the socket. Raise this on hosts with very high per-namespace flow counts. See [netlink collection](netlink-collection.md#netlinkers).
 
-## io_uring fast path
+## io_uring fast path (implemented, but not recommended)
 
-On Linux 6.1+ you can opt into an `io_uring`-based I/O path with `-ioUring`. Instead of blocking `recvfrom`/`sendto` syscalls, it submits batched `recvmsg` (netlink reads) and raw-socket write operations to an `io_uring` ring and reaps completions in batches, cutting syscall overhead on high-fanout hosts. The implementation:
+On Linux 6.1+ you can opt into an `io_uring`-based I/O path with `-ioUring`. Instead of blocking `recvfrom`/`sendto` syscalls, it submits batched `recvmsg` (netlink reads) and raw-socket write operations to an `io_uring` ring and reaps completions in batches. The implementation:
 
 - `pkg/io_uring/ring.go` — ring lifecycle, SQE submission, CQE reaping.
 - `pkg/xtcp/netlinker_iouring.go` — the `io_uring` variant of the netlinker.
+- Tuning: `-ioUringRecvBatch` (default 64, recvmsg SQEs in flight per netlinker, 1–4096) and `-ioUringCqeBatch` (default 128, max CQEs reaped per call, 1–4096). Ring memory is bounded by `RLIMIT_MEMLOCK`; `CAP_SYS_RESOURCE` lets the daemon raise it (see [observability](observability.md#capability-checks)). The `iouring-audit` flake check guards this code, and a coverage microVM exercises the path.
 
-Tuning:
+### Measured impact — and why we don't recommend it
 
-- `-ioUringRecvBatch` (default 64) — recvmsg SQEs kept in flight per netlinker (1–4096); higher reduces syscalls.
-- `-ioUringCqeBatch` (default 128) — max CQEs reaped per poll (1–4096).
+A controlled A/B (1 h each, identical stable workload, `io_uring` the only variable; see [stability-testing.md](stability-testing.md)) found **no kernel-load benefit** for xtcp2's netlink workload:
 
-`io_uring` ring memory is bounded by `RLIMIT_MEMLOCK`; `CAP_SYS_RESOURCE` lets the daemon raise it (see [observability](observability.md#capability-checks)). The `iouring-audit` flake check guards this code, and a dedicated coverage microVM exercises the path.
+| per netlink packet | syscall | io_uring |
+|---|---|---|
+| kernel CPU (`stime`) | 743 µs | 733 µs (−1.4%, noise) |
+| context switches | 0.086 | 0.083 |
+| RSS | ~56 MB | ~186 MB (**+232%**) |
+| dominant syscall | `recvfrom` (92.5%) | `io_uring_enter` (92.4%) |
+
+io_uring cleanly *replaces* `recvfrom` with `io_uring_enter` but doesn't lower per-packet kernel CPU, because **the cost is dominated by the kernel generating the `inet_diag` dump** (walking the socket table, serializing `tcp_info`/cong/meminfo — ~10 µs/socket), not by syscall entry/exit overhead (~0.1% of the per-packet cost). io_uring optimizes that 0.1%. It also doesn't reduce OS-thread usage — the io_uring netlinker still `runtime.LockOSThread()`s per netlinker (same `ns × netlinkers` [scaling](network-namespaces.md)). Net: same CPU, same thread count, **3× the memory**.
+
+**Recommendation: leave `-ioUring` off** (it already defaults off). The real levers for kernel load are reducing what the kernel has to dump — fewer attributes via `-deserializers`, or a lower poll `-frequency` — not the read mechanism. The flag and code are kept (tested, guarded) for completeness and for workloads that may differ.
 
 ## Runtime tuning
 
@@ -54,7 +63,7 @@ Earlier profiles showed `google.golang.org/protobuf/proto.Size` at ~40% of non-i
 - the size-cap keeps an **O(1) running byte accumulator** (`pkg/xtcp/deserialize.go`, `envelopeRowBytes` in `pkg/xtcp/marshallers.go`) — each row's exact wire size is added once at append time, equal to `proto.Size(Envelope)` but without the per-check walk;
 - the protobufList marshal uses **vtprotobuf**'s generated, reflection-free `SizeVT` / `MarshalToSizedBufferVT` (`pkg/recordfmt/marshal_envelope.go`).
 
-A retest under the same synthetic load shows total daemon CPU roughly halved and the entire `proto.Size`/reflective-marshal tree gone — the daemon is now netlink-I/O-bound (`Syscall6` is the dominant cost). The next CPU lever is the netlink read path itself (the optional [`io_uring`](#io_uring-fast-path) reader).
+A retest under the same synthetic load shows total daemon CPU roughly halved and the entire `proto.Size`/reflective-marshal tree gone — the daemon is now netlink-I/O-bound (`Syscall6` is the dominant cost). That remaining cost is the kernel generating the `inet_diag` dump; the lever for it is reducing what's dumped (`-deserializers`, poll `-frequency`), **not** the read mechanism — `io_uring` was tested and gave no benefit (see [below](#io_uring-fast-path-implemented-but-not-recommended)).
 
 ### Finding the bottleneck
 
@@ -89,7 +98,7 @@ Commit the updated `cmd/xtcp2/default.pgo`; the next build applies it automatica
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `-ioUring` | `false` | Enable the `io_uring` I/O path (Linux 6.1+). |
+| `-ioUring` | `false` | Enable the `io_uring` I/O path (Linux 6.1+). Tested — no measured benefit for this workload; leave off (see [io_uring section](#io_uring-fast-path-implemented-but-not-recommended)). |
 | `-ioUringRecvBatch` | `64` | recvmsg SQEs in flight per netlinker (1–4096). |
 | `-ioUringCqeBatch` | `128` | Max CQEs reaped per poll (1–4096). |
 | `-netlinkers` | `4` | Parallel netlink readers per namespace. |

--- a/docs/stability-testing.md
+++ b/docs/stability-testing.md
@@ -9,6 +9,7 @@ This document records the stability/performance testing campaign run against xtc
 - [Bugs found and fixed](#bugs-found-and-fixed)
 - [The OS-thread scaling model](#the-os-thread-scaling-model)
 - [Soak results](#soak-results)
+- [io_uring evaluation](#io_uring-evaluation)
 - [Operator guidance](#operator-guidance)
 - [Known limitation & future work](#known-limitation--future-work)
 - [How to reproduce](#how-to-reproduce)
@@ -89,8 +90,9 @@ backlog pushes the total past the 2,000 cap → crash.
 
 **io_uring does *not* avoid this.** The io_uring netlinker also
 `runtime.LockOSThread()`s for the ring's lifetime (one pinned thread per
-netlinker) and its wait is a blocking `io_uring_enter`. io_uring helps with
-*syscall batching*, not thread count.
+netlinker) and its wait is a blocking `io_uring_enter` — same thread cost. (And
+as the [io_uring evaluation](#io_uring-evaluation) below shows, it doesn't reduce
+kernel CPU either.)
 
 The only approach that decouples thread count from `ns × netlinkers` is reading
 netlink non-blocking through Go's runtime poller (readers park instead of
@@ -110,6 +112,41 @@ The 12 h soak ran the worst case: ~200 namespaces churned at 100 ms add/delete.
 draining many churning sockets) — a steady-state degradation, not a leak. Real
 deployments with stable containers and low churn do far less per-poll work.
 
+## io_uring evaluation
+
+We implemented and benchmarked the optional `io_uring` netlink reader (`-ioUring`)
+to test the hypothesis that its shared-memory ring + batched syscalls would
+reduce kernel load. A **controlled A/B** on the stable `tcp-stress` workload —
+1 h each, `io_uring` the only variable, `-d 1` so logging doesn't confound CPU —
+showed it does **not** help this workload:
+
+| per netlink packet | syscall | io_uring | Δ |
+|---|---|---|---|
+| kernel CPU (`stime`) | 743 µs | 733 µs | −1.4% (noise) |
+| context switches | 0.086 | 0.083 | −3.4% |
+| kernel/user CPU ratio | 4.14 | 4.10 | −0.8% |
+| RSS | ~56 MB | ~186 MB | **+232%** |
+| dominant syscall (`strace -c`) | `recvfrom` 92.5% (2,115 calls) | `io_uring_enter` 92.4% (3,467 calls) | replaced, not reduced |
+
+**Why:** io_uring cleanly replaces `recvfrom` with `io_uring_enter`, but per-packet
+kernel CPU is unchanged because the cost is dominated by the kernel **generating
+the `inet_diag` dump** (walking the socket table + serializing `tcp_info`/cong/
+meminfo — roughly ~10 µs/socket, ~99.9% of the per-packet cost), not by syscall
+entry/exit overhead (~1 µs/packet, ~0.1%). io_uring optimizes the 0.1%. It also
+gives no thread benefit — the io_uring netlinker still `LockOSThread`s per
+netlinker (same `ns × netlinkers` scaling). Net: same CPU, same thread count,
+**3× the memory** for the ring buffers.
+
+io_uring wins for high-frequency *small* I/O where syscall overhead dominates;
+netlink `inet_diag` dumps are the opposite (infrequent, large, kernel-generation-
+heavy). No io_uring config rescues it: bigger batches don't touch dump-gen, and
+`SQPOLL` would burn a dedicated kernel thread per ring (more system CPU, not
+less). The real lever for kernel load is **reducing what the kernel dumps**
+(`-deserializers`, poll `-frequency`).
+
+**Verdict: leave `-ioUring` off.** The code/flag are kept (tested, `iouring-audit`
+guarded) for completeness; the default is correct. See [performance.md](performance.md).
+
 ## Operator guidance
 
 For a deployment of **up to ~200 containers** (namespaces):
@@ -121,9 +158,9 @@ For a deployment of **up to ~200 containers** (namespaces):
 - `-netlinkers 1` is also validated (the 12 h soak config) and has the smallest
   footprint (~400 threads); choose it if your per-namespace socket volume is
   low. `-netlinkers 2` is the recommended balance for production.
-- **Do not reach for `-ioUring` to reduce threads** — it has the same
-  `ns × netlinkers` thread cost. Use it only for syscall batching on very
-  high-throughput single hosts.
+- **Leave `-ioUring` off.** It was tested and gives no benefit for this workload —
+  same kernel CPU/packet, same `ns × netlinkers` thread cost, and +232% RSS (see
+  [io_uring evaluation](#io_uring-evaluation)).
 - Rule of thumb for any config: keep `-maxThreads` (and systemd
   `TasksMax`/`LimitNPROC`, default 8192 in the microVMs) above
   `namespaces × (netlinkers + 1)` with healthy margin.


### PR DESCRIPTION
## Summary

Documents the io_uring evaluation: we implemented and benchmarked the optional `-ioUring` netlink reader, and a controlled A/B shows it gives **no kernel-load benefit** for xtcp2's workload — so the docs now recommend leaving it off (it already defaults off). Implementing + testing it was worthwhile; this records *why* not to use it.

## The finding (controlled A/B, tcp-stress, 1 h each, io_uring the only variable)

| per netlink packet | syscall | io_uring |
|---|---|---|
| kernel CPU (`stime`) | 743 µs | 733 µs (−1.4%, noise) |
| context switches | 0.086 | 0.083 |
| RSS | ~56 MB | ~186 MB (**+232%**) |
| dominant syscall | `recvfrom` 92.5% | `io_uring_enter` 92.4% |

**Why:** io_uring replaces `recvfrom` with `io_uring_enter` but per-packet kernel CPU is unchanged, because the cost is dominated by the kernel **generating the `inet_diag` dump** (socket-table walk + `tcp_info` serialization, ~10 µs/socket ≈ 99.9%), not syscall entry/exit overhead (~0.1%). io_uring optimizes the 0.1%. It also gives no thread benefit (still `LockOSThread` per netlinker). Net: same CPU, same threads, 3× memory.

## Changes
- `docs/performance.md` — rewrote the io_uring section (retitled "implemented, but not recommended") with the measured table, the root-cause explanation, and the recommendation; fixed the now-incorrect "next CPU lever is io_uring" line (the real lever is reducing what's dumped via `-deserializers` / poll `-frequency`); annotated the `-ioUring` config-table row.
- `docs/stability-testing.md` — added an "io_uring evaluation" section and aligned the OS-thread-model + operator-guidance mentions.

Docs-only; anchors and cross-links verified. The flag and code stay (tested, `iouring-audit`-guarded) for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)