### PR TITLE
PR5: pre-poll reconcile + fix microVM self-test namespace checks for Method B

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -309,9 +309,9 @@ The shared self-test (`nix/microvms/self-test.nix`) runs 10 checks in sequence o
 | 5 | `GRPC_ROUNDTRIP` | `xtcp2client -target 127.0.0.1 -port 8889` connects and produces output |
 | 6 | `NS_INSPECT` | `ns` namespace inspector binary runs |
 | 7 | `NSTEST` | `nsTest -help` works |
-| 8 | `NS_LIFECYCLE` | `ip netns add/delete` propagates → fsnotify event + `netNamespaceInstance` start counter both bump |
-| 9 | `NS_TRAFFIC` | TCP listener+client inside a fresh netns produces measurable Netlinker `packets` |
-| 10 | `NS_DOCKER` | Bind-mount under `/run/docker/netns/` fires the second `watchNsNamespace` goroutine end-to-end |
+| 8 | `NS_LIFECYCLE` | a netns holding a live process is discovered by the Method B `/proc` scan (pre-poll reconcile → `netNamespaceInstance` start); process exit + ns removal → reconcile `delete`. Both counters bump |
+| 9 | `NS_TRAFFIC` | TCP listener (the live process Method B keys on) + client inside a fresh netns produces measurable Netlinker `packets` |
+| 10 | `NS_DOCKER` | docker-style netns: bind-mount under `/run/docker/netns/` + a live process is discovered via `/proc` and named from the bind mount; `netNamespaceInstance` start + `delete` bump |
 | — | `OVERALL` | All of 1–10 passed |
 
 The **soak** flavor doesn't run the self-test; instead its runner sleeps for `--duration`, then prints:

--- a/nix/microvms/self-test.nix
+++ b/nix/microvms/self-test.nix
@@ -13,11 +13,12 @@
 #   XTCP2_SELF_TEST_GRPC_ROUNDTRIP_{PASS,FAIL} xtcp2 ↔ xtcp2client gRPC works
 #   XTCP2_SELF_TEST_NS_INSPECT_{PASS,FAIL}     ns inspector reads netns state
 #   XTCP2_SELF_TEST_NSTEST_{PASS,FAIL}         nsTest binary runs
-#   XTCP2_SELF_TEST_NS_LIFECYCLE_{PASS,FAIL}   ip netns add/delete propagates to
-#                                              xtcp2 (drives the fsnotify watch
-#                                              + nsAdd + nsDelete code paths,
-#                                              spawning a per-ns netlinker
-#                                              goroutine end-to-end)
+#   XTCP2_SELF_TEST_NS_LIFECYCLE_{PASS,FAIL}   a netns holding a live process is
+#                                              discovered by the Method B /proc
+#                                              scan (pre-poll reconcile → nsAdd,
+#                                              spawning a per-ns netlinker); when
+#                                              the process exits + the ns is
+#                                              removed, reconcile → nsDelete
 #   XTCP2_SELF_TEST_NS_TRAFFIC_{PASS,FAIL}     TCP socket created inside a fresh
 #                                              netns produces records via that
 #                                              ns's netlinker (drives the full
@@ -312,42 +313,45 @@ pkgs.writeShellApplication {
     fi
     if [ "$check7" -ne 0 ]; then overall_ok=0; fi
 
-    # ─── Check 8: ns lifecycle — ip netns add/delete propagates ──────────
-    # The xtcp2 daemon watches /run/netns/ via fsnotify. Creating a new
-    # netns SHOULD fire the watcher → nsAdd → openAndSetNSWithRetries →
-    # createNetlinkersAndStore (spawns a per-ns netlinker goroutine).
-    # Then deletion SHOULD tear it down via nsDelete.
-    #
-    # We assert the daemon noticed by reading two metric counters:
-    #   * the watchNamespaces "event" counter (the fsnotify callback)
-    #   * the netNamespaceInstance "start" counter (per-ns goroutine)
-    # Both should bump by ≥1 between before/after, and the netlinker
-    # count should drop back when we delete the ns.
-    echo "--- check 8: ns lifecycle (ip netns add/delete) ---"
+    # ─── Check 8: ns lifecycle — a namespace with a live process ─────────
+    # Method B discovers namespaces by scanning /proc/<pid>/ns/net on every
+    # pre-poll reconcile — there is no /run/netns fsnotify watcher any more.
+    # A namespace is only visible while it holds a LIVE PROCESS, so we keep one
+    # alive with `sleep` inside the ns; the daemon should enter it and spawn a
+    # per-ns netlinker (netNamespaceInstance "start"). When that process exits
+    # and the ns is removed, the next reconcile tears it down (the "delete"
+    # counter bumps).
+    echo "--- check 8: ns lifecycle (live process in a fresh netns) ---"
     check8=1
     if command -v ip >/dev/null 2>&1; then
       # The label keys are function/variable/type (see promLabels in
       # pkg/xtcp/prometheus.go). Prometheus prints labels alphabetically
       # (function, type, variable), so the helper takes the function/
       # variable filters as separate args.
-      before_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
       before_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
+      before_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
       ip netns add xtcp_test_ns_a 2>&1 || true
       # Bring lo up so a subsequent socket inside the ns is meaningful.
       ip netns exec xtcp_test_ns_a ip link set lo up 2>&1 || true
-      # Give the daemon time to fsnotify + nsAdd + spawn netlinker.
-      sleep 3
-      after_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
+      # Hold the ns open with a live process so the /proc scan sees it.
+      ip netns exec xtcp_test_ns_a sleep 60 &
+      ns_a_pid=$!
+      # Give the daemon a couple of poll cycles (~2s each) to reconcile + enter.
+      sleep 6
       after_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
+      # Drop the process (ns now has no live process) and remove the bind mount.
+      kill "$ns_a_pid" 2>/dev/null || true
+      wait "$ns_a_pid" 2>/dev/null || true
       ip netns delete xtcp_test_ns_a 2>&1 || true
-      sleep 3
-      after_delete_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
+      # Give the daemon a couple of cycles to notice the ns is gone → nsDelete.
+      sleep 6
+      after_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
 
-      if [ "$after_evt" -gt "$before_evt" ] && [ "$after_inst" -gt "$before_inst" ] && [ "$after_delete_evt" -gt "$after_evt" ]; then
-        echo "XTCP2_SELF_TEST_NS_LIFECYCLE_PASS  (evt:$before_evt→$after_evt→$after_delete_evt inst:$before_inst→$after_inst)"
+      if [ "$after_inst" -gt "$before_inst" ] && [ "$after_del" -gt "$before_del" ]; then
+        echo "XTCP2_SELF_TEST_NS_LIFECYCLE_PASS  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
         check8=0
       else
-        echo "XTCP2_SELF_TEST_NS_LIFECYCLE_FAIL  (evt:$before_evt→$after_evt→$after_delete_evt inst:$before_inst→$after_inst)"
+        echo "XTCP2_SELF_TEST_NS_LIFECYCLE_FAIL  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
       fi
     else
       echo "XTCP2_SELF_TEST_NS_LIFECYCLE_FAIL  (ip not on PATH)"
@@ -355,11 +359,14 @@ pkgs.writeShellApplication {
     if [ "$check8" -ne 0 ]; then overall_ok=0; fi
 
     # ─── Check 9: TCP traffic inside a fresh netns — full netlinker path ─
-    # Creates a netns, brings up lo, starts a listening socket. xtcp2's
-    # per-ns netlinker SHOULD poll inet_diag and see the socket; the
-    # Deserialize loop SHOULD parse the response into TCPInfo / inet_diag
-    # attributes. We assert via the Netlinker "packets" counter for the
-    # per-ns netlinker fd: it must bump by ≥1 while the ns is live.
+    # Creates a netns, brings up lo, starts a listening socket. The listener is
+    # a LIVE PROCESS, so Method B's pre-poll reconcile discovers the ns via the
+    # /proc scan; xtcp2's per-ns netlinker then polls inet_diag and sees the
+    # socket, and the Deserialize loop parses the response into TCPInfo /
+    # inet_diag attributes. We assert via the Netlinker "packets" counter: it
+    # must bump by ≥1 while the ns is live. (The counter is process-wide, so the
+    # always-on host netlinker also drives it; this check confirms the netlinker
+    # path stays alive end-to-end while the ns exists, not per-ns isolation.)
     echo "--- check 9: TCP socket inside netns drives netlinker traffic ---"
     check9=1
     if command -v ip >/dev/null 2>&1 && command -v nc >/dev/null 2>&1; then
@@ -368,17 +375,19 @@ pkgs.writeShellApplication {
       before_packets=$(metric_value "xtcp_counts" 'variable="packets"')
       ip netns add xtcp_test_ns_b 2>&1 || true
       ip netns exec xtcp_test_ns_b ip link set lo up 2>&1 || true
-      # Listener in the ns. timeout bounds wall-clock so we don't leak
-      # a process if the check fails partway.
-      ip netns exec xtcp_test_ns_b timeout 10s nc -l 127.0.0.1 17322 >/dev/null 2>&1 &
+      # Listener in the ns — this is the live process Method B keys on. timeout
+      # bounds wall-clock so we don't leak a process if the check fails partway;
+      # it must outlast the discovery + poll window below.
+      ip netns exec xtcp_test_ns_b timeout 15s nc -l 127.0.0.1 17322 >/dev/null 2>&1 &
       ns_listener=$!
       sleep 1
       # Client also in the ns (loopback only — the ns has no real iface).
-      ip netns exec xtcp_test_ns_b sh -c '(echo hello; sleep 5) | nc -w 5 127.0.0.1 17322' >/dev/null 2>&1 &
+      ip netns exec xtcp_test_ns_b sh -c '(echo hello; sleep 8) | nc -w 8 127.0.0.1 17322' >/dev/null 2>&1 &
       ns_client=$!
 
-      # xtcp2 polls every 2s; give it two cycles to see the socket(s).
-      sleep 5
+      # xtcp2 polls every ~2s. Method B needs one pre-poll reconcile to discover
+      # the ns and a following cycle to poll its socket, so allow a few cycles.
+      sleep 8
       after_packets=$(metric_value "xtcp_counts" 'variable="packets"')
 
       # Tear down the listener + client and the ns itself.
@@ -397,43 +406,44 @@ pkgs.writeShellApplication {
     fi
     if [ "$check9" -ne 0 ]; then overall_ok=0; fi
 
-    # ─── Check 10: docker netns lifecycle — /run/docker/netns/ watch path ──
-    # xtcp2 probes /run/netns/ AND /run/docker/netns/ at startup
-    # (pkg/xtcp/init.go netNsCandidateDirs). When the coverage VM pre-
-    # creates the docker dir via tmpfiles, the daemon spawns a SECOND
-    # watchNsNamespace goroutine for it. Without exercising it the docker
-    # branch in watchNsNamespace stays at 0% coverage.
-    #
-    # We mimic docker's behavior — create a netns under /run/netns/ via
-    # the kernel's normal mechanism, then bind-mount it under
-    # /run/docker/netns/ to fire fsnotify Create on the docker dir.
-    # That's all docker actually does at the filesystem level when
-    # `docker run --network=…` spawns a container.
-    echo "--- check 10: docker netns lifecycle (/run/docker/netns/) ---"
+    # ─── Check 10: docker-style netns — /run/docker/netns/ bind mount ──────
+    # A container's netns is bind-mounted under /run/docker/netns/<id>. Under
+    # Method B the daemon discovers it by the LIVE PROCESS inside it (the /proc
+    # scan), and the resolver uses the /run/docker/netns bind mount for a
+    # best-effort NAME. We mimic docker: create a netns, bind it under
+    # /run/docker/netns/, and hold a live process in it. The daemon should enter
+    # it (netNamespaceInstance "start"); dropping the process + mount then tears
+    # it down (the "delete" counter bumps).
+    echo "--- check 10: docker-style netns (/run/docker/netns/ + live process) ---"
     check10=1
     if command -v ip >/dev/null 2>&1 && [ -d /run/docker/netns ]; then
-      before_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
       before_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
+      before_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
 
       ip netns add xtcp_docker_ns 2>&1 || true
-      # mount --bind reuses the netns inode under the docker dir, so
-      # checkMountInfo can find it just like a docker-managed one.
+      # mount --bind reuses the netns inode under the docker dir, so the resolver
+      # can name it just like a docker-managed one.
       mount --bind /run/netns/xtcp_docker_ns /run/docker/netns/xtcp_docker_ns 2>&1 || true
-      sleep 3
-      after_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
+      ip netns exec xtcp_docker_ns ip link set lo up 2>&1 || true
+      # Live process holds the ns open for the /proc scan.
+      ip netns exec xtcp_docker_ns sleep 60 &
+      ns_d_pid=$!
+      sleep 6
       after_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
 
+      kill "$ns_d_pid" 2>/dev/null || true
+      wait "$ns_d_pid" 2>/dev/null || true
       umount /run/docker/netns/xtcp_docker_ns 2>&1 || true
       rm -f /run/docker/netns/xtcp_docker_ns 2>&1 || true
       ip netns delete xtcp_docker_ns 2>&1 || true
-      sleep 3
-      after_delete_evt=$(metric_value "xtcp_counts" 'function="watchNamespaces"' 'variable="event"')
+      sleep 6
+      after_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
 
-      if [ "$after_evt" -gt "$before_evt" ] && [ "$after_inst" -gt "$before_inst" ] && [ "$after_delete_evt" -gt "$after_evt" ]; then
-        echo "XTCP2_SELF_TEST_NS_DOCKER_PASS  (evt:$before_evt→$after_evt→$after_delete_evt inst:$before_inst→$after_inst)"
+      if [ "$after_inst" -gt "$before_inst" ] && [ "$after_del" -gt "$before_del" ]; then
+        echo "XTCP2_SELF_TEST_NS_DOCKER_PASS  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
         check10=0
       else
-        echo "XTCP2_SELF_TEST_NS_DOCKER_FAIL  (evt:$before_evt→$after_evt→$after_delete_evt inst:$before_inst→$after_inst)"
+        echo "XTCP2_SELF_TEST_NS_DOCKER_FAIL  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
       fi
     else
       echo "XTCP2_SELF_TEST_NS_DOCKER_FAIL  (ip not on PATH or /run/docker/netns/ missing)"

--- a/pkg/xtcp/ns_reconcile.go
+++ b/pkg/xtcp/ns_reconcile.go
@@ -56,6 +56,13 @@ func (x *XTCP) mapReconciler(ctx context.Context, wg *sync.WaitGroup) {
 // pid on the next scan.
 func (x *XTCP) reconcile(ctx context.Context) (dels, stores int) {
 
+	// Serialize against the other caller (background mapReconciler vs. the
+	// Poller's pre-poll reconcile). Beyond keeping the nsMap diff coherent, this
+	// is REQUIRED for memory safety: discoverNamespaces drives nsScanner, which
+	// reuses buffers and a persistent /proc fd and must never run concurrently.
+	x.reconcileMu.Lock()
+	defer x.reconcileMu.Unlock()
+
 	startTime := time.Now()
 	defer func() {
 		x.pH.WithLabelValues("reconcile", "complete", "counter").Observe(time.Since(startTime).Seconds())

--- a/pkg/xtcp/ns_test.go
+++ b/pkg/xtcp/ns_test.go
@@ -162,7 +162,7 @@ func TestHandlePollRequest_alreadyPolling(t *testing.T) {
 	x := newNsFixture(t)
 	// pollAllNetlinkSockets requires more state; skip by checking the
 	// already-polling early return.
-	_, polled := x.handlePollRequest(1, 5 /* count > 0 */, x.pollStartTime)
+	_, polled := x.handlePollRequest(context.Background(), 1, 5 /* count > 0 */, x.pollStartTime)
 	if polled {
 		t.Error("handlePollRequest should return polled=false when count>0")
 	}

--- a/pkg/xtcp/poller.go
+++ b/pkg/xtcp/poller.go
@@ -60,7 +60,7 @@ func (x *XTCP) Poller(ctx context.Context, wg *sync.WaitGroup) {
 	x.pollTimeoutTimer = time.NewTimer(x.config.PollTimeout.AsDuration())
 	defer x.pollTimeoutTimer.Stop()
 
-	count := x.pollAllNetlinkSockets(0)
+	count := x.reconcileThenPoll(ctx, 0)
 	lastPollTime := time.Now()
 
 	for pollingLoops := uint64(1); misc.MaxLoopsOrForEver(pollingLoops, x.config.MaxLoops); pollingLoops++ {
@@ -80,7 +80,7 @@ func (x *XTCP) Poller(ctx context.Context, wg *sync.WaitGroup) {
 			// with any other periodic event. pct==0 → exactly PollFrequency.
 			ticker.Reset(computePollInterval(x.config.PollFrequency.AsDuration(), x.config.PollJitterPct, misc.JitterDuration))
 		case <-x.pollRequestCh:
-			next, polled := x.handlePollRequest(pollingLoops, count, lastPollTime)
+			next, polled := x.handlePollRequest(ctx, pollingLoops, count, lastPollTime)
 			if !polled {
 				continue
 			}
@@ -239,7 +239,7 @@ func (x *XTCP) recordPollerCycleDuration(pollingLoops uint64) {
 // handlePollRequest reacts to a poll-request tick. Returns (newCount, true)
 // when a fresh dump was issued, or (count, false) when the previous dump
 // is still in flight and the request was coalesced.
-func (x *XTCP) handlePollRequest(pollingLoops uint64, count int, lastPollTime time.Time) (int, bool) {
+func (x *XTCP) handlePollRequest(ctx context.Context, pollingLoops uint64, count int, lastPollTime time.Time) (int, bool) {
 	x.pC.WithLabelValues("Poller", "pollRequestCh", "count").Inc()
 	if x.debugLevel > 10 {
 		log.Printf("Poller <-x.pollRequestCh pollingLoops:%d count:%d", pollingLoops, count)
@@ -256,7 +256,7 @@ func (x *XTCP) handlePollRequest(pollingLoops uint64, count int, lastPollTime ti
 		log.Printf("Poller <-ticker.C pollingLoops:%d timeSinceLastPoll:%0.3fs",
 			pollingLoops, time.Since(lastPollTime).Seconds())
 	}
-	return x.pollAllNetlinkSockets(pollingLoops), true
+	return x.reconcileThenPoll(ctx, pollingLoops), true
 }
 
 // observeNetlinkerDone records the per-fd poll→done latency and (at
@@ -288,6 +288,25 @@ func (x *XTCP) observeNetlinkerDone(d netlinkerDone, count int) {
 	x.pC.WithLabelValues("Poller", "fdToNsMap", "error").Inc()
 	log.Printf("Poller <-x.netlinkerDoneCh, count:%d fd:%d after: %0.3fs %dms",
 		count, d.fd, pTime.Seconds(), pTime.Milliseconds())
+}
+
+// reconcileThenPoll runs a pre-poll reconcile and then issues the dump against
+// every ready socket. The reconcile re-derives the live namespace set from /proc
+// immediately before polling, so a namespace that appeared since the last cycle
+// (e.g. a container that just started) is entered and gets a socket without
+// waiting up to reconcileFrequency (5m) for the background ticker — this ties
+// discovery cadence to poll cadence. reconcile is mutex-guarded, so it never
+// races the background mapReconciler or the shared, buffer-reusing nsScanner.
+//
+// A namespace discovered here is polled starting the NEXT cycle: its socket
+// opens asynchronously (netNamespaceInstance) and is still -1 (reserved, skipped
+// by pollAllNetlinkSockets) during this cycle.
+func (x *XTCP) reconcileThenPoll(ctx context.Context, pollingLoops uint64) (count int) {
+	dels, stores := x.reconcile(ctx)
+	if (dels > 0 || stores > 0) && x.debugLevel > 10 {
+		log.Printf("reconcileThenPoll pre-poll reconcile dels:%d stores:%d", dels, stores)
+	}
+	return x.pollAllNetlinkSockets(pollingLoops)
 }
 
 func (x *XTCP) pollAllNetlinkSockets(pollingLoops uint64) (count int) {

--- a/pkg/xtcp/poller_pure_test.go
+++ b/pkg/xtcp/poller_pure_test.go
@@ -12,6 +12,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/randomizedcoder/xtcp2/pkg/nsdiscover"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
 	"github.com/randomizedcoder/xtcp2/pkg/xtcp_flat_record"
 )
@@ -48,6 +49,14 @@ func newPollerFixture(t *testing.T) *XTCP {
 	nl := make([]byte, 16)
 	x.nlRequest = &nl
 	x.pollTimeoutTimer = time.NewTimer(time.Hour) // never fires during test
+	// The reconcileThenPoll path (initial poll + fresh handlePollRequest) runs a
+	// pre-poll reconcile, which scans /proc via nsScanner. Point it at an empty
+	// temp tree so no namespaces are discovered and the poll logic under test is
+	// unaffected.
+	proc := t.TempDir()
+	x.nsScanner = nsdiscover.NewScanner(proc)
+	x.nsResolver = nsdiscover.NewResolver(proc, nil)
+	t.Cleanup(func() { _ = x.nsScanner.Close() })
 	return x
 }
 
@@ -285,9 +294,38 @@ func TestObserveNetlinkerDone_knownFDMissingNS(t *testing.T) {
 // branch is covered by ns_test.go:TestHandlePollRequest_alreadyPolling.
 func TestHandlePollRequest_fresh(t *testing.T) {
 	x := newPollerFixture(t)
-	count, polled := x.handlePollRequest(1, 0, time.Now())
+	count, polled := x.handlePollRequest(context.Background(), 1, 0, time.Now())
 	if count != 0 || !polled {
 		t.Errorf("fresh: count=%d, polled=%v; want 0, true", count, polled)
+	}
+}
+
+// reconcileThenPoll runs a pre-poll reconcile before polling. Here /proc (the
+// fixture's empty temp tree) shows no live namespaces, so two stale nsMap
+// entries must be reconciled away (their cancel fired) BEFORE the poll — proving
+// discovery happens on the poll path, not only on the 5m background ticker.
+func TestReconcileThenPoll_reconcilesBeforePolling(t *testing.T) {
+	x := newPollerFixture(t)
+	var mu sync.Mutex
+	cancels := 0
+	for _, ino := range []uint64{4026531900, 4026531901} {
+		wrapped := func() { mu.Lock(); cancels++; mu.Unlock() }
+		name := "gone"
+		x.nsMap.Store(ino, netNSitem{inode: ino, name: &name, cancel: wrapped, socketFD: -1})
+	}
+
+	count := x.reconcileThenPoll(context.Background(), 1)
+
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (stale entries reconciled away, none ready to poll)", count)
+	}
+	if n := lenSyncMap(x.nsMap); n != 0 {
+		t.Errorf("nsMap len = %d after pre-poll reconcile, want 0 (stale entries deleted)", n)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if cancels != 2 {
+		t.Errorf("cancels = %d, want 2 (both stale namespaces torn down)", cancels)
 	}
 }
 

--- a/pkg/xtcp/xtcp.go
+++ b/pkg/xtcp/xtcp.go
@@ -59,6 +59,13 @@ type XTCP struct {
 	nsResolver  *nsdiscover.Resolver
 	selfNsInode uint64
 
+	// reconcileMu serializes reconcile(). Two goroutines call it now — the
+	// background mapReconciler ticker and the Poller's pre-poll reconcile — and
+	// nsScanner reuses buffers + a persistent /proc fd (lseek+getdents), so it is
+	// NOT safe for concurrent use. The mutex guarantees single-threaded scanner
+	// access as well as a coherent nsMap diff.
+	reconcileMu sync.Mutex
+
 	packetBufferPool xsync.Pool[*[]byte]
 	xtcpEnvelopePool xsync.Pool[*xtcp_flat_record.Envelope]
 	xtcpRecordPool   xsync.Pool[*xtcp_flat_record.XtcpFlatRecord]
@@ -298,9 +305,13 @@ func (x *XTCP) Run(ctx context.Context, wg *sync.WaitGroup, runPoller bool) {
 	wg.Add(1)
 	go x.nsMapCountReporter(ctx, wg)
 
-	// Namespace discovery is the mapReconciler: it scans /proc each cycle and
-	// converges nsMap. There is no inotify watcher under Method B — a /proc scan
-	// re-derives ground truth (incl. anonymous namespaces) and cannot drift.
+	// Namespace discovery is reconcile(): a /proc scan re-derives ground truth
+	// (incl. anonymous namespaces) and converges nsMap — there is no inotify
+	// watcher under Method B. Two goroutines drive it: the Poller runs a pre-poll
+	// reconcile every cycle (so discovery tracks poll cadence), and this
+	// background mapReconciler ticks slowly as a floor — and is the ONLY driver
+	// when the poller is disabled (runPoller=false). reconcile is mutex-guarded,
+	// so the two never race the shared nsScanner.
 	wg.Add(1)
 	go x.mapReconciler(ctx, wg)
 
@@ -327,7 +338,8 @@ func (x *XTCP) Run(ctx context.Context, wg *sync.WaitGroup, runPoller bool) {
 	x.closeDestination()
 
 	// Release the persistent /proc scanner fd. Safe here: wg.Wait above means
-	// mapReconciler (the only scanner user) has already exited.
+	// both scanner users — the background mapReconciler and the Poller's pre-poll
+	// reconcile — have already exited.
 	if x.nsScanner != nil {
 		if cerr := x.nsScanner.Close(); cerr != nil && x.debugLevel > 10 {
 			log.Printf("XTCP.Run() nsScanner close: %v", cerr)


### PR DESCRIPTION
## Why

Two gaps left after the Method B (/proc-scan) discovery migration:

1. **Discovery latency** — discovery only ran on the background `mapReconciler` ticker (every 5m) plus a startup pass. A container that started between ticks wasn't monitored for up to 5 minutes: a real audit gap.
2. **The microVM self-test namespace checks were broken** — checks 8/9/10 were written for the removed dir-scan/inotify model. They assert on the `watchNamespaces` "event" counter (gone in the inotify removal), and checks 8/10 create namespaces with **no live process**, which Method B correctly never sees. On `main` today these checks fail.

## Pre-poll reconcile

- The Poller runs `reconcile()` immediately before each poll cycle (`reconcileThenPoll`), so a namespace that appeared since the last cycle is entered and gets a socket within ~1 poll interval instead of up to `reconcileFrequency` (5m). A namespace discovered here is polled from the **next** cycle (socket opens asynchronously, still `-1`/reserved this cycle — the existing skip path).
- `reconcile()` is now guarded by `reconcileMu`. Beyond a coherent `nsMap` diff this is **required for memory safety**: `nsScanner` reuses buffers + a persistent `/proc` fd and now has two callers (background `mapReconciler` + Poller), which must never scan concurrently.
- `ctx` threaded into the poll-driving path; the pure `pollAllNetlinkSockets` stays reconcile-free so its unit tests are unaffected. Shutdown's `nsScanner.Close()` stays safe — both scanner users are in the same `WaitGroup`.

## Self-test fixed for Method B

- Checks 8 (`NS_LIFECYCLE`) and 10 (`NS_DOCKER`) now hold a **live process** (`sleep`) inside the test namespace so the `/proc` scan can see it; assert discovery via `netNamespaceInstance` "start" and teardown via the `delete` counter (dropped the dead `watchNamespaces` assertions).
- Check 9 (`NS_TRAFFIC`) already had a persistent `nc` listener — refreshed its comment and widened timings for the discover-then-poll window.
- **Token names + themes unchanged** (`NS_LIFECYCLE`/`NS_TRAFFIC`/`NS_DOCKER`), so `nix/microvms/default.nix`'s sentinel parser and the docs table stay valid. No WIP nix files touched.

## Verification

- `go test -race ./pkg/xtcp/` ✅ (15.8s) · `-tags dest_s3parquet` ✅ · `./cmd/xtcp2/` ✅ · whole-module build ✅
- `golangci-lint` 0 issues · `gofmt` clean · `nix-instantiate --parse self-test.nix` OK
- New `TestReconcileThenPoll_reconcilesBeforePolling` proves the pre-poll reconcile runs (stale entries torn down) before the poll.
- io_uring WIP in `nix/microvms/{lib,mkVm}.nix` untouched.

## Deliberately deferred

- **Config knobs** for reconcile cadence / readiness grace (proto tags + `cmd/xtcp2` touchpoints) — pre-poll reconcile is always-on with a sensible default; the background ticker stays a 5m floor.
- **Anonymous-netns coverage proof** (`unshare -n`, no bind mount) — the headline Method B validation, but it needs a new self-test sentinel (touches `default.nix` and the harness setup that lives partly in the WIP `mkVm.nix`), so it's better done alongside that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
