### PR TITLE
fix(xtcp2): context-aware -healthcheck probe (noctx/contextcheck clean)

### DIFF
--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -659,7 +659,7 @@ func runMain(parentCtx context.Context) int {
 	// starting the daemon. The scratch image has no shell/curl, so the binary
 	// self-checks (same pattern as the docker_custom_scrape exporter).
 	if *f.healthcheck {
-		return runHealthcheck(*f.promListen)
+		return runHealthcheck(ctx, *f.promListen)
 	}
 
 	c, done := prepareConfig(f)
@@ -826,7 +826,7 @@ func servePromHandler(promListen string, ipv4TTL, ipv6HopLimit uint32) {
 // the `-healthcheck` mode used by the container HEALTHCHECK on the scratch image
 // (no shell/curl to run an external probe). The port comes from PROM_LISTEN or
 // the -promListen flag; the daemon listens on 0.0.0.0, so 127.0.0.1 reaches it.
-func runHealthcheck(promListen string) int {
+func runHealthcheck(ctx context.Context, promListen string) int {
 	addr := promListen
 	if v, ok := os.LookupEnv("PROM_LISTEN"); ok && v != "" {
 		addr = v
@@ -836,8 +836,15 @@ func runHealthcheck(promListen string) int {
 		port = "9088" // promListenCst default
 	}
 	url := "http://127.0.0.1:" + port + "/readyz"
+	reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Printf("healthcheck: new request %s: %v", url, err)
+		return 1
+	}
 	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("healthcheck: GET %s: %v", url, err)
 		return 1

--- a/cmd/xtcp2/xtcp2_test.go
+++ b/cmd/xtcp2/xtcp2_test.go
@@ -448,7 +448,7 @@ func TestRunHealthcheck(t *testing.T) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer notReady.Close()
-	if rc := runHealthcheck(":" + portOf(notReady.URL)); rc != 1 {
+	if rc := runHealthcheck(context.Background(), ":"+portOf(notReady.URL)); rc != 1 {
 		t.Errorf("not-ready: rc=%d, want 1", rc)
 	}
 
@@ -456,12 +456,12 @@ func TestRunHealthcheck(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ready.Close()
-	if rc := runHealthcheck(":" + portOf(ready.URL)); rc != 0 {
+	if rc := runHealthcheck(context.Background(), ":"+portOf(ready.URL)); rc != 0 {
 		t.Errorf("ready: rc=%d, want 0", rc)
 	}
 
 	// Nothing listening -> unreachable -> 1.
-	if rc := runHealthcheck(":1"); rc != 1 {
+	if rc := runHealthcheck(context.Background(), ":1"); rc != 1 {
 		t.Errorf("unreachable: rc=%d, want 1", rc)
 	}
 }


### PR DESCRIPTION
## What

Fixes the pre-existing `noctx` lint finding on the `-healthcheck` `/readyz` probe (`cmd/xtcp2/xtcp2.go`) — `http.Client.Get` issues a request with no context.

- Build the request with `http.NewRequestWithContext` + `client.Do`.
- Thread `runMain`'s `ctx` down into `runHealthcheck` and derive a `3s` `WithTimeout` from it, so the probe honors process cancellation — which also satisfies `contextcheck` (the follow-on linter that fired once a local context appeared).

## No behavior change

The client keeps its existing 3s timeout; exit codes are unchanged (`0` ready / `1` not-ready-or-unreachable). `TestRunHealthcheck` (all three arms) passes with the call sites updated to pass `context.Background()`.

## Verification

- `golangci-lint run ./cmd/xtcp2/...` → **0 issues** (was 1: the `noctx`).
- `go test ./cmd/xtcp2/` ✅ · build ✅ · `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
