### PR TITLE
fix(nix): build binaries with the pinned Go (versions.go), not pkgs.go

### DIFF
--- a/nix/lib/goModules.nix
+++ b/nix/lib/goModules.nix
@@ -28,7 +28,7 @@ let
   # in the repo, including pkg/clickhouse_protolist, pkg/xtcp_config, etc.) so
   # that lint checks can type-check them. Restricting subPackages omits deps
   # of unbuilt packages from vendor/.
-  parent = pkgs.buildGoModule {
+  parent = (pkgs.buildGoModule.override { inherit (versions) go; }) {
     pname = "xtcp2";
     version = "vendored";
     inherit src vendorHash;

--- a/nix/lib/mkGoBinary.nix
+++ b/nix/lib/mkGoBinary.nix
@@ -26,7 +26,10 @@ let
   versions = import ../versions.nix { inherit pkgs; };
   patchGoMod = import ./patchGoMod.nix { inherit giouring; };
 
-  buildGoModule = pkgs.buildGoModule;
+  # Build with the pinned Go toolchain (versions.go = 1.26.5), not pkgs'
+  # default `go` — otherwise the compiled binary uses whatever pkgs.go
+  # resolves to, defeating the version pin.
+  buildGoModule = pkgs.buildGoModule.override { inherit (versions) go; };
 in
 {
   name,


### PR DESCRIPTION
## Summary

Follow-up to #64. That PR pinned `versions.go` to 1.26.5, but the **binary build didn't actually use it** — `nix/lib/mkGoBinary.nix` and `nix/lib/goModules.nix` called plain `pkgs.buildGoModule`, which uses pkgs' default `go` (1.26.2 at the pinned nixpkgs). So the dev shell got 1.26.5 but the **compiled binary was still go1.26.2**.

Fix: override `buildGoModule`'s `go` with `versions.go` in both places:

```nix
buildGoModule = pkgs.buildGoModule.override { inherit (versions) go; };
```

## Verification

```
nix build .#xtcp2-s3parquet
go version ./result/bin/xtcp2        # -> go1.26.5  (was go1.26.2)
nix build .#test-cmd-xtcp2           # pass
nix build .#test-go-flavor-s3parquet # pass
```

`goVendorHash` unchanged (vendored module set is toolchain-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)