### PR TITLE
feat(dest): default -dest to the sole compiled-in destination

### DIFF
--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -116,8 +116,16 @@ const (
 	pyroscopeSampleHzCst  uint = 100
 	pyroscopeUploadSecCst uint = 15
 
-	// Redpanda
+	// destCst is the `-dest` fallback used when the binary compiles in
+	// several library destinations (the "full" flavor) — kafka is the
+	// historical default. A binary with exactly one library destination
+	// defaults to that destination instead; one with none defaults to
+	// stdoutDestCst. See defaultDest.
 	destCst = "kafka:redpanda-0:9092"
+	// stdoutDestCst is the `-dest` default for the "min" flavor (no library
+	// destinations compiled in): an always-compiled sink so the binary boots
+	// without the operator having to pass -dest.
+	stdoutDestCst = "stdout"
 	// destCst = "udp:127.0.0.1:13000"
 	// destCst = "nsq:nsqd:4150"
 	// destCst = "nats:nats:8222"
@@ -235,6 +243,31 @@ type mainFlags struct {
 	ioUringCqeBatch     *uint
 }
 
+// defaultDestFor picks the `-dest` default from the library destinations
+// compiled into this binary: the sole one's registered default when exactly
+// one is present, stdoutDestCst when none are (the "min" flavor), and destCst
+// (kafka) when several are (the "full" flavor). lookup resolves a scheme to
+// its registered default (xtcp.LibraryDefaultDest in production; a stub in
+// tests). Kept pure so the branching is unit-testable without global state.
+func defaultDestFor(libs []string, lookup func(string) string) string {
+	switch len(libs) {
+	case 1:
+		return lookup(libs[0])
+	case 0:
+		return stdoutDestCst
+	default:
+		return destCst
+	}
+}
+
+// defaultDest is the `-dest` flag default, derived from the destinations
+// linked into this binary. init() funcs in pkg/xtcp populate the registry
+// before defineFlags runs, so the compiled-in set is known here. An explicit
+// -dest flag or DEST env var still overrides this (it is only the default).
+func defaultDest() string {
+	return defaultDestFor(xtcp.CompiledInLibrarySchemes(), xtcp.LibraryDefaultDest)
+}
+
 func defineFlags() *mainFlags {
 	f := &mainFlags{}
 	f.nltimeout = flag.Uint64("nltimeout", nltimeoutCst, "Netlink socket timeout in milliseconds.  Zero(0) for no timeout")
@@ -262,7 +295,7 @@ func defineFlags() *mainFlags {
 	f.s3Region = flag.String("s3Region", s3RegionCst, "s3parquet: S3 region. Defaults to 'us-east-1' when empty; required by AWS, ignored by most MinIO setups.")
 	f.s3SkipBucketProbe = flag.Bool("s3SkipBucketProbe", s3SkipBucketProbeCst, "s3parquet: skip the startup BucketExists probe (a HeadBucket needing s3:ListBucket). Set true for a write-only, s3:PutObject-only credential. Falls back to S3_SKIP_BUCKET_PROBE env.")
 	f.s3ParquetFlushBytes = flag.Uint("s3ParquetFlushBytes", s3ParquetFlushThresholdBytesCst, "s3parquet: soft cap on the in-memory Parquet builder's uncompressed row bytes before finalize+upload. 0 = daemon default (63 MiB).")
-	f.dest = flag.String("dest", destCst, "scheme:addr — kafka:host:9092, nats:..., nsq:..., valkey:..., udp:host:13000, tcp:host:9000, unix:/path, unixgram:/path, file:/path, http(s)://host/ingest, s3parquet:..., stdout, stderr, null (pair stdout/file/tcp with -marshal jsonl|csv|tsv)")
+	f.dest = flag.String("dest", defaultDest(), "scheme:addr — kafka:host:9092, nats:..., nsq:..., valkey:..., udp:host:13000, tcp:host:9000, unix:/path, unixgram:/path, file:/path, http(s)://host/ingest, s3parquet:..., stdout, stderr, null (pair stdout/file/tcp with -marshal jsonl|csv|tsv)")
 	f.destWriteFiles = flag.Uint("destWriteFiles", DestWriteFilesCst, "Write out the marshaled data to destWriteFiles number of files ( for debugging only )")
 	f.topic = flag.String("topic", topicCst, "Kafka or NSQ topic")
 	f.xtcpProtoFile = flag.String("xtcpProtoFile", xtcpProtoFileCst, "xtcpProtoFile for registering with the schema registry")

--- a/cmd/xtcp2/xtcp2_test.go
+++ b/cmd/xtcp2/xtcp2_test.go
@@ -973,3 +973,27 @@ func TestPrepareConfig_runPath(t *testing.T) {
 		t.Error("non-short-circuit path should produce a non-nil config")
 	}
 }
+
+func TestDefaultDestFor(t *testing.T) {
+	// lookup stub returns a recognizable default per scheme so we can assert
+	// the single-library branch resolves through it.
+	lookup := func(scheme string) string { return scheme + ":resolved" }
+
+	tests := []struct {
+		name string
+		libs []string
+		want string
+	}{
+		{"no library dests → stdout (min flavor)", nil, stdoutDestCst},
+		{"empty slice → stdout", []string{}, stdoutDestCst},
+		{"single library dest → its default", []string{"s3parquet"}, "s3parquet:resolved"},
+		{"multiple library dests → kafka (full flavor)", []string{"kafka", "nats"}, destCst},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultDestFor(tt.libs, lookup); got != tt.want {
+				t.Errorf("defaultDestFor(%v) = %q, want %q", tt.libs, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/xtcp/destinations_core.go
+++ b/pkg/xtcp/destinations_core.go
@@ -66,6 +66,14 @@ var knownSchemes = []string{
 var (
 	destRegistryMu sync.RWMutex
 	destRegistry   = map[string]DestinationFactory{}
+
+	// libraryDefaultDest maps a library (build-tag-gated) destination scheme
+	// to the canonical `-dest` value the CLI should default to. Populated
+	// from the same init() that calls RegisterDestination. Stdlib
+	// destinations (null/stdout/file/tcp/...) register none, so registering a
+	// default is what marks a scheme as a "library" destination for
+	// auto-defaulting. Guarded by destRegistryMu.
+	libraryDefaultDest = map[string]string{}
 )
 
 // RegisterDestination wires a factory into the runtime dispatch map. Called
@@ -84,6 +92,40 @@ func RegisterDestination(scheme string, f DestinationFactory) {
 		panic(fmt.Sprintf("xtcp: RegisterDestination called twice for scheme %q — duplicate //go:build tag?", scheme))
 	}
 	destRegistry[scheme] = f
+}
+
+// RegisterLibraryDefaultDest records the canonical `-dest` value for a
+// library (build-tag-gated) destination. The CLI uses it as the default
+// `-dest` when exactly one library destination is compiled into the binary,
+// so a single-destination build (e.g. s3parquet-only) works without the
+// operator overriding the default. Called from the same init() as
+// RegisterDestination; stdlib destinations register none and thus never
+// participate in auto-defaulting.
+func RegisterLibraryDefaultDest(scheme, dest string) {
+	destRegistryMu.Lock()
+	defer destRegistryMu.Unlock()
+	libraryDefaultDest[scheme] = dest
+}
+
+// CompiledInLibrarySchemes returns the sorted list of library-destination
+// schemes linked into this binary (those that registered a default dest).
+func CompiledInLibrarySchemes() []string {
+	destRegistryMu.RLock()
+	defer destRegistryMu.RUnlock()
+	out := make([]string, 0, len(libraryDefaultDest))
+	for s := range libraryDefaultDest {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LibraryDefaultDest returns the registered default `-dest` for a library
+// scheme, or "" if the scheme registered none / is not compiled in.
+func LibraryDefaultDest(scheme string) string {
+	destRegistryMu.RLock()
+	defer destRegistryMu.RUnlock()
+	return libraryDefaultDest[scheme]
 }
 
 // IsKnownScheme reports whether scheme was ever a valid xtcp2 destination

--- a/pkg/xtcp/destinations_core_test.go
+++ b/pkg/xtcp/destinations_core_test.go
@@ -1,0 +1,51 @@
+package xtcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+// withEmptyLibraryDefaults swaps libraryDefaultDest for an empty map for the
+// duration of the test and restores it afterwards. The default test binary
+// compiles in no library destinations (no dest_* build tags), so the map is
+// already empty, but saving/restoring keeps the tests independent of build
+// tags and of one another.
+func withEmptyLibraryDefaults(t *testing.T) {
+	t.Helper()
+	destRegistryMu.Lock()
+	saved := libraryDefaultDest
+	libraryDefaultDest = map[string]string{}
+	destRegistryMu.Unlock()
+	t.Cleanup(func() {
+		destRegistryMu.Lock()
+		libraryDefaultDest = saved
+		destRegistryMu.Unlock()
+	})
+}
+
+func TestLibraryDefaultDestRegistry(t *testing.T) {
+	withEmptyLibraryDefaults(t)
+
+	// Zero library destinations: no schemes, no defaults.
+	if got := CompiledInLibrarySchemes(); len(got) != 0 {
+		t.Fatalf("CompiledInLibrarySchemes on empty registry = %v, want empty", got)
+	}
+	if got := LibraryDefaultDest("kafka"); got != "" {
+		t.Fatalf("LibraryDefaultDest(kafka) on empty registry = %q, want \"\"", got)
+	}
+
+	// One library destination.
+	RegisterLibraryDefaultDest("s3parquet", "s3parquet:")
+	if got, want := CompiledInLibrarySchemes(), []string{"s3parquet"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CompiledInLibrarySchemes = %v, want %v", got, want)
+	}
+	if got, want := LibraryDefaultDest("s3parquet"), "s3parquet:"; got != want {
+		t.Fatalf("LibraryDefaultDest(s3parquet) = %q, want %q", got, want)
+	}
+
+	// Two library destinations: result is sorted.
+	RegisterLibraryDefaultDest("kafka", "kafka:redpanda-0:9092")
+	if got, want := CompiledInLibrarySchemes(), []string{"kafka", "s3parquet"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CompiledInLibrarySchemes = %v, want sorted %v", got, want)
+	}
+}

--- a/pkg/xtcp/destinations_kafka.go
+++ b/pkg/xtcp/destinations_kafka.go
@@ -344,4 +344,5 @@ func resolveKafkaCompression(name string) ([]kgo.CompressionCodec, error) {
 
 func init() {
 	RegisterDestination("kafka", newKafkaDest)
+	RegisterLibraryDefaultDest("kafka", "kafka:redpanda-0:9092")
 }

--- a/pkg/xtcp/destinations_nats.go
+++ b/pkg/xtcp/destinations_nats.go
@@ -107,4 +107,5 @@ func (d *natsDest) Close() error {
 
 func init() {
 	RegisterDestination("nats", newNATSDest)
+	RegisterLibraryDefaultDest("nats", "nats:nats:8222")
 }

--- a/pkg/xtcp/destinations_nsq.go
+++ b/pkg/xtcp/destinations_nsq.go
@@ -80,4 +80,5 @@ func (d *nsqDest) Close() error {
 
 func init() {
 	RegisterDestination("nsq", newNSQDest)
+	RegisterLibraryDefaultDest("nsq", "nsq:nsqd:4150")
 }

--- a/pkg/xtcp/destinations_s3parquet.go
+++ b/pkg/xtcp/destinations_s3parquet.go
@@ -642,4 +642,8 @@ func rowFromProto(r *xtcp_flat_record.XtcpFlatRecord) ParquetRow {
 
 func init() {
 	RegisterDestination(schemeS3Parquet, newS3ParquetDest)
+	// Bare scheme: the endpoint/bucket come from -s3Endpoint/S3_ENDPOINT etc.
+	// (newS3ParquetDest falls back to config.S3Endpoint when the dest payload
+	// is empty).
+	RegisterLibraryDefaultDest(schemeS3Parquet, schemeS3Parquet+":")
 }

--- a/pkg/xtcp/destinations_valkey.go
+++ b/pkg/xtcp/destinations_valkey.go
@@ -120,4 +120,5 @@ func (d *valkeyDest) Close() error {
 
 func init() {
 	RegisterDestination("valkey", newValKeyDest)
+	RegisterLibraryDefaultDest("valkey", "valkey:valkey:6379")
 }


### PR DESCRIPTION
## Problem

The `-dest` flag default was the hardcoded constant `kafka:redpanda-0:9092` regardless of which destinations were compiled in via build tags. A binary built **without** kafka (e.g. the s3parquet image) still defaulted to kafka and failed semantic validation at daemon start:

```
destination "kafka" is not compiled into this binary; rebuild with '-tags dest_kafka' ...
Compiled-in destinations: [file http https null s3parquet stderr stdout tcp udp unix unixgram]
```

Operators had to remember to pass `-dest`/`DEST` on every deployment of a single-destination image.

## Change

Derive the `-dest` default from what the binary actually links in. Each library (build-tag-gated) destination registers its canonical default via a new `RegisterLibraryDefaultDest`, next to `RegisterDestination` in its `init()`. The CLI resolves the flag default from the registry:

| Compiled-in library destinations | default `-dest` |
|---|---|
| exactly one | that destination's default (e.g. `s3parquet:`, `kafka:redpanda-0:9092`) |
| none (`min` flavor) | `stdout` |
| several (`full` flavor) | `kafka:redpanda-0:9092` (unchanged) |

Only the flag's *default value* changes, so an explicit `-dest` flag or `DEST` env var still overrides it. Stdlib destinations (`null`/`stdout`/`file`/`tcp`/...) register no default and never participate in auto-defaulting — registering a default is what marks a scheme as a "library" destination.

## Files

- `pkg/xtcp/destinations_core.go` — `libraryDefaultDest` map + `RegisterLibraryDefaultDest` / `CompiledInLibrarySchemes` / `LibraryDefaultDest`
- `destinations_{kafka,s3parquet,nats,nsq,valkey}.go` — one registration line each in `init()`
- `cmd/xtcp2/xtcp2.go` — `stdoutDestCst`, pure `defaultDestFor` + `defaultDest`, `-dest` flag default
- tests: `pkg/xtcp/destinations_core_test.go`, `TestDefaultDestFor` in `cmd/xtcp2/xtcp2_test.go`

## Verification

`go test ./pkg/xtcp/... ./cmd/xtcp2/...` passes; gofmt + vet clean. Per-flavor `-conf` output:

| build tags | `c.Dest` |
|---|---|
| `dest_s3parquet` | `s3parquet:` |
| `dest_kafka` | `kafka:redpanda-0:9092` |
| `dest_nats` | `nats:nats:8222` |
| none (min) | `stdout` |
| all (full) | `kafka:redpanda-0:9092` |

Overrides confirmed: `-dest null` and `DEST=null` both win over the computed default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)