### PR TITLE
Namespace-discovery A/B benchmark + design (dir-scan vs /proc-scan)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Run `nix flake show` for the complete, current list. The main groups:
 
 ### MicroVM integration tests (`nix build .#microvm-x86_64*` / `nix run .#microvm-x86_64-*`)
 
-Boot xtcp2 inside a QEMU microVM against a real kernel and real namespaces: `microvm-x86_64` (minimal lifecycle), `-coverage`, `-coverage-iouring`, `-soak`, `-tcp-stress`, `-clickhouse-pipeline`, `-clickhouse-pipeline-parquet`, `-s3parquet-pipeline`, `-s3parquet-long`, and `-capcheck-fail`. See [Testing](#testing) and [docs/integration-testing.md](docs/integration-testing.md).
+Boot xtcp2 inside a QEMU microVM against a real kernel and real namespaces: `microvm-x86_64` (minimal lifecycle), `-coverage`, `-coverage-iouring`, `-soak`, `-tcp-stress`, `-clickhouse-pipeline`, `-clickhouse-pipeline-parquet`, `-s3parquet-pipeline`, `-s3parquet-long`, `-capcheck-fail`, and `-discovery-bench` (namespace-discovery A/B benchmark: dir-scan vs `/proc`-scan on a real kernel). See [Testing](#testing) and [docs/integration-testing.md](docs/integration-testing.md).
 
 ### Utility apps (`nix run .#<name>`)
 
@@ -118,6 +118,7 @@ nix run .#microvm-x86_64-lifecycle                 # ~45s smoke test
 nix run .#microvm-x86_64-soak -- --duration 1h     # long-running stability
 nix run .#microvm-x86_64-tcp-stress -- --duration 180s
 nix run .#microvm-x86_64-clickhouse-pipeline       # full xtcp2 → redpanda → clickhouse stack
+nix run .#microvm-x86_64-discovery-bench -- --timeout 900  # ns-discovery A/B grid
 ```
 
 See [docs/integration-testing.md](docs/integration-testing.md) for the harness internals, flavor descriptions, and troubleshooting.

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ See **[CONTRIBUTING.md](../CONTRIBUTING.md)** for the development environment, t
 - [Protobuf formats](protobuf-formats.md) — the config/data/ClickHouse schemas, generated code, and how to regenerate.
 - [Parquet format](parquet-format.md) — the S3/Parquet layout and schema, for data teams consuming the export.
 - [Fleet jitter & upload backoff](design-jitter-and-backoff.md) — thundering-herd avoidance: poll jitter, jittered S3 flush (size + time), and jittered proportional upload retry, for fleet-scale (5–10k machine) deployments.
+- [Namespace discovery & reconciliation](design-namespace-discovery-and-reconcile.md) — proposed pull-based (pre-poll) reconcile, proportional/optional background reconcile, inotify overflow self-heal, and the dir-scan vs `/proc`-scan discovery analysis (with the `discovery-bench` benchmark).
 - [Socket analysis](socket-analysis.md) — finding RTT bands and other socket groupings by clustering (data-team methodology).
 - [Build flavors](build-flavors.md) — the build-variant × destination-flavor matrix.
 - [Integration testing](integration-testing.md) — the QEMU microVM test harness.

--- a/docs/design-namespace-discovery-and-reconcile.md
+++ b/docs/design-namespace-discovery-and-reconcile.md
@@ -1,0 +1,219 @@
+# Design: namespace discovery & reconciliation — on-demand, proportional, drift-free
+
+**xtcp2 monitors TCP sockets inside every network namespace on a host, which means it must keep an open, bound netlink socket in each live namespace and tear it down when the namespace goes away. Today that "which namespaces are live" set is maintained by a *push* model — an inotify watcher mutates a long-lived in-memory mirror as filesystem events arrive — backed by a fixed 5-minute reconcile loop that re-scans the filesystem to repair anything the watcher missed. That reconcile fires on a fixed cadence regardless of how often the daemon actually polls: with a 24 h poll frequency it runs 288 times a day to protect an invariant that only matters once a day. This document describes the risks (wasted CPU at fleet scale, a real drift window on inotify overflow, and an async socket-readiness gap), redesigns reconciliation to be *pull-based and proportional to the poll frequency* so correctness is guaranteed at the only moment it matters, and — at the user's request — steps back to evaluate whether inotify is even the right primitive, sketching alternative discovery designs that could eliminate drift structurally.**
+
+## Table of contents
+
+- [Background: how namespace tracking works today](#background-how-namespace-tracking-works-today)
+- [The observation: work decoupled from need](#the-observation-work-decoupled-from-need)
+- [Risks](#risks)
+- [Design principles](#design-principles)
+- [Feature 1 — Pre-poll reconcile (correctness at poll time)](#feature-1--pre-poll-reconcile-correctness-at-poll-time)
+- [Feature 2 — Proportional, optional background reconcile & gauge](#feature-2--proportional-optional-background-reconcile--gauge)
+- [Feature 3 — inotify overflow / error self-heal](#feature-3--inotify-overflow--error-self-heal)
+- [New configuration surface](#new-configuration-surface)
+- [Step back: is inotify the right primitive?](#step-back-is-inotify-the-right-primitive)
+- [Implementation plan (PR breakdown)](#implementation-plan-pr-breakdown)
+- [Testing strategy](#testing-strategy)
+- [Rollout & backward compatibility](#rollout--backward-compatibility)
+- [Open questions & future work](#open-questions--future-work)
+- [See also](#see-also)
+
+## Background: how namespace tracking works today
+
+xtcp2's core capability is [multi-namespace visibility](network-namespaces.md): a netlink socket only sees the netns it was created in, so to observe sockets inside containers/pods the daemon enters each namespace with `setns(CLONE_NEWNET)` and keeps a dedicated, bound netlink socket there. The authoritative in-memory structure is `x.nsMap` (a `sync.Map` of `namespace-path → netNSitem`), where each `netNSitem` owns a per-ns `context`/`cancel`, the open `socketFD`, and the netlinker goroutines reading it.
+
+Three concurrent loops keep `nsMap` synchronized with the filesystem (all started in `Run`, `pkg/xtcp/xtcp.go`):
+
+| Loop | Where | Cadence | Cost per fire | Role |
+|---|---|---|---|---|
+| **inotify watcher** | `watchNsNamespace` (`ns_watch.go`) | event-driven | ~0 when idle (blocks on channel) | **Primary.** `Create`→`nsAdd`, `Remove`→`nsDelete`, in real time |
+| **map reconciler** | `mapReconciler` (`ns_reconcile.go`) | **fixed `reconcileFrequency = 5m`** | `os.ReadDir` per watched dir + two full `nsMap` ranges + per-file Prometheus `Inc` | **Safety net** — repairs whatever the watcher missed |
+| **gauge reporter** | `nsMapCountReporter` (`ns_map_count.go`) | **fixed `guageUpdateFrequency = 1m`** | atomic loads (cheap) | Publishes the namespace-count gauge |
+
+The watched directories (`netNsDirs`) default to `/run/netns/` and `/run/docker/netns/` (`netNsCandidateDirs`, `init.go`).
+
+### The push model, precisely
+
+The watcher is *edge-triggered*: it converts each inotify `Create`/`Remove` into a mutation of `nsMap`. There is no re-derivation from ground truth on the watcher path — the mirror is only ever as correct as the stream of events that built it. `mapReconciler` is the *level-triggered* backstop: its `reconcile` re-reads the directories (`discoverAllNamespaces`) and diffs against `nsMap` (`reconcileMaps`), deleting entries whose namespace is gone and `nsAdd`-ing namespaces that appeared. Note `reconcileMaps` treats a `nil` src value as "present, not drift" on purpose — production `discoverNamespaces` stores keys with `nil` values, and comparing that `nil` against the live `netNSitem` would otherwise delete and re-create every reader every cycle (documented in `ns_reconcile.go`).
+
+### Async socket readiness (important for everything below)
+
+`nsAdd` is **not** synchronous. It reserves the `nsMap` slot (with the per-ns `cancel`, so a racing delete can always reach it — the fix for the thread-exhaustion bug) and launches `netNamespaceInstance` as a goroutine. That goroutine then does the slow part: `checkMountInfo` retries (the bind-mount may not be visible yet), `open` + `setns` with exponential-backoff retries (`openAndSetNSWithRetries`, up to `maxRetriesCst = 10` attempts), `socket()` + `bind()`, and only *then* `createNetlinkersAndStore` writes the real `socketFD` into the `nsMap` item and registers it in `fdToNsMap`. **Until that final store lands, the namespace is "known" but has no pollable socket.** Any design that says "reconcile then poll" must account for this window.
+
+## The observation: work decoupled from need
+
+The reconcile the operator sees ticking in Prometheus (`mapReconciler/tick/count`) fires every 5 minutes **no matter what the poll frequency is**. The daemon is expected to run with poll frequencies from ~1 minute (dense) down to 2 h or 24 h (sparse). At 24 h:
+
+- The namespace set is *consumed* exactly once per day — `pollAllNetlinkSockets` iterates `GetNetlinkSocketFDs()` and polls each.
+- The namespace set is *reconciled* 288 times per day.
+- 287 of those reconciles produce a result nobody reads before it's re-derived: the set is re-checked, re-ranged, and re-counted, and then the machine sits idle for hours before anything uses it.
+
+Between two polls, drift in `nsMap` is **invisible** — nothing reads the set, so whether it's momentarily wrong is irrelevant. The invariant that actually matters is narrow: *at the instant a poll begins, `nsMap` must match the live namespaces and their sockets must be open.* The current design maintains that invariant continuously and eagerly; it only needs to hold it momentarily and lazily.
+
+At fleet scale (5–10k machines × 20–30 containers, each container an xtcp instance with up to ~100 namespaces) the aggregate of "cheap" 5-minute + 1-minute ticks is a persistent, coordinated background CPU floor that buys nothing when polling is sparse.
+
+## Risks
+
+1. **Wasted CPU, proportional to the wrong thing.** Reconcile cost scales with namespace count and fires on a fixed clock unrelated to poll frequency. The sparser the polling, the worse the waste ratio. This is the reported symptom.
+
+2. **A real drift window on inotify overflow.** inotify has a bounded per-instance event queue (`fs.inotify.max_queued_events`, default 16384). Under rapid `ip netns add/del` churn the queue can overflow; the kernel then drops events and delivers a single `IN_Q_OVERFLOW`. fsnotify surfaces this on its `Errors` channel — but `handleNsWatcherErr` (`ns_watch.go`) merely logs it (only at `debugLevel > 10`) and continues. **After an overflow, `nsMap` is silently wrong until the next 5-minute tick.** This is precisely the "gets out of sync under rapid adds/removes" case that motivated the reconciler in the first place, and today the recovery latency is "up to 5 minutes," not "immediate."
+
+3. **Async socket-readiness gap.** As noted above, a freshly `nsAdd`-ed namespace has no bound socket for a short window. If any future change polls "right after reconciling," it can poll a namespace whose socket isn't up yet and silently skip it (`GetNetlinkSocketFDs` only returns fds from stored `netNSitem`s). Sparse polling makes each miss expensive — a skipped namespace waits a *full poll period* (up to 24 h) for its next chance.
+
+4. **Stale documentation / dead assumption.** The doc comment on `watchNsNamespace` claims the function "also calls `discoverNamespaces()`" for initial population; it does not. Initial population actually comes from `mapReconciler`'s first (pre-loop) `reconcile`. If the periodic reconcile is ever disabled without accounting for this, startup discovery breaks. Worth fixing as part of the review so the two concerns (initial seed vs. periodic repair) are explicit and independent.
+
+## Design principles
+
+1. **Pull beats push for correctness.** Re-derive the namespace set from ground truth at the moment it's consumed (poll time), rather than maintaining a long-lived mirror that any missed event can silently corrupt. A pull design makes drift *structurally impossible* at the point of use: every poll starts from a fresh directory scan.
+
+2. **Any push mechanism is an optimization, never a correctness dependency.** inotify (or any future event source) exists only to keep the between-poll delta small and to pre-warm sockets so the pre-poll reconcile is cheap and adds no latency. If it misses events, the next poll's pull corrects it. It must never be load-bearing for correctness.
+
+3. **Cadence proportional to need.** Any remaining periodic work (a belt-and-suspenders reconcile, the gauge) should scale with poll frequency, be configurable, and be disable-able — mirroring the [jitter design](design-jitter-and-backoff.md)'s "proportional to poll frequency" principle.
+
+4. **Self-heal on known failure signals.** When the kernel *tells us* it dropped events (`IN_Q_OVERFLOW` / watcher error), react immediately with a reconcile instead of waiting for a timer.
+
+5. **Preserve persistent sockets.** Do **not** tear down and rebuild sockets each poll. Opening a netlink socket requires the `setns` + `LockOSThread` dance; doing it for ~100 namespaces every minute is its own waste. Keep sockets open across polls; the pre-poll reconcile only applies the *delta* (add appeared, remove departed).
+
+## Feature 1 — Pre-poll reconcile (correctness at poll time)
+
+Make the first step of every poll cycle a reconcile, so the namespace set is guaranteed current when it's about to be used.
+
+**Where:** `Poller` (`poller.go`). `pollAllNetlinkSockets` currently jumps straight to `GetNetlinkSocketFDs()`. Insert a reconcile before it (gated — see below), then poll.
+
+**Shape:**
+
+```
+poll cycle begins
+  ├─ (if enabled) reconcile(ctx)            // re-derive ground truth, apply delta
+  │     └─ returns (dels, stores)
+  ├─ if stores > 0: wait for socket readiness, bounded
+  │     └─ poll-readiness grace: up to readinessGrace, poll as soon as the
+  │        expected new sockets are registered in nsMap (fast path), else
+  │        proceed after the grace expires (newly-added ns caught next cycle)
+  └─ pollAllNetlinkSockets(...)
+```
+
+**Handling the async socket-readiness gap (principle 5 / risk 3).** Because `nsAdd` is async, a pre-poll reconcile that discovers new namespaces cannot immediately poll them. Two acceptable strategies, to decide during implementation:
+
+- **(a) Bounded grace wait (preferred for sparse polling).** If `reconcile` reported `stores > 0`, wait up to a small `readinessGrace` (e.g. a few seconds, or proportional to nothing — sockets come up in tens of ms typically) for the newly expected sockets to appear in `nsMap`, polling as soon as they're all ready. Rationale: when polls are hours apart, spending a few seconds so a just-appeared namespace is included *this* cycle (instead of waiting 24 h) is clearly worth it. Needs a readiness signal — either poll `nsMap` for the expected keys having a non-`-1` `socketFD`, or add a lightweight "ready" broadcast from `createNetlinkersAndStore`.
+- **(b) No wait, next-cycle inclusion.** Poll whatever is ready now; newly-added namespaces are picked up on the following poll. Simpler, zero added latency, but a namespace that appears between the last event and this poll waits a full period. Fine for dense polling, poor for 24 h.
+
+Because the inotify watcher (or its replacement) normally keeps the delta at zero, `stores > 0` at pre-poll time is the *exception*, so the grace wait rarely triggers in steady state — it's insurance for the missed-event case.
+
+**Result:** correctness no longer depends on the background tick at all. Even with the periodic reconcile fully disabled, every poll operates on a freshly reconciled, socket-ready set.
+
+## Feature 2 — Proportional, optional background reconcile & gauge
+
+Once Feature 1 guarantees correctness at poll time, the periodic reconcile is pure defense-in-depth (an independent drift *detector*, useful for alerting even though it's no longer needed for correctness). Reduce it from a fixed 5-minute clock to something proportional and configurable.
+
+- **Reconcile cadence** becomes `resolveReconcileInterval(config)`:
+  - explicit config value wins;
+  - `0` **disables** the background reconcile entirely (Feature 1 + Feature 3 carry correctness);
+  - unset → derive from poll frequency, e.g. `min(pollFrequency, reconcileCeiling)` with a sane floor, so a 24 h poll reconciles at most once per ceiling window (not 288×/day) while a 1-minute poll doesn't reconcile absurdly often either. Per the answered scope: **default is "occasional verification, proportional"** — kept on, but rare and tied to poll frequency.
+  - Optionally jitter it (reuse `misc.JitterDuration`) so the fleet's verification reconciles don't self-synchronize — consistent with the [jitter design](design-jitter-and-backoff.md).
+- **Gauge cadence** (`guageUpdateFrequency`): same treatment, or simply fold the gauge update into the pre-poll/reconcile path so it's published whenever a reconcile runs rather than on its own 1-minute clock.
+
+Both `reconcileFrequency` and `guageUpdateFrequency` are already `var` (not `const`) specifically so tests can shrink them; the change is to drive them from config/poll-frequency rather than hardcoded defaults.
+
+## Feature 3 — inotify overflow / error self-heal
+
+Close the concrete drift source (risk 2). When the watcher reports an error — most importantly the overflow signal that means "events were dropped" — trigger an **immediate** reconcile instead of waiting for the periodic one.
+
+**Where:** `handleNsWatcherErr` (`ns_watch.go`) and the `watcher.Errors` arm of `watchNsNamespace`. On a non-fatal watcher error, bump a dedicated counter (so overflow is *observable*, not buried at `debugLevel > 10`) and kick a reconcile — either by calling `reconcile(ctx)` directly or by signalling the reconcile loop via a channel so there's a single reconcile serialization point.
+
+With this in place, the recovery latency after a dropped event drops from "up to `reconcileFrequency`" to "≈immediate," which is what makes it safe to set the periodic reconcile rare or off. This is the fix that turns the reconciler from a *load-bearing crutch* into an *occasional verifier*.
+
+Serialization note: pre-poll reconcile (Feature 1), the periodic reconcile (Feature 2), and the self-heal reconcile (Feature 3) can all fire. `reconcile` mutates `nsMap` via `nsAdd`/`nsDelete`, which are already concurrency-safe (`LoadOrStore`, per-key cancel), but running two full reconciles simultaneously wastes work and could interleave confusingly. Prefer a single reconcile owner (a goroutine consuming a "reconcile requested" channel with coalescing, like the poller's `pollRequestCh` back-pressure pattern) that all three triggers feed.
+
+## New configuration surface
+
+Following the proto-config pattern established by the jitter work (`XtcpConfig` fields with `buf.validate` constraints, regenerated via `buf generate`), add to `proto/xtcp_config/v1/xtcp_config.proto` (next free tags after the jitter block at 221–226):
+
+| Field (proposed) | Type | Default | Meaning |
+|---|---|---|---|
+| `reconcile_interval` | `google.protobuf.Duration` | unset → derive | Background reconcile cadence. `0` disables; unset derives from poll frequency (`min(poll, ceiling)`). |
+| `reconcile_on_poll` | `bool` | `true` | Enable the pre-poll reconcile (Feature 1). |
+| `reconcile_readiness_grace` | `google.protobuf.Duration` | small default | Max wait for newly-added sockets before polling (Feature 1a); `0` = don't wait (Feature 1b). |
+| `gauge_interval` | `google.protobuf.Duration` | unset → derive | Namespace-count gauge cadence, or fold into reconcile. |
+
+Exact names/defaults to be finalized in the implementation PR. Each needs: const default in `cmd/xtcp2/xtcp2.go`, a `mainFlags` field, a `defineFlags` entry, `buildConfig`/`printFlags`/`printConfig` wiring, and env-override plumbing — the same six-touchpoint pattern used for the jitter fields.
+
+## Step back: is inotify the right primitive?
+
+The user's framing: inotify was written as a proof of concept, it works "ok," but it's comparatively slow and has downsides — is there a discovery design that resolves drift more fundamentally? The most useful lens here is **push vs. pull**, because it reframes the whole question.
+
+### The core realization
+
+xtcp doesn't actually need a real-time event stream. It needs the correct namespace set **at poll time**, with sockets open. Everything else — inotify, the 5-minute reconcile — exists to approximate that continuously. If discovery is *pull-based at poll time* (Feature 1 taken to its logical end), then:
+
+- **Drift is impossible by construction.** Each poll re-derives ground truth; there is no long-lived mirror to fall out of sync. A missed "event" isn't even a concept — there are no events, only a fresh scan each cycle.
+- **inotify becomes optional.** Its only remaining value is *pre-warming*: keeping sockets open between polls so the pre-poll scan finds them ready and adds zero latency. That's a latency/CPU optimization, and if it misses events the next poll's scan self-corrects. It can never cause incorrect data.
+
+So the strongest "resolves drift completely" design is not a better event source — it's **demoting event sources to optimizations and making the periodic pull the source of truth.** Feature 1 is the first step toward that; the end state is "inotify off by default, pull-only," which we can reach incrementally once Feature 1 is proven.
+
+### Candidate discovery mechanisms, compared
+
+| Mechanism | How | Drift behavior | Cost / latency | Downsides |
+|---|---|---|---|---|
+| **inotify (today)** | Watch `/run/netns/`, `/run/docker/netns/` | Push; **silent drift on queue overflow** | Low idle; event latency modest | Overflow drops events; only sees *bind-mounted named* netns; POC-grade error handling |
+| **Pull scan at poll time** (recommended source of truth) | `os.ReadDir` the watched dirs each poll | **No drift** — re-derived every cycle | One readdir per watched dir per poll; negligible at any poll freq | Only sees named/bind-mounted netns (same coverage as today); first poll after a ns appears pays socket setup (mitigated by pre-warm or grace) |
+| **fanotify** | `FAN_CREATE`/`FAN_DELETE` on the dirs (kernel ≥5.1) | Push; overflow still possible but larger/again configurable | Similar to inotify | Not fundamentally drift-free; more capability requirements; still only named netns |
+| **`/proc/*/ns/net` inode scan** (`lsns`-style) | Walk pids, stat `ns/net`, dedupe by inode | **No drift** (ground truth of *in-use* netns), and **broader coverage** — catches anonymous container netns with no `/run/netns` bind mount | O(#pids) stat per scan; needs a live pid fd per netns to `setns` | Heavier scan; entering requires a `/proc/<pid>/ns/net` fd (pid may exit); more moving parts |
+| **rtnetlink `RTM_*NSID` (RTNLGRP_NSID)** | Subscribe to nsid-assignment multicast | Push; only fires when an *nsid* is assigned (e.g. veth peering), not on every netns create | Cheap | **Incomplete** — not a general "netns created/destroyed" signal; nsids are per-netns relative |
+| **Container-runtime events (CRI / containerd / docker)** | Subscribe to container lifecycle | Authoritative for container netns; push | Cheap | **Couples xtcp to a runtime** (the `ns_watch.go` comment already flags this tradeoff); needs per-runtime integration |
+| **eBPF on netns create/free** | kprobe/tracepoint on `copy_net_ns`/`net_free` | Push, real-time, ring-buffer backpressure instead of silent drop | Low; kernel-version/verifier dependent | Most complex; extra privileges/build; overkill if pull already gives correctness |
+
+### Recommendation
+
+1. **Adopt pull (readdir at poll time) as the correctness source** — Feature 1. This alone makes drift structurally impossible for the currently-covered (named/bind-mounted) namespaces, which is the same coverage inotify has today, so it's a strict improvement with no coverage regression.
+2. **Keep inotify as an optional pre-warmer** with the overflow self-heal (Feature 3) while it remains on, and make it disable-able. Once Feature 1 is proven in the fleet, the default can flip to "pull-only, inotify off."
+3. **Note `/proc/*/ns/net` scanning as the natural future step** if/when xtcp needs to cover *anonymous* container namespaces that never get a `/run/netns` bind mount — it's both drift-free and broader-coverage, at higher scan cost. This is a coverage upgrade, orthogonal to the drift fix, and belongs in its own design.
+4. **eBPF and CRI integration are deliberately out of scope** — they add real-time push we've just argued we don't need for correctness, at significant complexity/coupling cost. Revisit only if a future requirement (sub-second reaction, or authoritative container identity) demands it.
+
+The elegant outcome: *the reconcile stops being a repair pass bolted onto a leaky event stream, and becomes the discovery mechanism itself — run exactly when its result is consumed.*
+
+## Implementation plan (PR breakdown)
+
+Suggested sequencing (each independently testable; can be one combined PR or split, matching the jitter precedent):
+
+1. **Config plumbing** — proto fields + `buf generate` + `cmd/xtcp2` six-touchpoint wiring + env overrides + validation-bounds test. No behavior change yet.
+2. **Feature 3 (self-heal)** — watcher overflow/error → immediate reconcile + observable counter. Small, high-value, lands the drift fix first.
+3. **Feature 1 (pre-poll reconcile)** — the reconcile-then-poll step with the socket-readiness grace; introduce the single reconcile-owner/coalescing channel here so all triggers share it.
+4. **Feature 2 (proportional/optional cadence)** — derive reconcile + gauge intervals from poll frequency; wire the disable path. Depends on 1 & 3 being in so disabling the tick is safe.
+5. **Docs** — fold the outcome into `network-namespaces.md` (correct the stale "calls `discoverNamespaces()`" note; document push-vs-pull and the new knobs).
+
+## Testing strategy
+
+Consistent with the repo's table-driven, seam-injected style (positive / negative / boundary / corner), and the existing namespace tests (`ns_churn_race_test.go`, `ns_thread_leak_test.go`, `ns_reconcile_test.go`):
+
+- **Pure helpers** (table-driven): `resolveReconcileInterval` (explicit / `0`-disable / derive-from-poll / floor / ceiling / poll==0 corner); the readiness-grace decision logic.
+- **Pre-poll reconcile**: fixture with a fake `discoverAllNamespaces` returning a set that differs from `nsMap`; assert the poll operates on the reconciled set; assert `stores > 0` triggers the readiness wait and that a socket appearing during the grace is included; assert grace expiry proceeds without it (next-cycle inclusion).
+- **Self-heal**: inject a watcher error/overflow on the `Errors` channel; assert a reconcile is kicked and the overflow counter increments (not just a debug log).
+- **Proportional cadence**: shrink the derived interval via config; assert the ticker fires at the derived (not fixed 5-minute) cadence; assert `0` disables the background loop entirely while correctness still holds (poll still reconciles).
+- **Serialization**: concurrent triggers (pre-poll + self-heal + periodic) coalesce to a single in-flight reconcile — no double-scan, no `nsMap` corruption (race detector on).
+- **Regression guards intact**: the churn/thread-leak tests must still pass — none of this changes the `nsAdd`/`netNamespaceInstance` cancel-reachability contract.
+
+## Rollout & backward compatibility
+
+- **Defaults preserve today's behavior where it matters:** pre-poll reconcile on; background reconcile kept (proportional, so *less* frequent for sparse polling, never more surprising); self-heal is purely additive. No operator action required to benefit.
+- **Object/data safety:** unchanged — this touches *which* namespaces are polled and *when* the set is refreshed, not marshalling or destinations.
+- **Opt-in leanness:** operators who want minimal CPU can set `reconcile_interval = 0` (pull-only) once comfortable; the daemon stays correct via Features 1 + 3.
+- **Coverage unchanged:** still named/bind-mounted netns only; the `/proc` scan is explicitly deferred, so no behavior surprise for anonymous-netns coverage.
+
+## Open questions & future work
+
+- **Readiness signal for the grace wait:** poll `nsMap` for expected keys vs. a broadcast from `createNetlinkersAndStore`? The latter is cleaner but adds a channel/condition to a hot path.
+- **Single reconcile owner:** confirm the coalescing-channel design vs. a mutex around `reconcile`; the channel matches the poller's existing back-pressure idiom.
+- **Gauge folding:** publish the count from the reconcile path vs. keep an independent (proportional) reporter — the former removes a whole loop.
+- **Pull-only default:** timeline for flipping inotify off by default once Feature 1 is fleet-proven.
+- **`/proc/*/ns/net` coverage upgrade:** separate design if anonymous container netns must be covered.
+- **eBPF / CRI:** revisit only under a future sub-second-reaction or authoritative-container-identity requirement.
+
+## See also
+
+- [Multi-namespace visibility](network-namespaces.md) — the discovery/reconcile/setns mechanism this redesigns.
+- [Design: fleet jitter & upload backoff](design-jitter-and-backoff.md) — the "proportional to poll frequency" + jitter precedent reused here.
+- [Netlink collection](netlink-collection.md) — what each per-namespace reader does with its socket.
+- [Polling and batching](polling-and-batching.md) — the poll cycle this hooks the reconcile into.
+- [Observability](observability.md) — capability checks and the counters that would make overflow/self-heal visible.

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -13,6 +13,7 @@ A comprehensive Nix-driven setup that boots xtcp2 inside QEMU microvms alongside
   - [nsTest — namespace churn driver](#nstest--namespace-churn-driver)
   - [tcp_server / tcp_client — socket population](#tcp_server--tcp_client--socket-population)
   - [oci-xtcp2-tcp-stress — containerized stress image](#oci-xtcp2-tcp-stress--containerized-stress-image)
+  - [discovery-bench — namespace-discovery A/B](#discovery-bench--namespace-discovery-ab)
   - [Redpanda](#redpanda)
   - [ClickHouse](#clickhouse)
   - [Prometheus](#prometheus)
@@ -47,6 +48,9 @@ nix run .#microvm-x86_64-soak -- --duration 12h
 
 # Per-container netns stress: 20 docker containers × 100 sockets each
 nix run .#microvm-x86_64-tcp-stress -- --duration 180s
+
+# Namespace-discovery A/B benchmark: dir-scan vs /proc-scan, on a real kernel
+nix run .#microvm-x86_64-discovery-bench -- --timeout 900
 
 # Full production pipeline: xtcp2 → redpanda → clickhouse + grafana
 nix run .#microvm-x86_64-clickhouse-pipeline
@@ -124,6 +128,7 @@ host
 | `microvm-x86_64-soak` | `soak` | 1024 MiB | xtcp2 + nsTest + tcp_server/client + prom-scraper | Long-running stability (1h/12h+) |
 | `microvm-x86_64-tcp-stress` | `tcp-stress` | 3072 MiB | xtcp2 + dockerd + N containers × M sockets | Per-container netns discovery under load |
 | `microvm-x86_64-clickhouse-pipeline` | `clickhouse-pipeline` | 3072 MiB | + Redpanda + ClickHouse + Prometheus + Grafana | Full xtcp2 → Kafka → ClickHouse data path |
+| `microvm-x86_64-discovery-bench` | `discovery-bench` | 4096 MiB | xtcp2 + `discovery-bench` grid | Namespace-discovery A/B benchmark (dir-scan vs `/proc`-scan) on a real kernel |
 
 Each flavor inherits the shared base config from `nix/microvms/mkVm.nix` and adds only what it needs. Common kernel cmdline / hypervisor / nic config stays identical across flavors.
 
@@ -176,6 +181,17 @@ Built via `pkgs.dockerTools.streamLayeredImage`. Bundles just the two tools from
 | `TCP_BIND` | 0.0.0.0 | Server listen address |
 
 In the `tcp-stress` and `clickhouse-pipeline` flavors, `dockerd` pre-loads this image at boot, then spawns N containers with `TCP_MODE=both`. Each container gets its own netns courtesy of docker's bridge network — xtcp2 discovers those via fsnotify on `/run/docker/netns/`.
+
+### discovery-bench — namespace-discovery A/B
+
+`tools/discovery-bench/`. A re-runnable benchmark comparing the two ways xtcp2 can discover the set of network namespaces to poll:
+
+- **Method A — directory scan** (what xtcp2 does today, `pkg/xtcp/ns_discover.go`): `os.ReadDir(/run/netns, /run/docker/netns)`. Cost is O(named-namespaces); it only sees bind-mounted namespaces, so **anonymous** container/`unshare -n` netns are invisible to it.
+- **Method B — `/proc/<pid>/ns/net` inode scan**: walk `/proc`, dedup namespaces by inode. Cost is O(processes); it sees **every** namespace with a live process, including anonymous ones. Two sub-variants: `readlink`+parse vs `stat`→`Stat_t.Ino`.
+
+Modes: `measure` (time each method against the live system + a coverage diff + per-method skip counts), `grid` (root-only `N namespaces × P processes` sweep, one JSON line per cell). The **`discovery-bench` microVM flavor** runs `grid` on boot as root — so Method B's `/proc` scan sees every namespace with no ptrace-gated skips, and `ip netns` builds the controlled grid — emitting `DISCOBENCH_START` / `DISCOBENCH_GRID` (per cell) / `DISCOBENCH_DONE` sentinels to the serial console. The grid populates each cell with cheap `sleep infinity` processes (`ip netns exec <ns> sleep infinity` for the in-namespace ones), so P can reach thousands without the RSS a fleet of real binaries would cost. Grid sizes are overridable via the `DISCO_NS_GRID` / `DISCO_PID_GRID` / `DISCO_ITERS` service env.
+
+A hermetic Go microbenchmark (the algorithmic O(namespaces) vs O(processes) shape) and a root-gated coverage proof (an anonymous `unshare -n` netns is found only by the `/proc` scan) ship in `discovery_bench_test.go` and run under ordinary `go test`. Background and motivation live in [docs/design-namespace-discovery-and-reconcile.md](design-namespace-discovery-and-reconcile.md).
 
 ### Redpanda
 
@@ -311,6 +327,11 @@ xtcp2.service started, docker.service started, oci image loaded,
 N containers spawned, ≥N per-container ns discovered, 0 panics
 ```
 
+The **discovery-bench** runner boots the VM, waits for the in-VM
+`discovery-bench-run` service to emit `DISCOBENCH_DONE` (bounded by
+`--timeout`, default 1200 s), prints the collected per-cell JSON, powers off,
+and passes iff no cell reported `DISCOBENCH_ERR`.
+
 The **clickhouse-pipeline** flavor doesn't have a runner with assertions — boot it and inspect via Grafana / curl. The companion service `xtcp2-clickpipe-monitor` emits `XTCP2_CLICKPIPE_ROWS … rows=N` lines every 30s to the journal.
 
 ## Host port forwards
@@ -404,6 +425,15 @@ nix run .#microvm-x86_64-tcp-stress -- --duration 300s
 # transcript shows /run/docker/netns/<containerID> CREATE events
 # pinged by fsnotify, per-container netNamespaceInstance goroutines
 # spawned, inet_diag readout populating in each
+```
+
+### Benchmark namespace discovery (dir-scan vs /proc-scan)
+
+```sh
+nix run .#microvm-x86_64-discovery-bench -- --timeout 900
+# boots a root VM, sweeps an N-namespaces × P-processes grid, and prints a
+# DISCOBENCH_GRID JSON line per cell with each method's ns/op + coverage.
+# Re-run any time to re-confirm the numbers on a new kernel/host.
 ```
 
 ### End-to-end: dashboards on real records

--- a/docs/network-namespaces.md
+++ b/docs/network-namespaces.md
@@ -64,4 +64,5 @@ The watched directories (`/run/netns/`, `/run/docker/netns/`) are built in, not 
 
 - [Netlink collection](netlink-collection.md) — what each per-namespace reader does.
 - [Performance](performance.md) — thread and parallelism tuning.
-- [Integration testing](integration-testing.md) — the microVM namespace-lifecycle and tcp-stress tests that exercise this path.
+- [Integration testing](integration-testing.md) — the microVM namespace-lifecycle, tcp-stress, and discovery-bench tests that exercise this path.
+- [Design: namespace discovery & reconciliation](design-namespace-discovery-and-reconcile.md) — proposed pull-based reconcile and the dir-scan vs `/proc`-scan discovery analysis.

--- a/docs/testing-and-quality.md
+++ b/docs/testing-and-quality.md
@@ -72,6 +72,7 @@ The suite is large and the bar is high:
 
 - **126 benchmark functions** (e.g. `pkg/xtcpnl/xtcpnl_bench_test.go`) measure parsing throughput against the fixture corpus, so performance changes are observable.
 - Fuzz testing exercises the parser against malformed input.
+- **Namespace-discovery A/B** (`tools/discovery-bench/`) compares directory-scan vs `/proc`-inode-scan discovery. A hermetic microbenchmark runs under `go test`; the root-only real-kernel grid runs via the `microvm-x86_64-discovery-bench` flavor. See [integration-testing.md](integration-testing.md#discovery-bench--namespace-discovery-ab).
 
 ## Audit tools
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
 #   nix run    .#regen-protos            # `buf generate` (needs network)
 #   nix flake check                      # Tier 0+1 lint + go-vet + audits + smokes
 #   nix run    .#microvm-x86_64-lifecycle  # boot xtcp2 in a VM, run 3-check self-test
+#   nix run    .#microvm-x86_64-discovery-bench  # ns-discovery A/B (dir vs /proc scan)
 #
 # Overriding the giouring source (local fork):
 #   nix develop --override-input giouring path:/home/das/Downloads/giouring

--- a/nix/binaries.nix
+++ b/nix/binaries.nix
@@ -132,6 +132,10 @@ let
   toolBinaryNames = [
     "tcp_server"
     "tcp_client"
+    # discovery-bench: namespace-discovery A/B benchmark (dir-scan vs /proc
+    # inode scan). Rides xtcp2AllPackage into the soak/tcp-stress/discovery-bench
+    # microvms so its root-only `grid` mode can run against a real kernel.
+    "discovery-bench"
   ];
   toolBinaries = lib.genAttrs toolBinaryNames (
     name:
@@ -202,6 +206,7 @@ defaultBinaries
   # tools/ helper binaries (test utilities, default variant only).
   tcp_server = toolBinaries.tcp_server;
   tcp_client = toolBinaries.tcp_client;
+  discovery-bench = toolBinaries.discovery-bench;
 
   # Internal nested sets for downstream consumers (containers/).
   inherit

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -440,6 +440,17 @@ in
       program = "${microvms.s3parquetLong.x86_64.runner}/bin/xtcp2-s3parquet-runner-x86_64";
     };
 
+    # Namespace-discovery A/B benchmark: boots a root microvm that runs the
+    # discovery-bench grid (dir-scan vs /proc-scan, over an N×P sweep) against a
+    # real kernel, prints the per-cell JSON, then powers off. Pass
+    # `--timeout <sec>` to bound the wait. Not in `nix flake check` — holds a KVM
+    # slot for the sweep. Override the grid via DISCO_NS_GRID / DISCO_PID_GRID /
+    # DISCO_ITERS on the in-VM service if needed.
+    microvm-x86_64-discovery-bench = {
+      type = "app";
+      program = "${microvms.discoveryBench.x86_64.runner}/bin/xtcp2-discovery-bench-x86_64";
+    };
+
     quality-report = {
       type = "app";
       program = "${qualityReport}/bin/quality-report";

--- a/nix/microvms/constants.nix
+++ b/nix/microvms/constants.nix
@@ -69,6 +69,11 @@
       # With the chatty-logs disable in place, 16384/12000m is generous
       # but cheap insurance.
       memClickPipeParquet = 16384;
+      # memDiscoveryBench is used by sink="discovery-bench". The grid sweep
+      # spawns up to a few thousand `sleep infinity` processes per cell (cheap,
+      # shared libc pages) plus the created namespaces; 4096 MiB leaves clear
+      # headroom for the largest (pids=3000) cell and the page cache.
+      memDiscoveryBench = 4096;
       vcpu = 2;
       serialPort = 12055;
       virtioPort = 12056;

--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -189,6 +189,23 @@ let
       sink = "capcheck-fail";
     };
 
+  # discovery-bench: root VM that runs the namespace-discovery A/B grid
+  # (tools/discovery-bench -mode grid) against a real kernel, then powers off.
+  mkOneDiscoveryBench =
+    arch:
+    import ./mkVm.nix {
+      inherit
+        pkgs
+        lib
+        microvm
+        nixpkgs
+        arch
+        xtcp2Package
+        xtcp2AllPackage
+        ;
+      sink = "discovery-bench";
+    };
+
   vms = lib.genAttrs constants.supportedArchs mkOne;
 
   vmsCoverage = lib.optionalAttrs (xtcp2CoverPackage != null) (
@@ -214,6 +231,8 @@ let
   vmsCapCheckFail = lib.genAttrs constants.supportedArchs mkOneCapCheckFail;
 
   vmsS3Parquet = lib.genAttrs constants.supportedArchs mkOneS3Parquet;
+
+  vmsDiscoveryBench = lib.genAttrs constants.supportedArchs mkOneDiscoveryBench;
 
   lifecycle = lib.genAttrs constants.supportedArchs (arch: {
     fullTest = microvmLib.mkLifecycleFullTest {
@@ -291,6 +310,13 @@ let
     })
   );
 
+  discoveryBench = lib.genAttrs constants.supportedArchs (arch: {
+    runner = microvmLib.mkDiscoveryBenchRunner {
+      inherit arch;
+      vm = vmsDiscoveryBench.${arch};
+    };
+  });
+
   # nix flake check compatible derivations. Builds the launcher (cheap) and
   # invokes the VM. Note: requires KVM access — CI runners without /dev/kvm
   # will need to mark this check as host-only or use --keep-going.
@@ -318,7 +344,9 @@ in
     vmsS3Parquet
     vmsS3ParquetLong
     vmsCapCheckFail
+    vmsDiscoveryBench
     s3parquetLong
+    discoveryBench
     lifecycle
     lifecycleS3Parquet
     lifecycleCoverage

--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -225,6 +225,137 @@ rec {
   #
   # Exits 0 if xtcp2 stayed up for the full duration with no panic or
   # restart in the journal, 1 otherwise.
+  # Host runner for the discovery-bench flavor. Boots the VM, taps the serial
+  # console, waits for the in-VM discovery-bench-run service to emit its
+  # DISCOBENCH_DONE sentinel (with a bounded timeout), prints the collected
+  # DISCOBENCH_GRID JSON lines, powers the VM off, and exits 0 iff the grid
+  # completed without a DISCOBENCH_ERR. This is a finite benchmark, not a soak.
+  mkDiscoveryBenchRunner =
+    {
+      arch,
+      vm,
+    }:
+    let
+      cfg = constants.architectures.${arch};
+    in
+    pkgs.writeShellApplication {
+      name = "xtcp2-discovery-bench-${arch}";
+      runtimeInputs = with pkgs; [
+        coreutils
+        gnugrep
+        netcat-gnu
+        procps
+      ];
+      text = ''
+        set -u
+
+        TIMEOUT_SEC=1200
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --timeout)   TIMEOUT_SEC="$2"; shift 2 ;;
+            --timeout=*) TIMEOUT_SEC="''${1#--timeout=}"; shift ;;
+            -h|--help)
+              echo "usage: $0 [--timeout <seconds>]"
+              echo "  Boots the discovery-bench microvm, runs the namespace-"
+              echo "  discovery A/B grid (dir-scan vs /proc-scan) against a real"
+              echo "  kernel, prints the per-cell JSON, then powers off."
+              exit 0
+              ;;
+            *) echo "unknown arg: $1" >&2; exit 1 ;;
+          esac
+        done
+
+        SERIAL_PORT=${toString cfg.serialPort}
+        VIRTCON_PORT=${toString cfg.virtioPort}
+        LOG=$(mktemp -t xtcp2-discovery-bench-XXXX.log)
+
+        echo "================================================"
+        echo " xtcp2 microvm discovery-bench — arch=${arch}"
+        echo " timeout: $TIMEOUT_SEC s"
+        echo " transcript: $LOG"
+        echo "================================================"
+
+        QEMU_LOG="''${LOG}.qemu"
+        ${vm}/bin/microvm-run > "$QEMU_LOG" 2>&1 &
+        vm_pid=$!
+
+        nc_serial_pid=""
+        nc_virtcon_pid=""
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$SERIAL_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$SERIAL_PORT" >> "$LOG" 2>&1 &
+            nc_serial_pid=$!
+            break
+          fi
+          sleep 1
+        done
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$VIRTCON_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$VIRTCON_PORT" >> "$LOG" 2>&1 &
+            nc_virtcon_pid=$!
+            break
+          fi
+          sleep 1
+        done
+
+        trap '
+          if kill -0 "$vm_pid" 2>/dev/null; then
+            ( printf "systemctl poweroff\n" | nc -q 1 127.0.0.1 "$SERIAL_PORT" ) >/dev/null 2>&1 || true
+            sleep 10
+            kill "$vm_pid" 2>/dev/null || true
+            wait "$vm_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_serial_pid" ] && kill -0 "$nc_serial_pid" 2>/dev/null; then
+            kill "$nc_serial_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_virtcon_pid" ] && kill -0 "$nc_virtcon_pid" 2>/dev/null; then
+            kill "$nc_virtcon_pid" 2>/dev/null || true
+          fi
+        ' EXIT
+
+        # Wait for the grid to finish (DISCOBENCH_DONE) or the timeout.
+        elapsed=0
+        done_seen=0
+        while [ "$elapsed" -lt "$TIMEOUT_SEC" ]; do
+          if ! kill -0 "$vm_pid" 2>/dev/null; then
+            echo "FATAL: qemu died at t=$elapsed s; tail of transcript:"
+            tail -n 40 "$LOG"
+            exit 2
+          fi
+          if grep -q 'DISCOBENCH_DONE' "$LOG" 2>/dev/null; then
+            done_seen=1
+            break
+          fi
+          sleep 5
+          elapsed=$((elapsed + 5))
+        done
+
+        if [ "$done_seen" -ne 1 ]; then
+          echo "FATAL: DISCOBENCH_DONE not seen within $TIMEOUT_SEC s"
+          tail -n 40 "$LOG" 2>/dev/null || true
+          exit 2
+        fi
+
+        echo ""
+        echo "================================================"
+        echo " discovery-bench results (per grid cell)"
+        echo "================================================"
+        grep -E 'DISCOBENCH_START|DISCOBENCH_GRID|DISCOBENCH_ERR' "$LOG" 2>/dev/null || true
+
+        rc=0
+        if grep -q 'DISCOBENCH_ERR' "$LOG" 2>/dev/null; then
+          echo "FAIL: at least one grid cell reported DISCOBENCH_ERR"
+          rc=1
+        else
+          cells=$(grep -cE 'DISCOBENCH_GRID' "$LOG" 2>/dev/null || true)
+          echo "PASS: grid completed — $cells cell(s) measured"
+        fi
+        echo ""
+        echo "Full transcript kept at: $LOG"
+        exit "$rc"
+      '';
+    };
+
   mkSoakRunner =
     {
       arch,

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -67,6 +67,10 @@ let
   # check should refuse to start; the lifecycle test verifies the
   # expected error appears on the serial console.
   isCapCheckFail = sink == "capcheck-fail";
+  # discovery-bench = a root VM that runs the namespace-discovery A/B grid
+  # (tools/discovery-bench -mode grid) against a real kernel, then powers off.
+  # No downstream/dockerd — it only needs ip netns + many cheap processes.
+  isDiscoveryBench = sink == "discovery-bench";
   # Convenience predicate — most plumbing (minio module, port forwards,
   # mem budget, daemon args base) is shared.
   isAnyS3Parquet = isS3Parquet || isS3ParquetLong || isCapCheckFail || isClickPipeParquet;
@@ -89,6 +93,9 @@ let
       # nsTest's churn working set (~320 MiB) OOM-loops at the 1024 MiB
       # baseline; give the soak its own larger budget.
       cfg.memSoak
+    else if isDiscoveryBench then
+      # The grid sweep spawns up to a few thousand processes per cell.
+      cfg.memDiscoveryBench
     else
       cfg.mem;
 
@@ -1845,6 +1852,43 @@ in
         # path.
         environment.etc."xtcp2/xtcp_flat_record.proto" = lib.mkIf isAnyClickPipe {
           source = ../../proto/xtcp_flat_record/v1/xtcp_flat_record.proto;
+        };
+
+        # discovery-bench flavor: run the namespace-discovery A/B grid on boot,
+        # emit DISCOBENCH_GRID JSON lines + a DISCOBENCH_DONE sentinel to the
+        # serial console, then let the host runner power the VM off. Runs as root
+        # inside the VM, so Method B's /proc scan sees every namespace (no
+        # ptrace-gated skips) and `ip netns` can build the controlled N×P grid.
+        systemd.services.discovery-bench-run = lib.mkIf isDiscoveryBench {
+          description = "xtcp2 — namespace-discovery A/B grid benchmark";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          path = with pkgs; [
+            iproute2
+            coreutils
+            util-linux
+          ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            # The largest grid cell spawns thousands of `sleep` procs in this
+            # service's cgroup; lift the per-service task cap to fit them.
+            TasksMax = 16384;
+            ExecStart = pkgs.writeShellScript "discovery-bench-run" ''
+              set -u
+              NS_GRID="''${DISCO_NS_GRID:-1,10,50,100}"
+              PID_GRID="''${DISCO_PID_GRID:-100,500,1000,3000}"
+              ITERS="''${DISCO_ITERS:-30}"
+              echo "DISCOBENCH_START ns_grid=$NS_GRID pid_grid=$PID_GRID iters=$ITERS"
+              ${xtcp2AllPackage}/bin/discovery-bench \
+                -mode grid -json \
+                -nsGrid "$NS_GRID" -pidGrid "$PID_GRID" -iters "$ITERS" \
+                || echo "DISCOBENCH_ERR grid exited non-zero"
+              echo "DISCOBENCH_DONE"
+            '';
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
         };
 
         environment.systemPackages =

--- a/tools/discovery-bench/discovery_bench.go
+++ b/tools/discovery-bench/discovery_bench.go
@@ -30,9 +30,10 @@
 //	-mode grid      Root-only. For each (N namespaces × P processes) cell: create
 //	                the namespaces, spawn the processes, run measure, tear down.
 //	                Emits one JSON line per cell for the harness to collect.
-//	-mode sleeper   Internal: a self-contained "hold a process alive" child used
-//	                by grid mode (optionally after setns into a namespace), so the
-//	                tool needs no external `sleep`/`nsenter`.
+//	                Processes are cheap `sleep infinity` (bulk, host netns) and
+//	                `ip netns exec <ns> sleep infinity` (the in-namespace ones) so
+//	                P can reach thousands without the RSS a fleet of Go binaries
+//	                would cost.
 package main
 
 import (
@@ -44,7 +45,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -84,14 +84,11 @@ func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	asJSON := fs.Bool("json", false, "emit one machine-readable JSON line per result")
 	nsGrid := fs.String("nsGrid", "1,10,50,100", "grid mode: namespace counts to sweep")
 	pidGrid := fs.String("pidGrid", "100,500,1000,5000", "grid mode: process counts to sweep")
-	setnsPath := fs.String("setns", "", "sleeper mode: setns into this netns path before holding")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
 	switch *mode {
-	case "sleeper":
-		return runSleeper(ctx, *setnsPath, stderr)
 	case "measure":
 		dirs := splitNonEmpty(*netnsDirs)
 		res := measure(*procRoot, dirs, *iters)
@@ -340,22 +337,18 @@ type gridRow struct {
 }
 
 // runGrid sweeps (N namespaces × P processes). For each cell it creates the
-// namespaces (ip netns add), spawns P sleeper children (some setns'd into the
-// created namespaces so Method B has distinct inodes to dedup and at least one
-// anonymous-coverage case), runs measure, then tears everything down.
+// namespaces (ip netns add), spawns P `sleep infinity` children (the first N via
+// `ip netns exec` so they live inside the created namespaces and give Method B
+// distinct inodes to dedup, the rest in the host netns to build the O(P) load),
+// runs measure, then tears everything down.
 func runGrid(ctx context.Context, procRoot string, dirs []string, iters int, nsCounts, pidCounts []int, asJSON bool, stdout, stderr io.Writer) int {
 	if os.Geteuid() != 0 {
 		fmt.Fprintln(stderr, "grid mode requires root (creates namespaces + processes)")
 		return 1
 	}
-	self, err := os.Executable()
-	if err != nil {
-		fmt.Fprintf(stderr, "cannot find own executable: %v\n", err)
-		return 1
-	}
 	for _, n := range nsCounts {
 		for _, p := range pidCounts {
-			row, err := runGridCell(ctx, self, procRoot, dirs, iters, n, p, stderr)
+			row, err := runGridCell(ctx, procRoot, dirs, iters, n, p, stderr)
 			if err != nil {
 				fmt.Fprintf(stderr, "cell ns=%d pids=%d failed: %v\n", n, p, err)
 				continue
@@ -376,7 +369,7 @@ func runGrid(ctx context.Context, procRoot string, dirs []string, iters int, nsC
 	return 0
 }
 
-func runGridCell(ctx context.Context, self, procRoot string, dirs []string, iters, n, p int, stderr io.Writer) (gridRow, error) {
+func runGridCell(ctx context.Context, procRoot string, dirs []string, iters, n, p int, stderr io.Writer) (gridRow, error) {
 	names := make([]string, 0, n)
 	for i := range n {
 		name := fmt.Sprintf("disco%d", i)
@@ -386,32 +379,47 @@ func runGridCell(ctx context.Context, self, procRoot string, dirs []string, iter
 		}
 		names = append(names, name)
 	}
-	// Spawn p sleeper children; distribute the first `n` across the created
-	// namespaces (one each) so B has distinct inodes, the rest stay in the host
-	// netns (they still cost B one readlink/stat each — the O(P) we're measuring).
-	procs := make([]*exec.Cmd, 0, p)
+	// Spawn p cheap `sleep infinity` children. The first n run via `ip netns
+	// exec` so they live inside the created namespaces (distinct inodes for B to
+	// dedup); the rest stay in the host netns but still cost B one readlink/stat
+	// each — the O(P) we're measuring.
+	held := make([]*exec.Cmd, 0, p)
 	for i := range p {
-		setns := ""
+		var cmd *exec.Cmd
+		var err error
 		if i < n {
-			setns = filepath.Join("/run/netns", names[i])
+			cmd, err = spawnHeld(ctx, stderr, "ip", "netns", "exec", names[i], "sleep", "infinity")
+		} else {
+			cmd, err = spawnHeld(ctx, stderr, "sleep", "infinity")
 		}
-		cmd := exec.CommandContext(ctx, self, "-mode", "sleeper", "-setns", setns)
-		cmd.Stderr = stderr
-		if err := cmd.Start(); err != nil {
-			killAll(procs, stderr)
+		if err != nil {
+			killAll(held, stderr)
 			cleanupNetns(ctx, names, stderr)
-			return gridRow{}, fmt.Errorf("spawn sleeper %d: %w", i, err)
+			return gridRow{}, fmt.Errorf("spawn process %d: %w", i, err)
 		}
-		procs = append(procs, cmd)
+		held = append(held, cmd)
 	}
-	// Small settle so the children have finished setns before we scan.
+	// Small settle so the children have entered their namespaces before we scan.
 	time.Sleep(settleDelay)
 
 	res := measure(procRoot, dirs, iters)
 
-	killAll(procs, stderr)
+	killAll(held, stderr)
 	cleanupNetns(ctx, names, stderr)
 	return gridRow{NS: n, PIDs: p, Measure: res}, nil
+}
+
+// spawnHeld starts a long-lived child in its own process group (Setpgid) so the
+// whole group can be signalled at teardown — `ip netns exec` forks, so killing
+// just the leader would orphan the actual `sleep`.
+func spawnHeld(ctx context.Context, stderr io.Writer, name string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stderr = stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return cmd, nil
 }
 
 func killAll(procs []*exec.Cmd, stderr io.Writer) {
@@ -419,8 +427,14 @@ func killAll(procs []*exec.Cmd, stderr io.Writer) {
 		if c.Process == nil {
 			continue
 		}
-		if err := c.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			fmt.Fprintf(stderr, "kill sleeper: %v\n", err)
+		// Kill the whole process group (negative pid). Falls back to the
+		// single process if the group lookup fails.
+		if pgid, err := syscall.Getpgid(c.Process.Pid); err == nil {
+			if kerr := syscall.Kill(-pgid, syscall.SIGKILL); kerr != nil && !errors.Is(kerr, syscall.ESRCH) {
+				fmt.Fprintf(stderr, "kill group %d: %v\n", pgid, kerr)
+			}
+		} else if kerr := c.Process.Kill(); kerr != nil && !errors.Is(kerr, os.ErrProcessDone) {
+			fmt.Fprintf(stderr, "kill pid %d: %v\n", c.Process.Pid, kerr)
 		}
 	}
 	for _, c := range procs {
@@ -428,7 +442,7 @@ func killAll(procs []*exec.Cmd, stderr io.Writer) {
 		// expected teardown path, not a failure worth reporting.
 		var ee *exec.ExitError
 		if err := c.Wait(); err != nil && !errors.As(err, &ee) {
-			fmt.Fprintf(stderr, "wait sleeper: %v\n", err)
+			fmt.Fprintf(stderr, "wait child: %v\n", err)
 		}
 	}
 }
@@ -439,27 +453,6 @@ func cleanupNetns(ctx context.Context, names []string, stderr io.Writer) {
 			fmt.Fprintf(stderr, "ip netns del %s: %v (%s)\n", name, err, out)
 		}
 	}
-}
-
-// runSleeper optionally enters a namespace then blocks until signalled. Used as
-// the grid's process-population primitive so we depend on no external binary.
-func runSleeper(ctx context.Context, setnsPath string, stderr io.Writer) int {
-	if setnsPath != "" {
-		f, err := os.Open(setnsPath)
-		if err != nil {
-			fmt.Fprintf(stderr, "sleeper open %s: %v\n", setnsPath, err)
-			return 1
-		}
-		defer func() { _ = f.Close() }()
-		if err := unix.Setns(int(f.Fd()), unix.CLONE_NEWNET); err != nil {
-			fmt.Fprintf(stderr, "sleeper setns %s: %v\n", setnsPath, err)
-			return 1
-		}
-	}
-	sigCtx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-	<-sigCtx.Done()
-	return 0
 }
 
 // ───────────────────────────── small helpers ────────────────────────────────

--- a/tools/discovery-bench/discovery_bench.go
+++ b/tools/discovery-bench/discovery_bench.go
@@ -1,0 +1,485 @@
+// discovery-bench compares network-namespace *discovery* methods head to head,
+// so we can decide (and, later, re-confirm) which one xtcp2 should use to build
+// its set of namespaces to poll.
+//
+// Two methods, because they scale with different things:
+//
+//	Method A — directory scan (what xtcp2 does today, pkg/xtcp/ns_discover.go):
+//	    os.ReadDir("/run/netns") [+ "/run/docker/netns"], filter, collect names.
+//	    Cost is O(named-namespaces). Only sees namespaces that have a bind-mount
+//	    under one of those dirs — anonymous container/`unshare -n` netns are
+//	    INVISIBLE to it.
+//
+//	Method B — /proc/<pid>/ns/net inode scan (the strong-correctness candidate):
+//	    os.ReadDir("/proc"), then for each numeric pid read its net-namespace
+//	    identity and dedup by inode. Cost is O(processes). Sees EVERY namespace
+//	    that has at least one live process — including anonymous ones. Two
+//	    sub-variants differ only in the per-pid syscall:
+//	      B-readlink: readlink(/proc/<pid>/ns/net) → parse "net:[<inode>]"
+//	      B-stat:     stat(/proc/<pid>/ns/net) → Stat_t.Ino
+//	    Both are gated by ptrace-access to the target process, so an unprivileged
+//	    run skips other users' pids — the tool counts those skips so the numbers
+//	    are interpretable. Production xtcp2 runs with CAP_SYS_ADMIN and sees all.
+//
+// Modes:
+//
+//	-mode measure   Time each method against the live system (default /proc and
+//	                /run/netns,/run/docker/netns) and report a coverage diff
+//	                (which inodes each method found; B-only = A's blind spots)
+//	                plus per-method skip counts (pids that errored: EACCES/gone).
+//	-mode grid      Root-only. For each (N namespaces × P processes) cell: create
+//	                the namespaces, spawn the processes, run measure, tear down.
+//	                Emits one JSON line per cell for the harness to collect.
+//	-mode sleeper   Internal: a self-contained "hold a process alive" child used
+//	                by grid mode (optionally after setns into a namespace), so the
+//	                tool needs no external `sleep`/`nsenter`.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultProcRoot = "/proc"
+	// The two standard bind-mount dirs xtcp2 watches today.
+	defaultNetnsDirs = "/run/netns,/run/docker/netns"
+	// How many timed repetitions per method in measure mode. Discovery is a
+	// once-per-poll operation, so we care about a stable single-scan cost, not
+	// throughput — a handful of iters with a min/median is plenty.
+	defaultIters = 25
+	// settleDelay lets freshly spawned sleeper children finish their setns
+	// before we scan, in grid mode.
+	settleDelay = 200 * time.Millisecond
+)
+
+func main() {
+	os.Exit(runMain(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runMain is the flag-parsing entrypoint, extracted so tests can drive it with
+// synthetic args + a cancellable ctx without subprocessing.
+func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("discovery-bench", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	mode := fs.String("mode", "measure", "measure | grid | sleeper")
+	procRoot := fs.String("proc", defaultProcRoot, "procfs root to scan for Method B")
+	netnsDirs := fs.String("netnsDirs", defaultNetnsDirs, "comma-separated dirs for Method A")
+	iters := fs.Int("iters", defaultIters, "timed repetitions per method (measure)")
+	asJSON := fs.Bool("json", false, "emit one machine-readable JSON line per result")
+	nsGrid := fs.String("nsGrid", "1,10,50,100", "grid mode: namespace counts to sweep")
+	pidGrid := fs.String("pidGrid", "100,500,1000,5000", "grid mode: process counts to sweep")
+	setnsPath := fs.String("setns", "", "sleeper mode: setns into this netns path before holding")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	switch *mode {
+	case "sleeper":
+		return runSleeper(ctx, *setnsPath, stderr)
+	case "measure":
+		dirs := splitNonEmpty(*netnsDirs)
+		res := measure(*procRoot, dirs, *iters)
+		report(stdout, res, *asJSON)
+		return 0
+	case "grid":
+		return runGrid(ctx, *procRoot, splitNonEmpty(*netnsDirs), *iters, parseInts(*nsGrid), parseInts(*pidGrid), *asJSON, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown -mode %q\n", *mode)
+		return 2
+	}
+}
+
+// ───────────────────────── Method A: directory scan ─────────────────────────
+
+// scanDirNames mirrors pkg/xtcp/ns_discover.go discoverNamespaces: ReadDir each
+// dir, skip subdirectories, return the full namespace paths. This is the timed
+// production-equivalent scan — no per-entry stat, matching today's behavior.
+func scanDirNames(dirs []string) []string {
+	var out []string
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // a missing dir (e.g. no docker) is normal, not an error
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			out = append(out, filepath.Join(dir, e.Name()))
+		}
+	}
+	return out
+}
+
+// ───────────────────────── Method B: /proc inode scan ───────────────────────
+
+// procResult is what a /proc scan returns: the deduped inode→handle set and the
+// number of pids skipped (readlink/stat error — EACCES for other users' pids
+// when unprivileged, or the pid exited mid-scan).
+type procResult struct {
+	seen    map[uint64]string
+	skipped int
+}
+
+// scanProcReadlink walks procRoot, reads each numeric pid's ns/net symlink,
+// parses the "net:[<inode>]" target, and dedups by inode. The handle is
+// /proc/<pid>/ns/net for one representative pid (the enterable fd source).
+func scanProcReadlink(procRoot string) procResult {
+	r := procResult{seen: make(map[uint64]string)}
+	forEachPid(procRoot, func(pidDir string) {
+		link := filepath.Join(pidDir, "ns", "net")
+		target, err := os.Readlink(link)
+		if err != nil {
+			r.skipped++
+			return
+		}
+		ino, ok := parseNetInode(target)
+		if !ok {
+			r.skipped++
+			return
+		}
+		if _, dup := r.seen[ino]; !dup {
+			r.seen[ino] = link
+		}
+	})
+	return r
+}
+
+// scanProcStat is the same walk but stats ns/net for its inode instead of
+// readlink+parse. stat follows the magic symlink to the nsfs inode, so
+// Stat_t.Ino IS the namespace identity — no string parsing.
+func scanProcStat(procRoot string) procResult {
+	r := procResult{seen: make(map[uint64]string)}
+	forEachPid(procRoot, func(pidDir string) {
+		link := filepath.Join(pidDir, "ns", "net")
+		var st unix.Stat_t
+		if err := unix.Stat(link, &st); err != nil {
+			r.skipped++
+			return
+		}
+		if _, dup := r.seen[st.Ino]; !dup {
+			r.seen[st.Ino] = link
+		}
+	})
+	return r
+}
+
+// forEachPid calls fn(pidDir) for every numeric-named entry directly under
+// procRoot. The first-byte digit check skips /proc's non-pid entries (cpuinfo,
+// sys, self, …) without a syscall per entry.
+func forEachPid(procRoot string, fn func(pidDir string)) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if len(name) == 0 || name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		fn(filepath.Join(procRoot, name))
+	}
+}
+
+// parseNetInode extracts the inode from a "net:[4026531840]" symlink target.
+func parseNetInode(target string) (uint64, bool) {
+	l := strings.IndexByte(target, '[')
+	r := strings.IndexByte(target, ']')
+	if l < 0 || r <= l {
+		return 0, false
+	}
+	ino, err := strconv.ParseUint(target[l+1:r], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return ino, true
+}
+
+// resolveDirInodes stats each Method-A path to get its nsfs inode, so A's
+// findings can be compared to B's in the same inode space. This is a COVERAGE
+// helper, deliberately outside the timed path (production Method A never stats).
+func resolveDirInodes(paths []string) map[uint64]string {
+	out := make(map[uint64]string, len(paths))
+	for _, p := range paths {
+		var st unix.Stat_t
+		if err := unix.Stat(p, &st); err != nil {
+			continue
+		}
+		out[st.Ino] = p
+	}
+	return out
+}
+
+// ───────────────────────────── measurement ──────────────────────────────────
+
+type methodResult struct {
+	Name    string `json:"method"`
+	Count   int    `json:"found"`   // namespaces discovered
+	Skipped int    `json:"skipped"` // pids that errored (EACCES/gone); 0 for dir
+	MinNs   int64  `json:"min_ns"`  // fastest of iters
+	MedNs   int64  `json:"med_ns"`  // median of iters
+	MeanNs  int64  `json:"mean_ns"` // mean of iters
+	Iters   int    `json:"iters"`
+}
+
+type measureResult struct {
+	ProcRoot   string         `json:"proc"`
+	NetnsDirs  []string       `json:"netns_dirs"`
+	Methods    []methodResult `json:"methods"`
+	CoverProcN int            `json:"coverage_proc_inodes"` // distinct inodes B saw
+	CoverDirN  int            `json:"coverage_dir_inodes"`  // distinct inodes A saw
+	BOnlyN     int            `json:"b_only_inodes"`        // A's blind spots
+	BOnly      []uint64       `json:"b_only_inode_list"`
+}
+
+// timeScan runs scan iters times and returns min/median/mean ns plus the count
+// and skip total from the last run (all runs see the same live set at this
+// cadence). scan returns (found, skipped).
+func timeScan(name string, iters int, scan func() (found, skipped int)) methodResult {
+	runs := make([]int64, 0, iters)
+	var lastCount, lastSkip int
+	for range iters {
+		start := time.Now()
+		lastCount, lastSkip = scan()
+		runs = append(runs, time.Since(start).Nanoseconds())
+	}
+	sorted := slices.Clone(runs)
+	slices.Sort(sorted)
+	var sum int64
+	for _, v := range sorted {
+		sum += v
+	}
+	mr := methodResult{Name: name, Count: lastCount, Skipped: lastSkip, Iters: iters}
+	if len(sorted) > 0 {
+		mr.MinNs = sorted[0]
+		mr.MedNs = sorted[len(sorted)/2]
+		mr.MeanNs = sum / int64(len(sorted))
+	}
+	return mr
+}
+
+// measure times all three methods against the live system and computes the
+// coverage diff (which namespaces Method B sees that Method A cannot).
+func measure(procRoot string, dirs []string, iters int) measureResult {
+	dirRes := timeScan("dir", iters, func() (int, int) { return len(scanDirNames(dirs)), 0 })
+	rlRes := timeScan("proc-readlink", iters, func() (int, int) {
+		r := scanProcReadlink(procRoot)
+		return len(r.seen), r.skipped
+	})
+	stRes := timeScan("proc-stat", iters, func() (int, int) {
+		r := scanProcStat(procRoot)
+		return len(r.seen), r.skipped
+	})
+
+	// Coverage: resolve A's paths → inodes, compare to B's inode set.
+	dirInodes := resolveDirInodes(scanDirNames(dirs))
+	procInodes := scanProcStat(procRoot).seen
+	var bOnly []uint64
+	for ino := range procInodes {
+		if _, seenByA := dirInodes[ino]; !seenByA {
+			bOnly = append(bOnly, ino)
+		}
+	}
+	slices.Sort(bOnly)
+
+	return measureResult{
+		ProcRoot:   procRoot,
+		NetnsDirs:  dirs,
+		Methods:    []methodResult{dirRes, rlRes, stRes},
+		CoverProcN: len(procInodes),
+		CoverDirN:  len(dirInodes),
+		BOnlyN:     len(bOnly),
+		BOnly:      bOnly,
+	}
+}
+
+func report(w io.Writer, r measureResult, asJSON bool) {
+	if asJSON {
+		b, err := json.Marshal(r)
+		if err != nil {
+			fmt.Fprintf(w, "DISCOBENCH_ERR %v\n", err)
+			return
+		}
+		fmt.Fprintf(w, "DISCOBENCH %s\n", b)
+		return
+	}
+	fmt.Fprintf(w, "proc=%s netnsDirs=%v\n", r.ProcRoot, r.NetnsDirs)
+	fmt.Fprintf(w, "%-16s %8s %8s %10s %10s %10s\n", "method", "found", "skipped", "min_us", "med_us", "mean_us")
+	for _, m := range r.Methods {
+		fmt.Fprintf(w, "%-16s %8d %8d %10.1f %10.1f %10.1f\n",
+			m.Name, m.Count, m.Skipped, us(m.MinNs), us(m.MedNs), us(m.MeanNs))
+	}
+	fmt.Fprintf(w, "coverage: proc saw %d distinct netns, dir saw %d; B-only (A blind spots)=%d\n",
+		r.CoverProcN, r.CoverDirN, r.BOnlyN)
+}
+
+func us(ns int64) float64 { return float64(ns) / 1000.0 }
+
+// ───────────────────────────── grid (root) ──────────────────────────────────
+
+type gridRow struct {
+	NS      int           `json:"ns"`
+	PIDs    int           `json:"pids"`
+	Measure measureResult `json:"measure"`
+}
+
+// runGrid sweeps (N namespaces × P processes). For each cell it creates the
+// namespaces (ip netns add), spawns P sleeper children (some setns'd into the
+// created namespaces so Method B has distinct inodes to dedup and at least one
+// anonymous-coverage case), runs measure, then tears everything down.
+func runGrid(ctx context.Context, procRoot string, dirs []string, iters int, nsCounts, pidCounts []int, asJSON bool, stdout, stderr io.Writer) int {
+	if os.Geteuid() != 0 {
+		fmt.Fprintln(stderr, "grid mode requires root (creates namespaces + processes)")
+		return 1
+	}
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(stderr, "cannot find own executable: %v\n", err)
+		return 1
+	}
+	for _, n := range nsCounts {
+		for _, p := range pidCounts {
+			row, err := runGridCell(ctx, self, procRoot, dirs, iters, n, p, stderr)
+			if err != nil {
+				fmt.Fprintf(stderr, "cell ns=%d pids=%d failed: %v\n", n, p, err)
+				continue
+			}
+			if asJSON {
+				b, jerr := json.Marshal(row)
+				if jerr != nil {
+					fmt.Fprintf(stderr, "marshal grid row: %v\n", jerr)
+					continue
+				}
+				fmt.Fprintf(stdout, "DISCOBENCH_GRID %s\n", b)
+			} else {
+				fmt.Fprintf(stdout, "\n== grid cell: ns=%d pids=%d ==\n", n, p)
+				report(stdout, row.Measure, false)
+			}
+		}
+	}
+	return 0
+}
+
+func runGridCell(ctx context.Context, self, procRoot string, dirs []string, iters, n, p int, stderr io.Writer) (gridRow, error) {
+	names := make([]string, 0, n)
+	for i := range n {
+		name := fmt.Sprintf("disco%d", i)
+		if out, err := exec.CommandContext(ctx, "ip", "netns", "add", name).CombinedOutput(); err != nil {
+			cleanupNetns(ctx, names, stderr)
+			return gridRow{}, fmt.Errorf("ip netns add %s: %v (%s)", name, err, out)
+		}
+		names = append(names, name)
+	}
+	// Spawn p sleeper children; distribute the first `n` across the created
+	// namespaces (one each) so B has distinct inodes, the rest stay in the host
+	// netns (they still cost B one readlink/stat each — the O(P) we're measuring).
+	procs := make([]*exec.Cmd, 0, p)
+	for i := range p {
+		setns := ""
+		if i < n {
+			setns = filepath.Join("/run/netns", names[i])
+		}
+		cmd := exec.CommandContext(ctx, self, "-mode", "sleeper", "-setns", setns)
+		cmd.Stderr = stderr
+		if err := cmd.Start(); err != nil {
+			killAll(procs, stderr)
+			cleanupNetns(ctx, names, stderr)
+			return gridRow{}, fmt.Errorf("spawn sleeper %d: %w", i, err)
+		}
+		procs = append(procs, cmd)
+	}
+	// Small settle so the children have finished setns before we scan.
+	time.Sleep(settleDelay)
+
+	res := measure(procRoot, dirs, iters)
+
+	killAll(procs, stderr)
+	cleanupNetns(ctx, names, stderr)
+	return gridRow{NS: n, PIDs: p, Measure: res}, nil
+}
+
+func killAll(procs []*exec.Cmd, stderr io.Writer) {
+	for _, c := range procs {
+		if c.Process == nil {
+			continue
+		}
+		if err := c.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			fmt.Fprintf(stderr, "kill sleeper: %v\n", err)
+		}
+	}
+	for _, c := range procs {
+		// A killed child exits via signal → *exec.ExitError; that's the
+		// expected teardown path, not a failure worth reporting.
+		var ee *exec.ExitError
+		if err := c.Wait(); err != nil && !errors.As(err, &ee) {
+			fmt.Fprintf(stderr, "wait sleeper: %v\n", err)
+		}
+	}
+}
+
+func cleanupNetns(ctx context.Context, names []string, stderr io.Writer) {
+	for _, name := range names {
+		if out, err := exec.CommandContext(ctx, "ip", "netns", "del", name).CombinedOutput(); err != nil {
+			fmt.Fprintf(stderr, "ip netns del %s: %v (%s)\n", name, err, out)
+		}
+	}
+}
+
+// runSleeper optionally enters a namespace then blocks until signalled. Used as
+// the grid's process-population primitive so we depend on no external binary.
+func runSleeper(ctx context.Context, setnsPath string, stderr io.Writer) int {
+	if setnsPath != "" {
+		f, err := os.Open(setnsPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "sleeper open %s: %v\n", setnsPath, err)
+			return 1
+		}
+		defer func() { _ = f.Close() }()
+		if err := unix.Setns(int(f.Fd()), unix.CLONE_NEWNET); err != nil {
+			fmt.Fprintf(stderr, "sleeper setns %s: %v\n", setnsPath, err)
+			return 1
+		}
+	}
+	sigCtx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	<-sigCtx.Done()
+	return 0
+}
+
+// ───────────────────────────── small helpers ────────────────────────────────
+
+func splitNonEmpty(csv string) []string {
+	var out []string
+	for s := range strings.SplitSeq(csv, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func parseInts(csv string) []int {
+	var out []int
+	for _, s := range splitNonEmpty(csv) {
+		if v, err := strconv.Atoi(s); err == nil {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/tools/discovery-bench/discovery_bench.go
+++ b/tools/discovery-bench/discovery_bench.go
@@ -302,6 +302,13 @@ func measure(procRoot string, dirs []string, iters int) measureResult {
 		r := scanProcStat(procRoot)
 		return len(r.seen), r.skipped
 	})
+	// proc-reuse: the reused, zero-allocation nsScanner. Created once and re-run
+	// across iters, so it measures the long-running-daemon steady state.
+	sc := newNsScanner(procRoot)
+	reuseRes := timeScan("proc-reuse", iters, func() (int, int) { return sc.scan() })
+	if cerr := sc.Close(); cerr != nil {
+		fmt.Fprintf(os.Stderr, "nsScanner close: %v\n", cerr)
+	}
 
 	// Coverage: resolve A's paths → inodes, compare to B's inode set.
 	dirInodes := resolveDirInodes(scanDirNames(dirs))
@@ -317,7 +324,7 @@ func measure(procRoot string, dirs []string, iters int) measureResult {
 	return measureResult{
 		ProcRoot:   procRoot,
 		NetnsDirs:  dirs,
-		Methods:    []methodResult{dirRes, rlRes, stRes},
+		Methods:    []methodResult{dirRes, rlRes, stRes, reuseRes},
 		CoverProcN: len(procInodes),
 		CoverDirN:  len(dirInodes),
 		BOnlyN:     len(bOnly),

--- a/tools/discovery-bench/discovery_bench.go
+++ b/tools/discovery-bench/discovery_bench.go
@@ -37,6 +37,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -134,19 +135,25 @@ type procResult struct {
 	skipped int
 }
 
-// scanProcReadlink walks procRoot, reads each numeric pid's ns/net symlink,
-// parses the "net:[<inode>]" target, and dedups by inode. The handle is
+// procMapHint pre-sizes the dedup map. Most hosts have well under this many
+// distinct network namespaces; overshoot just avoids a couple of early grows.
+const procMapHint = 64
+
+// scanProcReadlink walks procRoot, reads each numeric pid's ns/net symlink into
+// a reused buffer, parses the "net:[<inode>]" target straight from the bytes
+// (no result-string alloc), and dedups by inode. The handle is
 // /proc/<pid>/ns/net for one representative pid (the enterable fd source).
 func scanProcReadlink(procRoot string) procResult {
-	r := procResult{seen: make(map[uint64]string)}
-	forEachPid(procRoot, func(pidDir string) {
-		link := filepath.Join(pidDir, "ns", "net")
-		target, err := os.Readlink(link)
-		if err != nil {
+	r := procResult{seen: make(map[uint64]string, procMapHint)}
+	buf := make([]byte, 64) // "net:[<inode>]" is short; reused across pids
+	forEachPid(procRoot, func(name string) {
+		link := procRoot + "/" + name + "/ns/net"
+		n, err := unix.Readlink(link, buf)
+		if err != nil || n <= 0 {
 			r.skipped++
 			return
 		}
-		ino, ok := parseNetInode(target)
+		ino, ok := parseNetInode(buf[:n])
 		if !ok {
 			r.skipped++
 			return
@@ -160,12 +167,12 @@ func scanProcReadlink(procRoot string) procResult {
 
 // scanProcStat is the same walk but stats ns/net for its inode instead of
 // readlink+parse. stat follows the magic symlink to the nsfs inode, so
-// Stat_t.Ino IS the namespace identity — no string parsing.
+// Stat_t.Ino IS the namespace identity — no readlink buffer, no parsing.
 func scanProcStat(procRoot string) procResult {
-	r := procResult{seen: make(map[uint64]string)}
-	forEachPid(procRoot, func(pidDir string) {
-		link := filepath.Join(pidDir, "ns", "net")
-		var st unix.Stat_t
+	r := procResult{seen: make(map[uint64]string, procMapHint)}
+	var st unix.Stat_t
+	forEachPid(procRoot, func(name string) {
+		link := procRoot + "/" + name + "/ns/net"
 		if err := unix.Stat(link, &st); err != nil {
 			r.skipped++
 			return
@@ -177,33 +184,45 @@ func scanProcStat(procRoot string) procResult {
 	return r
 }
 
-// forEachPid calls fn(pidDir) for every numeric-named entry directly under
-// procRoot. The first-byte digit check skips /proc's non-pid entries (cpuinfo,
-// sys, self, …) without a syscall per entry.
-func forEachPid(procRoot string, fn func(pidDir string)) {
-	entries, err := os.ReadDir(procRoot)
+// forEachPid calls fn(name) for every numeric-named entry directly under
+// procRoot, reading the directory in batches. Readdirnames avoids os.ReadDir's
+// two big costs on /proc: sorting thousands of entries we don't need ordered,
+// and allocating an os.DirEntry per entry. The first-byte digit check skips the
+// non-pid entries (cpuinfo, sys, self, …) without a syscall each.
+func forEachPid(procRoot string, fn func(name string)) {
+	f, err := os.Open(procRoot)
 	if err != nil {
 		return
 	}
-	for _, e := range entries {
-		name := e.Name()
-		if len(name) == 0 || name[0] < '0' || name[0] > '9' {
-			continue
+	defer func() { _ = f.Close() }()
+	for {
+		names, err := f.Readdirnames(512)
+		for _, name := range names {
+			if len(name) == 0 || name[0] < '0' || name[0] > '9' {
+				continue
+			}
+			fn(name)
 		}
-		fn(filepath.Join(procRoot, name))
+		if err != nil {
+			return // io.EOF (done) or a real read error
+		}
 	}
 }
 
-// parseNetInode extracts the inode from a "net:[4026531840]" symlink target.
-func parseNetInode(target string) (uint64, bool) {
-	l := strings.IndexByte(target, '[')
-	r := strings.IndexByte(target, ']')
-	if l < 0 || r <= l {
+// parseNetInode extracts the inode from a "net:[4026531840]" symlink target,
+// operating on bytes so the readlink hot path needs no result-string alloc.
+func parseNetInode(target []byte) (uint64, bool) {
+	l := bytes.IndexByte(target, '[')
+	r := bytes.IndexByte(target, ']')
+	if l < 0 || r <= l+1 { // r<=l+1 also rejects empty brackets "[]"
 		return 0, false
 	}
-	ino, err := strconv.ParseUint(target[l+1:r], 10, 64)
-	if err != nil {
-		return 0, false
+	var ino uint64
+	for _, c := range target[l+1 : r] {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		ino = ino*10 + uint64(c-'0')
 	}
 	return ino, true
 }

--- a/tools/discovery-bench/discovery_bench_test.go
+++ b/tools/discovery-bench/discovery_bench_test.go
@@ -133,6 +133,55 @@ func BenchmarkProcScanReadlink(b *testing.B) {
 	}
 }
 
+// BenchmarkProcScanReuse measures the reused nsScanner in steady state (the
+// scanner is created + warmed once, then re-run) — the long-running-daemon case.
+// Allocs/op should be ~0 regardless of process count.
+func BenchmarkProcScanReuse(b *testing.B) {
+	const distinct = 100
+	for _, p := range []int{100, 1000, 10000} {
+		b.Run("pids="+strconv.Itoa(p), func(b *testing.B) {
+			proc := buildProcTree(b, p, distinct)
+			s := newNsScanner(proc)
+			b.Cleanup(func() {
+				if err := s.Close(); err != nil {
+					b.Error(err)
+				}
+			})
+			s.scan() // warm buffers + map
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				s.scan()
+			}
+		})
+	}
+}
+
+// TestNsScanner_matchesReadlink guards the unsafe fast path against the plain
+// implementation: same distinct inode set, same skip count.
+func TestNsScanner_matchesReadlink(t *testing.T) {
+	proc := buildProcTree(t, 500, 50)
+	want := scanProcReadlink(proc)
+	s := newNsScanner(proc)
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	found, skipped := s.scan()
+	if found != len(want.seen) {
+		t.Fatalf("nsScanner found %d, scanProcReadlink found %d", found, len(want.seen))
+	}
+	if skipped != want.skipped {
+		t.Fatalf("nsScanner skipped %d, scanProcReadlink skipped %d", skipped, want.skipped)
+	}
+	for ino := range want.seen {
+		if _, ok := s.seen[ino]; !ok {
+			t.Fatalf("nsScanner missing inode %d that scanProcReadlink found", ino)
+		}
+	}
+}
+
 // ─────────────────────── coverage proof (Exp 3, root) ───────────────────────
 
 // TestCoverage_anonymousNetnsFoundOnlyByProc creates an anonymous network

--- a/tools/discovery-bench/discovery_bench_test.go
+++ b/tools/discovery-bench/discovery_bench_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// ───────────────────────── synthetic-tree builders ──────────────────────────
+
+// buildNetnsDir creates n regular files under a fresh dir, mimicking /run/netns.
+func buildNetnsDir(tb testing.TB, n int) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	for i := range n {
+		f, err := os.Create(filepath.Join(dir, "ns"+strconv.Itoa(i)))
+		if err != nil {
+			tb.Fatal(err)
+		}
+		_ = f.Close()
+	}
+	return dir
+}
+
+// buildProcTree creates p pid dirs each with an ns/net symlink to net:[inode],
+// inode drawn from `distinct` namespaces, plus non-pid noise like real /proc.
+func buildProcTree(tb testing.TB, p, distinct int) string {
+	tb.Helper()
+	proc := tb.TempDir()
+	for _, name := range []string{"cpuinfo", "meminfo", "sys", "self", "stat", "uptime"} {
+		if err := os.Mkdir(filepath.Join(proc, name), 0o755); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	const base = 4026531840
+	for i := range p {
+		pidDir := filepath.Join(proc, strconv.Itoa(1000+i))
+		if err := os.MkdirAll(filepath.Join(pidDir, "ns"), 0o755); err != nil {
+			tb.Fatal(err)
+		}
+		target := "net:[" + strconv.Itoa(base+(i%distinct)) + "]"
+		if err := os.Symlink(target, filepath.Join(pidDir, "ns", "net")); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return proc
+}
+
+// ───────────────────────────── unit tests ───────────────────────────────────
+
+func TestParseNetInode(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   uint64
+		ok     bool
+	}{
+		{"positive typical", "net:[4026531840]", 4026531840, true},
+		{"positive min", "net:[1]", 1, true},
+		{"negative no brackets", "net:4026531840", 0, false},
+		{"negative empty brackets", "net:[]", 0, false},
+		{"negative reversed", "net:]123[", 0, false},
+		{"negative non-numeric", "net:[abc]", 0, false},
+		{"corner other nstype", "pid:[4026531836]", 4026531836, true}, // parser is nstype-agnostic
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseNetInode(tt.target)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("parseNetInode(%q) = (%d,%v), want (%d,%v)", tt.target, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestScanDirNames(t *testing.T) {
+	dir := buildNetnsDir(t, 50)
+	if got := len(scanDirNames([]string{dir})); got != 50 {
+		t.Fatalf("scanDirNames = %d, want 50", got)
+	}
+	// Missing dirs are tolerated (no docker netns dir is normal).
+	if got := len(scanDirNames([]string{dir, filepath.Join(dir, "does-not-exist")})); got != 50 {
+		t.Fatalf("scanDirNames with a missing dir = %d, want 50", got)
+	}
+}
+
+func TestScanProcReadlink_dedup(t *testing.T) {
+	proc := buildProcTree(t, 1000, 100)
+	got := scanProcReadlink(proc)
+	if len(got.seen) != 100 {
+		t.Fatalf("scanProcReadlink distinct = %d, want 100", len(got.seen))
+	}
+	if got.skipped != 0 {
+		t.Fatalf("scanProcReadlink skipped = %d, want 0 (all synthetic links are readable)", got.skipped)
+	}
+}
+
+// ───────────────────────── hermetic microbench (Exp 1) ──────────────────────
+// Real-procfs numbers come from `-mode grid` in the microVM; these isolate the
+// O(namespaces) vs O(processes) algorithmic shape. tmpfs understates the /proc
+// method (no per-access procfs generation cost), so treat B here as a floor.
+
+func BenchmarkDirScan(b *testing.B) {
+	for _, n := range []int{1, 10, 50, 100, 500} {
+		b.Run("ns="+strconv.Itoa(n), func(b *testing.B) {
+			dir := buildNetnsDir(b, n)
+			dirs := []string{dir}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = scanDirNames(dirs)
+			}
+		})
+	}
+}
+
+func BenchmarkProcScanReadlink(b *testing.B) {
+	const distinct = 100
+	for _, p := range []int{100, 500, 1000, 5000, 10000} {
+		b.Run("pids="+strconv.Itoa(p), func(b *testing.B) {
+			proc := buildProcTree(b, p, distinct)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = scanProcReadlink(proc)
+			}
+		})
+	}
+}
+
+// ─────────────────────── coverage proof (Exp 3, root) ───────────────────────
+
+// TestCoverage_anonymousNetnsFoundOnlyByProc creates an anonymous network
+// namespace (no /run/netns bind mount) via `unshare -n`, then asserts Method B
+// (proc scan) finds its inode while Method A (dir scan of /run/netns) does not.
+// This is the security-audit correctness argument, made executable. Root-only;
+// skips cleanly otherwise and in CI.
+func TestCoverage_anonymousNetnsFoundOnlyByProc(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to unshare a network namespace")
+	}
+	unshareBin, err := exec.LookPath("unshare")
+	if err != nil {
+		t.Skip("unshare not available")
+	}
+
+	// Baseline: inodes visible to the proc scan before we add the anon netns.
+	before := scanProcStat(defaultProcRoot).seen
+
+	// `unshare -n sleep 30` holds an anonymous netns alive in a child process.
+	cmd := exec.Command(unshareBin, "-n", "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start unshare child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	// Give the child a moment to enter the new netns.
+	time.Sleep(300 * time.Millisecond)
+
+	// The child's netns inode (from its own /proc/<pid>/ns/net).
+	var childSt unix.Stat_t
+	childLink := filepath.Join(defaultProcRoot, strconv.Itoa(cmd.Process.Pid), "ns", "net")
+	if err := unix.Stat(childLink, &childSt); err != nil {
+		t.Fatalf("stat child ns/net: %v", err)
+	}
+
+	// Method B must now see an inode it didn't see before — the anon netns.
+	after := scanProcStat(defaultProcRoot).seen
+	if _, ok := after[childSt.Ino]; !ok {
+		t.Fatalf("Method B (proc) did not find the anonymous netns inode %d", childSt.Ino)
+	}
+	if _, existedBefore := before[childSt.Ino]; existedBefore {
+		t.Fatalf("test setup invalid: inode %d already existed before unshare", childSt.Ino)
+	}
+
+	// Method A must NOT see it — there is no /run/netns bind mount for it.
+	dirInodes := resolveDirInodes(scanDirNames([]string{"/run/netns", "/run/docker/netns"}))
+	if _, seenByA := dirInodes[childSt.Ino]; seenByA {
+		t.Fatalf("Method A unexpectedly saw the anonymous netns inode %d", childSt.Ino)
+	}
+	t.Logf("confirmed: anon netns inode %d found by proc scan, invisible to dir scan", childSt.Ino)
+}

--- a/tools/discovery-bench/discovery_bench_test.go
+++ b/tools/discovery-bench/discovery_bench_test.go
@@ -70,7 +70,7 @@ func TestParseNetInode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := parseNetInode(tt.target)
+			got, ok := parseNetInode([]byte(tt.target))
 			if ok != tt.ok || got != tt.want {
 				t.Fatalf("parseNetInode(%q) = (%d,%v), want (%d,%v)", tt.target, got, ok, tt.want, tt.ok)
 			}

--- a/tools/discovery-bench/nsscanner.go
+++ b/tools/discovery-bench/nsscanner.go
@@ -1,0 +1,171 @@
+package main
+
+// nsScanner is the near-zero-allocation answer to "can a long-running daemon do
+// better than 3 allocs/pid on the /proc scan?" — the reference implementation a
+// productionized Method B would use.
+//
+// Why a struct and not sync.Pool: discovery runs on ONE goroutine, ONCE per poll
+// (possibly minutes apart). A sync.Pool's buffers would be GC'd between such
+// widely-spaced calls, so it would re-allocate every poll anyway. A long-lived
+// struct that OWNS its scratch — the getdents buffer, path/readlink buffers, the
+// dedup map, AND the open /proc directory fd — reuses all of it for the daemon's
+// entire life. sync.Pool is for transient objects shared across many goroutines
+// (which is exactly how the record/envelope hot path in pkg/xtcp uses it).
+//
+// Each scan:
+//   - rewinds the persistent /proc fd (lseek) — no per-poll open/close,
+//   - reads it with getdents into a reused buffer and parses dirents in place
+//     (no per-name string, none of os.ReadDir's sort / DirEntry overhead),
+//   - builds each "<pid>/ns/net\0" into a reused buffer and calls readlinkat
+//     relative to the /proc fd via a raw syscall (no BytePtrFromString cstring),
+//   - parses the inode straight from the reused readlink buffer,
+//   - dedups into a reused map (cleared, not reallocated) keyed by inode with the
+//     representative pid as the value (an int — no per-namespace string either).
+//
+// Result: zero steady-state allocation, independent of process count. Deliberately
+// unsafe/raw and x86_64-oriented (the project's only arch); the plain scanProc*
+// funcs remain for the A/B comparison and readability. Call Close at shutdown.
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type nsScanner struct {
+	fd   int            // persistent /proc directory fd, rewound each scan
+	dbuf []byte         // getdents buffer
+	pbuf []byte         // NUL-terminated relative-path scratch ("<pid>/ns/net\0")
+	lbuf []byte         // readlink target buffer
+	seen map[uint64]int // inode → representative pid (reused; cleared each scan)
+}
+
+// newNsScanner opens procRoot once. If the open fails the scanner is still
+// usable — scan just returns (0,0) — so callers need not special-case it.
+func newNsScanner(procRoot string) *nsScanner {
+	fd, err := unix.Open(procRoot, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		fd = -1
+	}
+	return &nsScanner{
+		fd:   fd,
+		dbuf: make([]byte, 64<<10),
+		pbuf: make([]byte, 0, 32),
+		lbuf: make([]byte, 64),
+		seen: make(map[uint64]int, procMapHint),
+	}
+}
+
+// Close releases the /proc directory fd. Idempotent.
+func (s *nsScanner) Close() error {
+	if s.fd < 0 {
+		return nil
+	}
+	err := unix.Close(s.fd)
+	s.fd = -1
+	return err
+}
+
+// scan rewinds the /proc fd and repopulates s.seen with the distinct
+// network-namespace inodes, returning (found, skipped). Zero steady-state allocs.
+func (s *nsScanner) scan() (found, skipped int) {
+	clear(s.seen)
+	if s.fd < 0 {
+		return 0, 0
+	}
+	if _, err := unix.Seek(s.fd, 0, unix.SEEK_SET); err != nil {
+		return 0, 0
+	}
+	for {
+		n, gerr := unix.Getdents(s.fd, s.dbuf)
+		if gerr != nil || n <= 0 {
+			break
+		}
+		for off := 0; off < n; {
+			d := (*unix.Dirent)(unsafe.Pointer(&s.dbuf[off]))
+			reclen := int(d.Reclen)
+			if reclen <= 0 || off+reclen > n {
+				break // malformed record; stop this batch defensively
+			}
+			off += reclen
+
+			name := direntName(d)
+			if len(name) == 0 || name[0] < '0' || name[0] > '9' {
+				continue
+			}
+			pid, ok := atoiBytes(name)
+			if !ok {
+				continue
+			}
+
+			// Relative path "<pid>/ns/net\0" resolved against the /proc fd.
+			s.pbuf = append(s.pbuf[:0], name...)
+			s.pbuf = append(s.pbuf, "/ns/net\x00"...)
+
+			m, ok := rawReadlinkat(s.fd, s.pbuf, s.lbuf)
+			if !ok {
+				skipped++
+				continue
+			}
+			ino, ok := parseNetInode(s.lbuf[:m])
+			if !ok {
+				skipped++
+				continue
+			}
+			if _, dup := s.seen[ino]; !dup {
+				s.seen[ino] = pid
+			}
+		}
+	}
+	return len(s.seen), skipped
+}
+
+// direntName returns the NUL-terminated name of a getdents64 record as a byte
+// slice aliasing the getdents buffer (no allocation). getdents guarantees the
+// name is NUL-terminated within the record.
+func direntName(d *unix.Dirent) []byte {
+	name := (*[256]byte)(unsafe.Pointer(&d.Name[0]))
+	i := 0
+	for i < len(name) && name[i] != 0 {
+		i++
+	}
+	return name[:i]
+}
+
+// atoiBytes parses a positive decimal from bytes without allocating.
+func atoiBytes(b []byte) (int, bool) {
+	if len(b) == 0 {
+		return 0, false
+	}
+	n := 0
+	for _, c := range b {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+// rawReadlinkat calls readlinkat(dirfd, nulPath, buf) via a raw syscall so the
+// path — already NUL-terminated in a reused buffer — is passed without the
+// BytePtrFromString cstring copy the unix.Readlinkat wrapper would make. Returns
+// the number of bytes written to buf.
+func rawReadlinkat(dirfd int, nulPath, buf []byte) (int, bool) {
+	r, _, errno := unix.Syscall6(
+		unix.SYS_READLINKAT,
+		uintptr(dirfd),
+		uintptr(unsafe.Pointer(&nulPath[0])),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0, 0,
+	)
+	if errno != 0 {
+		return 0, false
+	}
+	n := int(r)
+	if n <= 0 {
+		return 0, false
+	}
+	return n, true
+}


### PR DESCRIPTION
## Namespace-discovery A/B benchmark (research + tooling)

Foundation for productionizing `/proc`-based namespace discovery. This branch adds the tooling and evidence; the production port lives in the stacked PR (`feat/nsdiscover-lib`).

### What's here
- **`docs/design-namespace-discovery-and-reconcile.md`** — the design: pull-based (pre-poll) reconcile, proportional/optional background reconcile, and a push-vs-pull analysis of discovery mechanisms (dir-scan vs `/proc`-scan vs fanotify/rtnetlink/CRI/eBPF). Concludes: `/proc/<pid>/ns/net` inode scanning, because it's the only option that covers **anonymous** container/pod namespaces — the audit blind spot of the current `/run/netns` model.
- **`tools/discovery-bench/`** — a re-runnable benchmark: `measure` (time each method on the live system + coverage diff + skip counts), `grid` (root-only N×P sweep, JSON per cell), plus a hermetic microbench and a root-gated anonymous-netns coverage proof.
- **`microvm-x86_64-discovery-bench`** flavor — runs the grid as root on a real kernel, emits `DISCOBENCH_*` sentinels, powers off.

### Findings (real-kernel root grid)
- dir-scan is O(namespaces) (~5–35 µs); `/proc`-scan is O(processes) (~0.4 ms @ 100 pids → ~10 ms @ 3000). ~60× per-scan — but discovery runs **once per poll**, so it's ~0.017% of a core at 1-min polling.
- `stat` beats `readlink` (no ptrace-gated skips when privileged, no parse).
- A reused, **zero-allocation** scanner (`tools/discovery-bench/nsscanner.go`) is 0 allocs/op flat, independent of process count, and fastest — the shape a long-running daemon wants.
- Coverage proof: an anonymous `unshare -n` netns is found by `/proc`-scan and invisible to dir-scan.

Docs updated across `integration-testing.md`, `CONTRIBUTING.md`, `flake.nix`, `testing-and-quality.md`, `network-namespaces.md`, `docs/README.md`.

All green: `go test -race`, golangci-lint clean, gofmt clean; VM flavor validated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
