### PR TITLE
feat(health): -healthcheck mode + self-contained container HEALTHCHECK

### DIFF
--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -219,6 +219,7 @@ type mainFlags struct {
 	deserializers       *string
 	promListen          *string
 	promPath            *string
+	healthcheck         *bool
 	goMaxProcs          *uint
 	maxThreads          *int
 	profileMode         *string
@@ -278,6 +279,7 @@ func defineFlags() *mainFlags {
 	f.deserializers = flag.String("deserializers", deserializersCst, fmt.Sprintf("Comma separated list of deserializers,%v", xtcp.GetAllDeserializers()))
 	f.promListen = flag.String("promListen", promListenCst, "Prometheus http listening socket")
 	f.promPath = flag.String("promPath", promPathCst, "Prometheus http path")
+	f.healthcheck = flag.Bool("healthcheck", false, "probe the local /readyz endpoint and exit 0 (ready) / 1 (not ready or unreachable), then exit WITHOUT starting the daemon. For a container HEALTHCHECK on the scratch image (no shell/curl); uses -promListen / PROM_LISTEN to find the port.")
 	// Maximum number of CPUs that can be executing simultaneously
 	// https://golang.org/pkg/runtime/#GOMAXPROCS -> zero (0) means default
 	f.goMaxProcs = flag.Uint("goMaxProcs", 4, "goMaxProcs = https://golang.org/pkg/runtime/#GOMAXPROCS")
@@ -562,6 +564,13 @@ func runMain(parentCtx context.Context) int {
 	f := defineFlags()
 	flag.Parse()
 
+	// Container HEALTHCHECK mode: probe the local /readyz and exit, without
+	// starting the daemon. The scratch image has no shell/curl, so the binary
+	// self-checks (same pattern as the docker_custom_scrape exporter).
+	if *f.healthcheck {
+		return runHealthcheck(*f.promListen)
+	}
+
 	c, done := prepareConfig(f)
 	if done {
 		return 0
@@ -719,6 +728,35 @@ func servePromHandler(promListen string, ipv4TTL, ipv6HopLimit uint32) {
 	if err := srv.Serve(ln); err != nil {
 		fatalf("prometheus error: %v", err)
 	}
+}
+
+// runHealthcheck probes the local /readyz endpoint and returns a process exit
+// code: 0 when ready (HTTP 200), 1 otherwise (not ready, or unreachable). It is
+// the `-healthcheck` mode used by the container HEALTHCHECK on the scratch image
+// (no shell/curl to run an external probe). The port comes from PROM_LISTEN or
+// the -promListen flag; the daemon listens on 0.0.0.0, so 127.0.0.1 reaches it.
+func runHealthcheck(promListen string) int {
+	addr := promListen
+	if v, ok := os.LookupEnv("PROM_LISTEN"); ok && v != "" {
+		addr = v
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil || port == "" {
+		port = "9088" // promListenCst default
+	}
+	url := "http://127.0.0.1:" + port + "/readyz"
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Printf("healthcheck: GET %s: %v", url, err)
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		return 0
+	}
+	log.Printf("healthcheck: %s -> %d", url, resp.StatusCode)
+	return 1
 }
 
 // environmentOverrideProm MUTATES promListen, promPath, if the environment

--- a/cmd/xtcp2/xtcp2_test.go
+++ b/cmd/xtcp2/xtcp2_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -412,6 +414,34 @@ func TestAwaitSignalAndShutdown_completeBeforeTimeout(t *testing.T) {
 
 // servePromHandler error path with an invalid address forces
 // ListenAndServe to fail; fatalf captures the message.
+func TestRunHealthcheck(t *testing.T) {
+	portOf := func(url string) string {
+		_, p, _ := net.SplitHostPort(strings.TrimPrefix(url, "http://"))
+		return p
+	}
+
+	notReady := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer notReady.Close()
+	if rc := runHealthcheck(":" + portOf(notReady.URL)); rc != 1 {
+		t.Errorf("not-ready: rc=%d, want 1", rc)
+	}
+
+	ready := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ready.Close()
+	if rc := runHealthcheck(":" + portOf(ready.URL)); rc != 0 {
+		t.Errorf("ready: rc=%d, want 0", rc)
+	}
+
+	// Nothing listening -> unreachable -> 1.
+	if rc := runHealthcheck(":1"); rc != 1 {
+		t.Errorf("unreachable: rc=%d, want 1", rc)
+	}
+}
+
 func TestServePromHandler_bindError(t *testing.T) {
 	prev := fatalf
 	var captured string

--- a/nix/containers/default.nix
+++ b/nix/containers/default.nix
@@ -31,6 +31,22 @@
 let
   mkOciImage = import ../lib/mkOciImage.nix { inherit pkgs lib; };
 
+  # Self-contained container HEALTHCHECK for the xtcp2-daemon images (scratch,
+  # no shell/curl): the binary probes its own /readyz via `-healthcheck`.
+  # Durations are integer nanoseconds. NOT applied to the tcp-stress image
+  # (different entrypoint, no daemon).
+  xtcp2Healthcheck = {
+    Test = [
+      "CMD"
+      "/bin/xtcp2"
+      "-healthcheck"
+    ];
+    Interval = 30000000000; # 30s
+    Timeout = 5000000000; # 5s
+    StartPeriod = 15000000000; # 15s — grace while the daemon reaches ready
+    Retries = 3;
+  };
+
   # tcp-stress-only image: just tcp_server + tcp_client + an entrypoint
   # shell script that dispatches on TCP_MODE. Used by the Phase C
   # docker-in-VM lifecycle harness to spin up N containers with
@@ -116,6 +132,7 @@ let
         8889
       ];
       entrypoint = "/bin/xtcp2";
+      healthcheck = xtcp2Healthcheck;
     };
 
   mkFlavorImage =
@@ -130,6 +147,7 @@ let
         8889
       ];
       entrypoint = "/bin/xtcp2";
+      healthcheck = xtcp2Healthcheck;
     };
 in
 {

--- a/nix/lib/mkOciImage.nix
+++ b/nix/lib/mkOciImage.nix
@@ -19,6 +19,10 @@
   protoFile ? null, # path to the .proto file to ship at /<basename>
   exposedPorts ? [ ],
   entrypoint ? "/bin/xtcp2",
+  # Optional Docker HEALTHCHECK image-config block. Durations are integer
+  # nanoseconds (Docker image-config convention), e.g.
+  #   { Test = [ "CMD" "/bin/xtcp2" "-healthcheck" ]; Interval = 30000000000; }
+  healthcheck ? null,
 }:
 
 let
@@ -45,5 +49,6 @@ pkgs.dockerTools.streamLayeredImage {
   config = {
     Entrypoint = [ entrypoint ];
     ExposedPorts = exposedPortsAttr;
-  };
+  }
+  // lib.optionalAttrs (healthcheck != null) { Healthcheck = healthcheck; };
 }


### PR DESCRIPTION
## Summary

Makes the health endpoints usable as a **Docker `HEALTHCHECK`** on the `FROM scratch` images. Since there's no shell/curl in the image to run an external probe, the binary self-checks — the same pattern the `docker_custom_scrape` exporter uses.

## What

- **`cmd/xtcp2 -healthcheck`**: probes `http://127.0.0.1:<promPort>/readyz` and exits **0** (ready) / **1** (not ready or unreachable), *without* starting the daemon. Port from `-promListen` / `PROM_LISTEN`.
- **Baked `HEALTHCHECK`** in the xtcp2-daemon OCI images: `CMD ["/bin/xtcp2","-healthcheck"]`, `30s` interval / `5s` timeout / `15s` start-period / `3` retries. Added a `healthcheck` param to `mkOciImage` and applied it to `mkFatImage` + `mkFlavorImage` (all six flavors incl. `s3parquet`). Not applied to the `tcp-stress` image (different entrypoint, no daemon).

Downstream images that are `FROM` these (e.g. the RunPod s3parquet bake) inherit the `HEALTHCHECK`, so Docker/orchestration gets readiness for free — no per-deployment wiring.

## Verification

```
docker inspect xtcp2:s3parquet --format '{{json .Config.Healthcheck}}'
# {"Test":["CMD","/bin/xtcp2","-healthcheck"],"Interval":30000000000,...}

docker run --rm --network host xtcp2:s3parquet -healthcheck   # nothing listening
# healthcheck: ... connection refused ; exit 1

nix build .#test-cmd-xtcp2   # TestRunHealthcheck: 200->0, 503->1, unreachable->1
```

It probes `/readyz` (not `/healthz`) so "healthy" means the daemon is actually collecting; the `15s` start-period covers the pre-ready window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)