### PR TITLE
fix(s3parquet): thread ctx into the worker (contextcheck)

### DIFF
--- a/pkg/xtcp/destinations_s3parquet.go
+++ b/pkg/xtcp/destinations_s3parquet.go
@@ -221,7 +221,7 @@ func newS3ParquetDest(ctx context.Context, x *XTCP) (Destination, error) {
 		closedCh:           make(chan struct{}),
 		workerDone:         make(chan struct{}),
 	}
-	go d.worker()
+	go d.worker(ctx)
 	return d, nil
 }
 
@@ -336,7 +336,11 @@ func (d *s3ParquetDest) Close() error {
 // row to the in-memory writer, and finalizes + uploads when the
 // accumulated byte threshold is reached. On queue close (Close was
 // called) finalizes whatever's left and exits.
-func (d *s3ParquetDest) worker() {
+//
+// ctx is the daemon run context; the upload derives from it via
+// context.WithoutCancel (see finalize) so the final shutdown flush isn't
+// aborted when the daemon ctx is cancelled.
+func (d *s3ParquetDest) worker(ctx context.Context) {
 	defer close(d.workerDone)
 
 	var (
@@ -373,7 +377,12 @@ func (d *s3ParquetDest) worker() {
 			startBuilder()
 			return
 		}
-		uploadCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		// WithoutCancel is deliberate: on shutdown the daemon ctx is
+		// cancelled, but the final partial-Parquet flush (driven by Close)
+		// must still upload. Strip cancellation while keeping the 60s
+		// deadline + any ctx values. Mirrors the poller's shutdown flush
+		// (poller.go's context.WithoutCancel).
+		uploadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 		key := d.objectKey()
 		d.uploadWithRetry(uploadCtx, key, buf, fileRows)
 		cancel()

--- a/pkg/xtcp/destinations_s3parquet_test.go
+++ b/pkg/xtcp/destinations_s3parquet_test.go
@@ -126,7 +126,7 @@ func newS3ParquetFixtureCustom(t *testing.T, threshold int, injectErr func(int) 
 	if customize != nil {
 		customize(d)
 	}
-	go d.worker()
+	go d.worker(context.Background())
 	return d, upl, x
 }
 


### PR DESCRIPTION
## What

The s3parquet worker was started as `go d.worker()` with no context, and its `finalize` closure built the upload context from `context.Background()`. golangci-lint's `contextcheck` flags this:

```
pkg/xtcp/destinations_s3parquet.go: Function `worker->worker$2` should pass the context parameter (contextcheck)
	go d.worker()
```

This finding pre-dates the fleet-jitter PR (#69) — it was present on `main` before that work and left untouched. This PR addresses it.

## How

Thread `newS3ParquetDest`'s `ctx` (the daemon run context from `InitDests`) into `worker(ctx)`, and derive the upload context via **`context.WithoutCancel`**:

```go
uploadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
```

This propagates the context (satisfying `contextcheck`) while **stripping cancellation**, which is deliberate: on shutdown the daemon ctx is cancelled, but the final partial-Parquet flush (driven by `Close()`) must still upload. It mirrors the poller's shutdown flush, which already uses `context.WithoutCancel(ctx)`.

## Behavior

No change. The daemon ctx is only cancelled at shutdown, and `WithoutCancel` preserves today's "final flush still uploads" semantics — verified by the Close-triggered `TestS3ParquetDest_positive` and the time-flush / backoff tests still passing.

## Verification

- `golangci-lint run --modules-download-mode=mod --build-tags dest_s3parquet ./pkg/xtcp/...` → **0 issues** (was the lone `contextcheck` finding).
- `go test -ldflags=-checklinkname=0 -tags dest_s3parquet ./pkg/xtcp/... ./cmd/xtcp2/...` green.
- gofmt clean.

## Note (out of scope)

`destinations_kafka.go` uses the same `context.Background()` flush pattern but isn't currently flagged (only linted under `-tags dest_s3parquet`). Happy to do a tiny follow-up to make the pattern consistent across library destinations if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)