### PR TITLE
PR2: enter a namespace by /proc/<pid>/ns/net (optional mount-info gate)

### DIFF
--- a/pkg/xtcp/ns_net_namespace.go
+++ b/pkg/xtcp/ns_net_namespace.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -103,7 +104,11 @@ func (x *XTCP) netNamespaceInstance(nsCtx context.Context, nsCancel context.Canc
 	// 	log.Printf("netNamespaceInstance after LockOSThread: %s", ns.name)
 	// }
 
-	fd := x.openAndSetNSWithRetries(nsName)
+	// Production enters via the /run/netns (or /run/docker/netns) bind-mount
+	// path, which needs the mount-readiness gate. (Entering by /proc/<pid>/ns/net
+	// — checkMount=false — is exercised by tests and used by the /proc-scan
+	// discovery path.)
+	fd := x.openAndSetNSWithRetries(nsName, true)
 
 	// If the namespace was deleted during the (possibly slow, retrying) setns
 	// above, nsDelete has already called cancel() — reachable because nsAdd
@@ -316,35 +321,40 @@ func (x *XTCP) backoffSleep(attempt int) {
 	time.Sleep(backoffDuration)
 }
 
-// openAndSetNSWithRetries
-// opens the /run/netns/X directory, and then tries to run
-// SetNs on it.  When ns.new == true, there is a slight
-// sleep because it seems to take a moment for the kernel to
-// recognize a new netns
+// openAndSetNSWithRetries opens a namespace handle path and setns() into it,
+// retrying the setns with exponential backoff.
+//
+// The handle is either a /run/netns/<name> bind mount or a /proc/<pid>/ns/net
+// handle; both are opened + setns'd identically. The difference is the
+// readiness gate: a freshly-created /run/netns bind mount can take a moment for
+// the kernel to recognize (hence checkMountInfo, which waits for the mount to
+// appear in /proc/self/mountinfo), whereas a /proc/<pid>/ns/net handle is
+// immediately valid the moment the pid is observable — so callers entering by
+// pid pass checkMount=false to skip the gate entirely.
 //
 // beware of bugs:
 // https://github.com/iproute2/iproute2/blob/413cf4f03a9b6a219c94b86f41d67992b0a14b82/ip/ipnetns.c#L801
 // https://bugs.debiax.org/cgi-bin/bugreport.cgi?bug=949235
 //
-// The body was previously a 17-cyclo retry loop that mixed Open + Setns +
-// close-on-fail + backoff inline. The Open+Setns+close-on-fail step is
-// now attemptOpenAndSetns; the backoff is backoffSleep. The remaining
-// shell (gocyclo 6) is the orchestration: mount-info check, retry loop,
-// success/exhaust return.
-func (x *XTCP) openAndSetNSWithRetries(nsName *string) (fd int) {
+// The Open+Setns+close-on-fail step is attemptOpenAndSetns; the backoff is
+// backoffSleep. The remaining shell is the orchestration: optional mount-info
+// gate, retry loop, success/exhaust return.
+func (x *XTCP) openAndSetNSWithRetries(nsName *string, checkMount bool) (fd int) {
 
 	// https://www.man7.org/linux/man-pages/man2/opex.2.html
 	if x.debugLevel > 10 {
-		log.Printf("openAndSetNSWithRetries nsFullName: %s", *nsName)
+		log.Printf("openAndSetNSWithRetries nsFullName: %s checkMount:%t", *nsName, checkMount)
 	}
 
-	found, err := x.checkMountInfoWithRetries(nsName)
-	if err != nil || !found {
-		// Named return fd is zero-valued = 0 = stdin. Returning that
-		// would let the caller's closeFD(fd) close stdin on the next
-		// line. Return -1 (invalid-fd sentinel) so closeFD errors out
-		// cleanly via EBADF instead.
-		return -1
+	if checkMount {
+		found, err := x.checkMountInfoWithRetries(nsName)
+		if err != nil || !found {
+			// Named return fd is zero-valued = 0 = stdin. Returning that
+			// would let the caller's closeFD(fd) close stdin on the next
+			// line. Return -1 (invalid-fd sentinel) so closeFD errors out
+			// cleanly via EBADF instead.
+			return -1
+		}
 	}
 
 	for attempt := 0; attempt < maxRetriesCst; attempt++ {
@@ -372,6 +382,14 @@ func (x *XTCP) openAndSetNSWithRetries(nsName *string) (fd int) {
 	// closeFD's Close errors out cleanly via EBADF + its counter, but
 	// no real fd gets clobbered.
 	return -1
+}
+
+// procNsPath returns the /proc/<pid>/ns/net handle path used to enter a
+// namespace by a representative pid (the /proc-scan discovery path). Unlike a
+// /run/netns bind mount, this handle is valid the moment the pid is observable,
+// so callers pass checkMount=false to openAndSetNSWithRetries.
+func procNsPath(pid int) string {
+	return "/proc/" + strconv.Itoa(pid) + "/ns/net"
 }
 
 // checkMountInfoWithRetries is a retry look with exponential backoff around checkMountInfo

--- a/pkg/xtcp/ns_net_namespace_helpers_test.go
+++ b/pkg/xtcp/ns_net_namespace_helpers_test.go
@@ -345,7 +345,7 @@ func TestOpenAndSetNSWithRetries_table(t *testing.T) {
 			var fd int
 			withFakeSyscalls(t, fake.syscalls(), func() {
 				fullNS := "/run/netns/" + ns
-				fd = x.openAndSetNSWithRetries(&fullNS)
+				fd = x.openAndSetNSWithRetries(&fullNS, true)
 			})
 			if fd != tc.wantFD {
 				t.Errorf("fd = %d, want %d", fd, tc.wantFD)
@@ -387,7 +387,7 @@ func TestOpenAndSetNSWithRetries_missingMountInfo(t *testing.T) {
 	var fd int
 	withFakeSyscalls(t, fake, func() {
 		ns := "/run/netns/never_mounted"
-		fd = x.openAndSetNSWithRetries(&ns)
+		fd = x.openAndSetNSWithRetries(&ns, true)
 	})
 	if fd != -1 {
 		t.Errorf("fd = %d, want -1 on missing mount-info", fd)

--- a/pkg/xtcp/ns_net_namespace_procenter_test.go
+++ b/pkg/xtcp/ns_net_namespace_procenter_test.go
@@ -1,0 +1,90 @@
+package xtcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProcNsPath pins the /proc/<pid>/ns/net handle format.
+func TestProcNsPath(t *testing.T) {
+	if got := procNsPath(1234); got != "/proc/1234/ns/net" {
+		t.Fatalf("procNsPath(1234) = %q, want /proc/1234/ns/net", got)
+	}
+}
+
+// TestOpenAndSetNSWithRetries_checkMountFalseSkipsGate verifies that entering a
+// namespace by a /proc/<pid>/ns/net handle (checkMount=false) skips the
+// mount-info readiness gate entirely and enters via open()+setns() on that path.
+// The gate is pointed at an empty mountinfo so it WOULD fail if consulted.
+func TestOpenAndSetNSWithRetries_checkMountFalseSkipsGate(t *testing.T) {
+	// An empty mountinfo → checkMountInfoWithRetries would return (false, nil),
+	// which would short-circuit to -1 if the gate ran.
+	tmp := filepath.Join(t.TempDir(), "mountinfo")
+	if err := os.WriteFile(tmp, []byte(""), 0o600); err != nil {
+		t.Fatalf("seed mountinfo: %v", err)
+	}
+	orig := mountInfoDir
+	mountInfoDir = tmp
+	t.Cleanup(func() { mountInfoDir = orig })
+
+	const fakeFD = 7
+	var gotPath string
+	fake := openAndSetnsSyscallsT{
+		open: func(path string, _ int, _ uint32) (int, error) {
+			gotPath = path
+			return fakeFD, nil
+		},
+		setns: func(_ int, _ int) error { return nil },
+		close: func(_ int) error { return nil },
+	}
+
+	x := newTestXTCP(t, "null:")
+	var fd int
+	withFakeSyscalls(t, fake, func() {
+		p := procNsPath(1234)
+		fd = x.openAndSetNSWithRetries(&p, false)
+	})
+
+	if fd != fakeFD {
+		t.Fatalf("fd = %d, want %d (must enter despite an unsatisfiable mount-info gate)", fd, fakeFD)
+	}
+	if gotPath != "/proc/1234/ns/net" {
+		t.Fatalf("open() path = %q, want /proc/1234/ns/net", gotPath)
+	}
+}
+
+// TestOpenAndSetNSWithRetries_checkMountTrueStillGates is the paired negative:
+// with checkMount=true and an empty mountinfo, the gate short-circuits to -1 and
+// open() is never called — proving the gate still applies to the bind-mount path.
+func TestOpenAndSetNSWithRetries_checkMountTrueStillGates(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "mountinfo")
+	if err := os.WriteFile(tmp, []byte(""), 0o600); err != nil {
+		t.Fatalf("seed mountinfo: %v", err)
+	}
+	orig := mountInfoDir
+	mountInfoDir = tmp
+	t.Cleanup(func() { mountInfoDir = orig })
+	withShortBackoff(t)
+
+	opened := false
+	fake := openAndSetnsSyscallsT{
+		open:  func(string, int, uint32) (int, error) { opened = true; return 9, nil },
+		setns: func(int, int) error { return nil },
+		close: func(int) error { return nil },
+	}
+
+	x := newTestXTCP(t, "null:")
+	var fd int
+	withFakeSyscalls(t, fake, func() {
+		ns := "/run/netns/never_mounted"
+		fd = x.openAndSetNSWithRetries(&ns, true)
+	})
+
+	if fd != -1 {
+		t.Fatalf("fd = %d, want -1 (gate must short-circuit on empty mountinfo)", fd)
+	}
+	if opened {
+		t.Fatal("open() was called, but the mount-info gate should have short-circuited first")
+	}
+}


### PR DESCRIPTION
## PR2 of productionizing Method B: enter a namespace by `/proc/<pid>/ns/net`

Second phase of the approved plan. **Additive and non-breaking** — no production caller uses the new path yet (that's the discovery swap in PR3); this isolates and tests the enter-by-fd capability so PR3 stays focused.

### The insight
Entering via a `/proc/<pid>/ns/net` handle is the *same* `open()` + `setns()` as a `/run/netns` bind mount — the only difference is the `checkMountInfo` readiness gate, which exists solely because a freshly-created bind mount can lag appearing in `/proc/self/mountinfo`. A `/proc` handle is valid the instant the pid is observable, so that gate is unnecessary (and meaningless) for it.

### Change
- `openAndSetNSWithRetries` gains a `checkMount bool`; the mount-info gate runs only when `true`. Production (`/run/netns`) passes `true` → **behavior unchanged**.
- New `procNsPath(pid)` → `"/proc/<pid>/ns/net"`.
- Tests: `checkMount=false` enters despite an unsatisfiable mountinfo gate and opens the `/proc` path; paired positive that `checkMount=true` still short-circuits on empty mountinfo.

Full `pkg/xtcp` suite + `-race` pass; golangci-lint + gofmt clean.

### Next
PR3 — swap discovery to `/proc`-scan (`pkg/nsdiscover`), key `nsMap` by inode, remove inotify/dir-scan, wire the pre-poll reconcile using this enter-by-fd path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
