### PR TITLE
PR1: /proc namespace-discovery library (pkg/nsdiscover)

### DIFF
--- a/docs/design-namespace-discovery-and-reconcile.md
+++ b/docs/design-namespace-discovery-and-reconcile.md
@@ -2,8 +2,55 @@
 
 **xtcp2 monitors TCP sockets inside every network namespace on a host, which means it must keep an open, bound netlink socket in each live namespace and tear it down when the namespace goes away. Today that "which namespaces are live" set is maintained by a *push* model — an inotify watcher mutates a long-lived in-memory mirror as filesystem events arrive — backed by a fixed 5-minute reconcile loop that re-scans the filesystem to repair anything the watcher missed. That reconcile fires on a fixed cadence regardless of how often the daemon actually polls: with a 24 h poll frequency it runs 288 times a day to protect an invariant that only matters once a day. This document describes the risks (wasted CPU at fleet scale, a real drift window on inotify overflow, and an async socket-readiness gap), redesigns reconciliation to be *pull-based and proportional to the poll frequency* so correctness is guaranteed at the only moment it matters, and — at the user's request — steps back to evaluate whether inotify is even the right primitive, sketching alternative discovery designs that could eliminate drift structurally.**
 
+## Decision (post-benchmark, confirmed)
+
+The "step back" question below was resolved in favor of the strongest-correctness
+option: **`/proc/<pid>/ns/net` inode scanning (Method B) replaces the
+directory/inotify model outright.** The driver is that xtcp2 is used as a
+**security-audit** tool, where seeing *every* namespace — including anonymous
+container/pod netns that never get a `/run/netns` bind mount — outweighs
+everything else. The remaining doubt was cost; benchmarking removed it.
+
+**Evidence** (`tools/discovery-bench/`, and the `discovery-bench` microVM flavor —
+see [integration-testing.md](integration-testing.md#discovery-bench--namespace-discovery-ab)):
+
+- Real-kernel root grid (N namespaces × P processes): dir-scan is O(namespaces)
+  (~5–35 µs), `/proc`-scan is O(processes) (~0.4 ms @ 100 pids → ~10 ms @ 3000).
+  A ~60× per-scan gap — but discovery now runs **once per poll** (pull-at-poll),
+  so even the worst cell is ~0.017% of a core at 1-minute polling, negligible at
+  hour scale.
+- The `stat` variant beats `readlink` (no ptrace-gated skips when privileged, no
+  string parse). A **reused, zero-allocation scanner** (`tools/discovery-bench/
+  nsscanner.go`: persistent `/proc` fd + `getdents` + raw `readlinkat` + reused
+  map/buffers) is **0 allocs/op flat, independent of process count**, and the
+  fastest variant — the right shape for a long-running daemon.
+- Coverage proof: an anonymous `unshare -n` netns is found by the `/proc` scan and
+  invisible to the dir scan — the exact audit gap this closes.
+
+**Consequences carried into production** (see the implementation plan and the
+approved PR breakdown):
+
+- **Identity**: `nsMap` is keyed by **inode**. Each record keeps `netns` as a
+  best-effort human *name* (bind-mount name if the ns is named; else
+  container-derived from `/proc/<pid>/cgroup`; else `netns:[<inode>]`) and gains a
+  new **`netns_inode` uint64** field as the stable true identity.
+- **Enter by fd**: namespaces are entered via `/proc/<pid>/ns/net` + `setns`,
+  which *removes* the `checkMountInfo` mountinfo-readiness gate (an ns fd is
+  already valid).
+- **Process-visibility semantic**: Method B only sees namespaces with a **live
+  process**. An empty `ip netns add` (no process) is invisible — correct (nothing
+  to poll), but it changes the mental model and the microVM self-test (which must
+  run a process inside the test ns).
+- **Which features survive**: Feature 1 (pre-poll reconcile) becomes the core
+  integration point; Feature 2 (proportional/optional background reconcile)
+  survives as an optional socket pre-warm re-scan; **Feature 3 (inotify overflow
+  self-heal) is moot** — there is no inotify.
+
+Everything below is the analysis that led here; it is retained as the rationale.
+
 ## Table of contents
 
+- [Decision (post-benchmark, confirmed)](#decision-post-benchmark-confirmed)
 - [Background: how namespace tracking works today](#background-how-namespace-tracking-works-today)
 - [The observation: work decoupled from need](#the-observation-work-decoupled-from-need)
 - [Risks](#risks)
@@ -166,10 +213,11 @@ So the strongest "resolves drift completely" design is not a better event source
 
 ### Recommendation
 
-1. **Adopt pull (readdir at poll time) as the correctness source** — Feature 1. This alone makes drift structurally impossible for the currently-covered (named/bind-mounted) namespaces, which is the same coverage inotify has today, so it's a strict improvement with no coverage regression.
-2. **Keep inotify as an optional pre-warmer** with the overflow self-heal (Feature 3) while it remains on, and make it disable-able. Once Feature 1 is proven in the fleet, the default can flip to "pull-only, inotify off."
-3. **Note `/proc/*/ns/net` scanning as the natural future step** if/when xtcp needs to cover *anonymous* container namespaces that never get a `/run/netns` bind mount — it's both drift-free and broader-coverage, at higher scan cost. This is a coverage upgrade, orthogonal to the drift fix, and belongs in its own design.
-4. **eBPF and CRI integration are deliberately out of scope** — they add real-time push we've just argued we don't need for correctness, at significant complexity/coupling cost. Revisit only if a future requirement (sub-second reaction, or authoritative container identity) demands it.
+*(Resolved — see [Decision](#decision-post-benchmark-confirmed) at the top. Recorded here as the reasoning.)* The original recommendation staged pull-first with `/proc` scanning as a "future step." The benchmark evidence and the security-audit correctness requirement pulled that future forward: **`/proc/<pid>/ns/net` scanning is adopted now as the sole discovery mechanism, replacing dir-scan + inotify outright**, because it is the only option that covers anonymous namespaces — and pull-at-poll plus a zero-allocation reused scanner make its higher per-scan cost immaterial.
+
+1. **`/proc`-scan (stat variant) is the correctness source**, run pull-at-poll. Drift is structurally impossible (each poll re-derives ground truth) *and* coverage is complete (every namespace with a live process, incl. anonymous).
+2. **inotify + the `/run/netns` directory model are removed** — not kept as a pre-warmer. The reused scanner is cheap enough that a periodic background re-scan (Feature 2) covers pre-warming when wanted.
+3. **eBPF and CRI integration remain out of scope** — real-time push we don't need for correctness, at significant complexity/coupling cost. Revisit only under a future sub-second-reaction or authoritative-container-identity requirement.
 
 The elegant outcome: *the reconcile stops being a repair pass bolted onto a leaky event stream, and becomes the discovery mechanism itself — run exactly when its result is consumed.*
 

--- a/pkg/nsdiscover/resolve.go
+++ b/pkg/nsdiscover/resolve.go
@@ -1,0 +1,117 @@
+package nsdiscover
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// Resolver maps a network-namespace inode to a best-effort human name for record
+// labeling. Since Method B keys namespaces by inode (not by a filesystem path),
+// the friendly name is reconstructed here:
+//
+//  1. a bind-mount name — if the namespace happens to be named under one of the
+//     configured dirs (/run/netns, /run/docker/netns), that basename;
+//  2. else a container id parsed from /proc/<pid>/cgroup;
+//  3. else the synthetic "netns:[<inode>]".
+//
+// Not safe for concurrent use. Call Refresh once per discovery scan (it rebuilds
+// the inode→bind-name index), then Name per namespace.
+type Resolver struct {
+	procRoot  string
+	netnsDirs []string
+	byInode   map[uint64]string // bind-mount name index, rebuilt by Refresh
+}
+
+// NewResolver builds a resolver reading pids under procRoot (typically "/proc")
+// and looking for bind-mount names under netnsDirs (e.g. /run/netns,
+// /run/docker/netns). netnsDirs may be empty (then names come from cgroup or the
+// synthetic fallback only).
+func NewResolver(procRoot string, netnsDirs []string) *Resolver {
+	return &Resolver{
+		procRoot:  procRoot,
+		netnsDirs: netnsDirs,
+		byInode:   make(map[uint64]string),
+	}
+}
+
+// Refresh rebuilds the inode→bind-name index by statting every entry under each
+// configured netns dir. Cheap (O(named namespaces)) and reuses the map. Call it
+// once per discovery scan before any Name lookups so freshly-named namespaces
+// are picked up.
+func (r *Resolver) Refresh() {
+	clear(r.byInode)
+	for _, dir := range r.netnsDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue // a missing dir (e.g. no docker) is normal
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			var st unix.Stat_t
+			if err := unix.Stat(filepath.Join(dir, e.Name()), &st); err != nil {
+				continue
+			}
+			// First name wins for a given inode (deterministic across dirs).
+			if _, ok := r.byInode[st.Ino]; !ok {
+				r.byInode[st.Ino] = e.Name()
+			}
+		}
+	}
+}
+
+// Name returns a best-effort human name for the namespace (inode, pid), using
+// the index from the last Refresh, then the cgroup of pid, then a synthetic id.
+func (r *Resolver) Name(inode uint64, pid int) string {
+	if name, ok := r.byInode[inode]; ok {
+		return name
+	}
+	if cid := r.containerID(pid); cid != "" {
+		return cid
+	}
+	return "netns:[" + strconv.FormatUint(inode, 10) + "]"
+}
+
+// containerID reads /proc/<pid>/cgroup and returns the first container id found
+// (a 64-char lowercase-hex run), or "" if none. Covers the common docker /
+// containerd / cri-o / kubernetes cgroup layouts, whose paths embed the 64-hex
+// container id (e.g. ".../docker-<id>.scope", ".../cri-containerd-<id>.scope",
+// ".../kubepods-.../<id>").
+func (r *Resolver) containerID(pid int) string {
+	data, err := os.ReadFile(filepath.Join(r.procRoot, strconv.Itoa(pid), "cgroup"))
+	if err != nil {
+		return ""
+	}
+	return parseContainerID(data)
+}
+
+// parseContainerID finds the first maximal lowercase-hex run of length >= 64 in
+// the cgroup file and returns its first 64 chars (the container id). Runtimes
+// sometimes suffix the id (e.g. "<id>.scope"); taking exactly 64 hex chars
+// normalizes that.
+func parseContainerID(cgroup []byte) string {
+	run := 0
+	start := 0
+	for i := 0; i <= len(cgroup); i++ {
+		if i < len(cgroup) && isHexLower(cgroup[i]) {
+			if run == 0 {
+				start = i
+			}
+			run++
+			continue
+		}
+		if run >= 64 {
+			return string(cgroup[start : start+64])
+		}
+		run = 0
+	}
+	return ""
+}
+
+func isHexLower(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+}

--- a/pkg/nsdiscover/resolve_test.go
+++ b/pkg/nsdiscover/resolve_test.go
@@ -1,0 +1,80 @@
+package nsdiscover
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestParseContainerID(t *testing.T) {
+	const id = "3f2a1b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708" // 64 hex
+	tests := []struct {
+		name   string
+		cgroup string
+		want   string
+	}{
+		{"docker cgroup v2", "0::/system.slice/docker-" + id + ".scope\n", id},
+		{"containerd", "0::/kubepods/besteffort/pod123/cri-containerd-" + id + ".scope\n", id},
+		{"k8s bare id", "12:pids:/kubepods/burstable/podXYZ/" + id + "\n", id},
+		{"none", "0::/system.slice/sshd.service\n", ""},
+		{"too short (48 hex)", "0::/x/" + id[:48] + "\n", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseContainerID([]byte(tt.cgroup)); got != tt.want {
+				t.Fatalf("parseContainerID = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolver_Name_bindMount(t *testing.T) {
+	netnsDir := t.TempDir()
+	// Create a "named" namespace file and learn its inode.
+	p := filepath.Join(netnsDir, "myns")
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var st unix.Stat_t
+	if err := unix.Stat(p, &st); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewResolver(t.TempDir(), []string{netnsDir})
+	r.Refresh()
+	if got := r.Name(st.Ino, 0); got != "myns" {
+		t.Fatalf("Name(bind-mounted) = %q, want %q", got, "myns")
+	}
+}
+
+func TestResolver_Name_cgroupFallback(t *testing.T) {
+	const id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 64 hex
+	procRoot := t.TempDir()
+	pid := 4242
+	cg := filepath.Join(procRoot, strconv.Itoa(pid))
+	if err := os.MkdirAll(cg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cg, "cgroup"), []byte("0::/system.slice/docker-"+id+".scope\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewResolver(procRoot, nil)
+	r.Refresh()
+	// Unknown inode (no bind mount) → container id from cgroup.
+	if got := r.Name(999999, pid); got != id {
+		t.Fatalf("Name(cgroup) = %q, want the container id", got)
+	}
+}
+
+func TestResolver_Name_syntheticFallback(t *testing.T) {
+	r := NewResolver(t.TempDir(), nil) // empty procRoot: no cgroup for any pid
+	r.Refresh()
+	if got := r.Name(4026531840, 7); got != "netns:[4026531840]" {
+		t.Fatalf("Name(fallback) = %q, want netns:[4026531840]", got)
+	}
+}

--- a/pkg/nsdiscover/scanner.go
+++ b/pkg/nsdiscover/scanner.go
@@ -1,0 +1,193 @@
+// Package nsdiscover discovers the set of Linux network namespaces on a host by
+// scanning /proc/<pid>/ns/net inodes — i.e. every namespace that has at least
+// one live process, including anonymous container/pod namespaces that have no
+// /run/netns bind mount. This is the "Method B" discovery xtcp2 uses; see
+// docs/design-namespace-discovery-and-reconcile.md for why it replaced the
+// /run/netns directory + inotify model.
+//
+// Scanner is a reusable, zero-allocation scanner meant to be created once and
+// reused for a long-running daemon's whole life (a struct that owns its scratch,
+// not sync.Pool — see the design doc). Resolver maps a namespace inode to a
+// best-effort human name for record labeling.
+package nsdiscover
+
+import (
+	"bytes"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Namespace is one discovered network namespace.
+type Namespace struct {
+	Inode uint64 // nsfs inode — the stable identity
+	Pid   int    // a representative live pid; enter it via /proc/<Pid>/ns/net
+}
+
+// scannerMapHint pre-sizes the dedup set. Most hosts have well under this many
+// distinct network namespaces; overshoot just avoids a couple of early grows.
+const scannerMapHint = 64
+
+// Scanner scans a procfs for distinct network namespaces. It is NOT safe for
+// concurrent use: it is intended for a single owner goroutine that reuses it
+// across polls. Each Scan rewinds the persistent procfs fd and reuses every
+// buffer + the dedup map, so steady-state allocation is zero regardless of the
+// process count. Call Close at shutdown.
+type Scanner struct {
+	fd   int                 // persistent procfs dir fd, rewound each scan
+	dbuf []byte              // getdents buffer
+	pbuf []byte              // NUL-terminated relative-path scratch ("<pid>/ns/net\0")
+	lbuf []byte              // readlink target buffer
+	seen map[uint64]struct{} // per-scan dedup set (cleared, not reallocated)
+}
+
+// NewScanner opens procRoot (typically "/proc"). If the open fails the scanner
+// still constructs and Scan returns 0 — callers need not special-case it.
+func NewScanner(procRoot string) *Scanner {
+	fd, err := unix.Open(procRoot, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		fd = -1
+	}
+	return &Scanner{
+		fd:   fd,
+		dbuf: make([]byte, 64<<10),
+		pbuf: make([]byte, 0, 32),
+		lbuf: make([]byte, 64),
+		seen: make(map[uint64]struct{}, scannerMapHint),
+	}
+}
+
+// Close releases the procfs fd. Idempotent.
+func (s *Scanner) Close() error {
+	if s.fd < 0 {
+		return nil
+	}
+	err := unix.Close(s.fd)
+	s.fd = -1
+	return err
+}
+
+// Scan rewinds procfs and calls fn exactly once per distinct network namespace.
+// It returns the number of pids skipped (the pid exited mid-scan, or readlinkat
+// returned EACCES when unprivileged). Zero steady-state allocation. fn receives
+// a Namespace by value; it may copy it but must not assume any ordering.
+func (s *Scanner) Scan(fn func(Namespace)) (skipped int) {
+	clear(s.seen)
+	if s.fd < 0 {
+		return 0
+	}
+	if _, err := unix.Seek(s.fd, 0, unix.SEEK_SET); err != nil {
+		return 0
+	}
+	for {
+		n, gerr := unix.Getdents(s.fd, s.dbuf)
+		if gerr != nil || n <= 0 {
+			break
+		}
+		for off := 0; off < n; {
+			d := (*unix.Dirent)(unsafe.Pointer(&s.dbuf[off]))
+			reclen := int(d.Reclen)
+			if reclen <= 0 || off+reclen > n {
+				break // malformed record; stop this batch defensively
+			}
+			off += reclen
+
+			name := direntName(d)
+			if len(name) == 0 || name[0] < '0' || name[0] > '9' {
+				continue
+			}
+			pid, ok := atoiBytes(name)
+			if !ok {
+				continue
+			}
+
+			// Relative path "<pid>/ns/net\0" resolved against the procfs fd.
+			s.pbuf = append(s.pbuf[:0], name...)
+			s.pbuf = append(s.pbuf, "/ns/net\x00"...)
+
+			m, ok := rawReadlinkat(s.fd, s.pbuf, s.lbuf)
+			if !ok {
+				skipped++
+				continue
+			}
+			ino, ok := parseNetInode(s.lbuf[:m])
+			if !ok {
+				skipped++
+				continue
+			}
+			if _, dup := s.seen[ino]; !dup {
+				s.seen[ino] = struct{}{}
+				fn(Namespace{Inode: ino, Pid: pid})
+			}
+		}
+	}
+	return skipped
+}
+
+// direntName returns the NUL-terminated name of a getdents64 record as a byte
+// slice aliasing the getdents buffer (no allocation). getdents guarantees the
+// name is NUL-terminated within the record.
+func direntName(d *unix.Dirent) []byte {
+	name := (*[256]byte)(unsafe.Pointer(&d.Name[0]))
+	i := 0
+	for i < len(name) && name[i] != 0 {
+		i++
+	}
+	return name[:i]
+}
+
+// atoiBytes parses a positive decimal from bytes without allocating.
+func atoiBytes(b []byte) (int, bool) {
+	if len(b) == 0 {
+		return 0, false
+	}
+	n := 0
+	for _, c := range b {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+// parseNetInode extracts the inode from a "net:[4026531840]" symlink target,
+// operating on bytes so the hot path needs no result-string alloc.
+func parseNetInode(target []byte) (uint64, bool) {
+	l := bytes.IndexByte(target, '[')
+	r := bytes.IndexByte(target, ']')
+	if l < 0 || r <= l+1 { // r<=l+1 also rejects empty brackets "[]"
+		return 0, false
+	}
+	var ino uint64
+	for _, c := range target[l+1 : r] {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		ino = ino*10 + uint64(c-'0')
+	}
+	return ino, true
+}
+
+// rawReadlinkat calls readlinkat(dirfd, nulPath, buf) via a raw syscall so the
+// path — already NUL-terminated in a reused buffer — is passed without the
+// BytePtrFromString cstring copy the unix.Readlinkat wrapper would make. Returns
+// the number of bytes written to buf.
+func rawReadlinkat(dirfd int, nulPath, buf []byte) (int, bool) {
+	r, _, errno := unix.Syscall6(
+		unix.SYS_READLINKAT,
+		uintptr(dirfd),
+		uintptr(unsafe.Pointer(&nulPath[0])),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		0, 0,
+	)
+	if errno != 0 {
+		return 0, false
+	}
+	n := int(r)
+	if n <= 0 {
+		return 0, false
+	}
+	return n, true
+}

--- a/pkg/nsdiscover/scanner_test.go
+++ b/pkg/nsdiscover/scanner_test.go
@@ -1,0 +1,138 @@
+package nsdiscover
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// buildProcTree creates p pid dirs each with an ns/net symlink to net:[inode],
+// the inode drawn from `distinct` namespaces, plus non-pid noise like real /proc.
+func buildProcTree(tb testing.TB, p, distinct int) string {
+	tb.Helper()
+	proc := tb.TempDir()
+	for _, name := range []string{"cpuinfo", "meminfo", "sys", "self", "stat"} {
+		if err := os.Mkdir(filepath.Join(proc, name), 0o755); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	const base = 4026531840
+	for i := range p {
+		pidDir := filepath.Join(proc, strconv.Itoa(1000+i))
+		if err := os.MkdirAll(filepath.Join(pidDir, "ns"), 0o755); err != nil {
+			tb.Fatal(err)
+		}
+		target := "net:[" + strconv.Itoa(base+(i%distinct)) + "]"
+		if err := os.Symlink(target, filepath.Join(pidDir, "ns", "net")); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return proc
+}
+
+func TestScanner_dedup(t *testing.T) {
+	proc := buildProcTree(t, 1000, 100)
+	s := NewScanner(proc)
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	got := make(map[uint64]int) // inode -> pid
+	skipped := s.Scan(func(ns Namespace) { got[ns.Inode] = ns.Pid })
+
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0 (all synthetic links readable)", skipped)
+	}
+	if len(got) != 100 {
+		t.Fatalf("distinct namespaces = %d, want 100", len(got))
+	}
+	const base = 4026531840
+	for i := range 100 {
+		if _, ok := got[uint64(base+i)]; !ok {
+			t.Fatalf("missing inode %d", base+i)
+		}
+	}
+}
+
+func TestScanner_rescanIsStable(t *testing.T) {
+	proc := buildProcTree(t, 200, 20)
+	s := NewScanner(proc)
+	t.Cleanup(func() { _ = s.Close() })
+
+	count := func() int {
+		n := 0
+		s.Scan(func(Namespace) { n++ })
+		return n
+	}
+	first := count()
+	second := count() // rewind + re-scan must yield the same set
+	if first != 20 || second != 20 {
+		t.Fatalf("scan counts = (%d, %d), want (20, 20)", first, second)
+	}
+}
+
+func TestScanner_badProcRoot(t *testing.T) {
+	s := NewScanner(filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Cleanup(func() { _ = s.Close() })
+	if n := s.Scan(func(Namespace) { t.Fatal("fn called on a bad proc root") }); n != 0 {
+		t.Fatalf("skipped = %d, want 0", n)
+	}
+}
+
+func TestParseNetInode(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   uint64
+		ok     bool
+	}{
+		{"positive typical", "net:[4026531840]", 4026531840, true},
+		{"positive min", "net:[1]", 1, true},
+		{"negative no brackets", "net:4026531840", 0, false},
+		{"negative empty brackets", "net:[]", 0, false},
+		{"negative non-numeric", "net:[abc]", 0, false},
+		{"corner other nstype", "pid:[4026531836]", 4026531836, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseNetInode([]byte(tt.target))
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("parseNetInode(%q) = (%d,%v), want (%d,%v)", tt.target, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+// TestScanner_zeroAlloc pins the steady-state (reused) allocation to zero.
+func TestScanner_zeroAlloc(t *testing.T) {
+	proc := buildProcTree(t, 500, 50)
+	s := NewScanner(proc)
+	t.Cleanup(func() { _ = s.Close() })
+	sink := 0
+	fn := func(Namespace) { sink++ }
+	s.Scan(fn) // warm
+	if a := testing.AllocsPerRun(20, func() { s.Scan(fn) }); a != 0 {
+		t.Fatalf("Scan allocs/op = %v, want 0", a)
+	}
+	_ = sink
+}
+
+func BenchmarkScanner(b *testing.B) {
+	for _, p := range []int{100, 1000, 10000} {
+		b.Run("pids="+strconv.Itoa(p), func(b *testing.B) {
+			proc := buildProcTree(b, p, 100)
+			s := NewScanner(proc)
+			b.Cleanup(func() { _ = s.Close() })
+			fn := func(Namespace) {}
+			s.Scan(fn) // warm
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				s.Scan(fn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## PR1 of productionizing Method B: the `/proc` discovery library

Stacked on #71 (review/merge that first). This is the first phase of making `/proc`-based namespace discovery production-ready, per the approved phased plan. **Additive only — no `pkg/xtcp` wiring yet**, so it reviews in isolation.

### `docs(design)` — records the decision
The design doc's open "step back" question is resolved: **`/proc/<pid>/ns/net` inode scanning replaces the dir-scan/inotify model outright**, driven by the security-audit requirement to see every namespace (incl. anonymous). Adds a Decision section with the VM numbers, the zero-alloc scanner, the coverage proof, and the production consequences.

### `feat(nsdiscover)` — the library
New `pkg/nsdiscover` (ported from the benchmarked `tools/discovery-bench/nsscanner.go`):
- **`Scanner`** — reusable **0-allocs/op** `/proc` scanner (persistent fd rewound each scan, `getdents` parsed in place, raw `readlinkat`, reused map/buffers). `Scan(fn)` calls `fn` once per distinct namespace as `{Inode, Pid}`. Steady-state zero allocation regardless of process count (test-pinned).
- **`Resolver`** — inode → best-effort human name for record labeling: bind-mount basename (`/run/netns` + `/run/docker/netns`, indexed by inode) → container id from `/proc/<pid>/cgroup` (docker/containerd/cri-o/k8s) → synthetic `netns:[<inode>]`.

Table-driven tests (synthetic `/proc` + netns dirs), `-race` clean, golangci-lint clean, gofmt clean.

### Confirmed decisions carried forward
- **Identity**: keep record `netns` as a best-effort name; add a new `netns_inode` uint64 (PR4).
- **Rollout**: replace dir-scan outright (no dual-mode flag).
- **Delivery**: phased PRs. Next: PR2 (enter a namespace by `/proc/<pid>/ns/net` fd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
