### PR TITLE
test(selftest): anonymous-netns discovery proof (Method B audit gap)

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -312,7 +312,8 @@ The shared self-test (`nix/microvms/self-test.nix`) runs 10 checks in sequence o
 | 8 | `NS_LIFECYCLE` | a netns holding a live process is discovered by the Method B `/proc` scan (pre-poll reconcile → `netNamespaceInstance` start); process exit + ns removal → reconcile `delete`. Both counters bump |
 | 9 | `NS_TRAFFIC` | TCP listener (the live process Method B keys on) + client inside a fresh netns produces measurable Netlinker `packets` |
 | 10 | `NS_DOCKER` | docker-style netns: bind-mount under `/run/docker/netns/` + a live process is discovered via `/proc` and named from the bind mount; `netNamespaceInstance` start + `delete` bump |
-| — | `OVERALL` | All of 1–10 passed |
+| 16 | `NS_ANONYMOUS` | **the Method B audit-gap proof**: an anonymous `unshare -n` netns (no `/run/netns` bind mount) held by a live process is discovered purely via `/proc` — the exact case dir-scan/inotify was blind to; `netNamespaceInstance` start + `delete` bump |
+| — | `OVERALL` | All checks passed |
 
 The **soak** flavor doesn't run the self-test; instead its runner sleeps for `--duration`, then prints:
 

--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -241,7 +241,7 @@ let
       # Surface every sentinel the self-test emits so a real failure in
       # Check 4+ (BINARIES_HELP, GRPC_ROUNDTRIP, NS_*) doesn't hide
       # behind an unhelpful OVERALL_FAIL with no breadcrumbs.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
     };
   });
 
@@ -253,7 +253,7 @@ let
       # The two s3parquet-specific sentinels alongside the baseline set.
       # 240 s timeout because the worker accumulates rows for several
       # poll cycles before triggering the 1 MiB-threshold finalize.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
       timeoutSec = 240;
     };
   });
@@ -270,7 +270,7 @@ let
         # outcome visible. Without this the default filter hides
         # them; the checks still execute (and the daemon exercises the
         # corresponding code paths) but the harness output is misleading.
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
       };
     })
   );
@@ -282,7 +282,7 @@ let
         vm = vmsCoverageIoUring.${arch};
         suffix = "-coverage-iouring";
         scrapeCoverage = true;
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
       };
     })
   );

--- a/nix/microvms/self-test.nix
+++ b/nix/microvms/self-test.nix
@@ -26,6 +26,11 @@
 #                                              Deserialize on real netlink
 #                                              bytes — the main reason this
 #                                              exists)
+#   XTCP2_SELF_TEST_NS_ANONYMOUS_{PASS,FAIL}   an anonymous `unshare -n` netns
+#                                              (no /run/netns bind mount) held by
+#                                              a live process is discovered by
+#                                              the Method B /proc scan — the
+#                                              audit gap dir-scan/inotify missed
 #   XTCP2_SELF_TEST_CLICKHOUSE_RECORDS_{PASS,FAIL}    (clickhouse-pipeline only)
 #                                              xtcp.xtcp_flat_records > 0 AND
 #                                              xtcp.xtcp_flat_records_errors == 0
@@ -449,6 +454,45 @@ pkgs.writeShellApplication {
       echo "XTCP2_SELF_TEST_NS_DOCKER_FAIL  (ip not on PATH or /run/docker/netns/ missing)"
     fi
     if [ "$check10" -ne 0 ]; then overall_ok=0; fi
+
+    # ─── Check 16: anonymous netns (unshare -n, no bind mount) — audit gap ──
+    # THE Method B proof. `unshare --net` creates a network namespace with a
+    # live process but NO /run/netns or /run/docker/netns bind mount — exactly
+    # the anonymous container/pod netns the old dir-scan/inotify model was blind
+    # to. Method B discovers it purely from /proc/<pid>/ns/net, so xtcp2 should
+    # enter it and spawn a per-ns netlinker (netNamespaceInstance "start"), then
+    # tear it down (delete counter) once the process exits. Numbered 16 (next
+    # free id) but belongs with the NS group (8-10).
+    echo "--- check 16: anonymous netns (unshare -n, no bind mount) ---"
+    check16=1
+    if command -v unshare >/dev/null 2>&1; then
+      before_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
+      before_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
+      # Anonymous netns held open by a live process; no bind mount anywhere.
+      # exec sleep so the backgrounded pid IS the live process in the ns (kill
+      # then reaches it directly).
+      unshare --net sh -c 'ip link set lo up 2>/dev/null; exec sleep 60' &
+      anon_pid=$!
+      # A couple of poll cycles (~2s each) for the pre-poll reconcile to find it.
+      sleep 6
+      after_inst=$(metric_value "xtcp_counts" 'function="netNamespaceInstance"' 'variable="start"')
+      # Drop the process → the anonymous ns now has no live process → reconcile
+      # tears it down on a following cycle.
+      kill "$anon_pid" 2>/dev/null || true
+      wait "$anon_pid" 2>/dev/null || true
+      sleep 6
+      after_del=$(metric_value "xtcp_counts" 'function="delete"' 'variable="delete"')
+
+      if [ "$after_inst" -gt "$before_inst" ] && [ "$after_del" -gt "$before_del" ]; then
+        echo "XTCP2_SELF_TEST_NS_ANONYMOUS_PASS  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
+        check16=0
+      else
+        echo "XTCP2_SELF_TEST_NS_ANONYMOUS_FAIL  (inst:$before_inst→$after_inst del:$before_del→$after_del)"
+      fi
+    else
+      echo "XTCP2_SELF_TEST_NS_ANONYMOUS_FAIL  (unshare not on PATH)"
+    fi
+    if [ "$check16" -ne 0 ]; then overall_ok=0; fi
 
     ${lib.optionalString runS3ParquetCheck ''
       # ─── Check 13: s3parquet object landed in MinIO ──────────────────


### PR DESCRIPTION
## What

Thing 2 of the two deferred items — the **headline validation of Method B**. Adds self-test **Check 16 (`NS_ANONYMOUS`)**:

`unshare --net` creates a network namespace with a live process but **no `/run/netns` or `/run/docker/netns` bind mount** — exactly the anonymous container/pod netns the old dir-scan/inotify model was blind to. Method B discovers it purely from `/proc/<pid>/ns/net`, so the check asserts xtcp2 **enters it** (`netNamespaceInstance` "start" bumps) and **tears it down** once the process exits (`delete` bumps).

This is the proof of what the whole discovery migration buys: seeing *every* live namespace, not just the bind-mounted ones.

## Details

- **`self-test.nix`**: Check 16 + header token listing. Uses `exec sleep` so the backgrounded pid *is* the live process in the ns (so `kill` reaches it directly). `unshare` is already on the self-test PATH (`util-linux`). Runs in **every flavor** (ungated) alongside the other NS checks, needs **no host setup**, so **no microVM harness (`mkVm.nix`) changes** — nothing in the WIP files is touched.
- **`default.nix`**: `NS_ANONYMOUS` added to all four `sentinelRe` filters so the result line is surfaced (the check affects `OVERALL` regardless).
- **`docs/integration-testing.md`**: table row for the new check.

## Verification

- `nix-instantiate --parse` OK on both `self-test.nix` and `default.nix`.
- No Go changes. io_uring WIP untouched.

This is independent of #79 (config knobs) — both branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
