### PR TITLE
build(nix): pin Go toolchain to 1.26.5 (security fixes)

### DIFF
--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -8,9 +8,16 @@
 { pkgs }:
 
 {
-  # Go toolchain. Must satisfy go.mod's `go 1.25` directive.
-  # nixpkgs unstable should have go_1_25; fall back to `go` (latest) if not.
-  go = pkgs.go_1_25 or pkgs.go;
+  # Go toolchain — pinned to 1.26.5 for its security fixes. The pinned nixpkgs
+  # only packages go_1_26 = 1.26.2, so override the version + source to 1.26.5
+  # until nixpkgs catches up (then this can drop back to plain `pkgs.go_1_26`).
+  go = pkgs.go_1_26.overrideAttrs (_old: rec {
+    version = "1.26.5";
+    src = pkgs.fetchurl {
+      url = "https://go.dev/dl/go${version}.src.tar.gz";
+      hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
+    };
+  });
 
   # protobuf tooling
   buf = pkgs.buf;


### PR DESCRIPTION
## Summary

Pins the Go toolchain to **1.26.5** for its security fixes.

The pinned nixpkgs only packages `go_1_26` = **1.26.2** (1.26.5 just released), so `nix/versions.nix` overrides the Go derivation's `version` + `src` to 1.26.5. When nixpkgs packages 1.26.5+, this can drop back to plain `pkgs.go_1_26`.

- `go.mod`'s `go 1.25` floor is left unchanged — a 1.26.5 toolchain satisfies it, and keeping it avoids `go mod tidy`/vendor churn. (Happy to bump it to `go 1.26` if you'd prefer the project to require 1.26.)
- `goVendorHash` unchanged (module set is toolchain-independent).

## Verification

```
nix develop -c go version            # go version go1.26.5 linux/amd64
nix build .#xtcp2-s3parquet          # builds on 1.26.5
nix build .#test-cmd-xtcp2           # pass
nix build .#test-go-flavor-s3parquet # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)