### PR TITLE
style(ctx): name the incoming context param ctx, not parentCtx

### DIFF
--- a/cmd/nsTest/nsTest.go
+++ b/cmd/nsTest/nsTest.go
@@ -264,8 +264,8 @@ var trafficSendIntervals = []time.Duration{
 // varied per-conn profiles, and registers a per-ns cancel so churn()
 // can tear it down before deleting the ns. Non-fatal on errors — a
 // failure to bring up some ns's traffic must not stop the wider churn.
-func startPersistentTraffic(parentCtx context.Context, nsName string, count int) {
-	nsCtx, cancel := context.WithCancel(parentCtx)
+func startPersistentTraffic(ctx context.Context, nsName string, count int) {
+	nsCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	nsTrafficStates.Store(nsName, &nsTrafficState{cancel: cancel, done: done})
 

--- a/cmd/xtcp2/xtcp2.go
+++ b/cmd/xtcp2/xtcp2.go
@@ -645,8 +645,8 @@ func main() {
 
 // runMain wires the production main body. Extracted so tests can run
 // it with stubbed daemonRunner / promHandlerStarter.
-func runMain(parentCtx context.Context) int {
-	ctx, cancel := context.WithCancel(parentCtx)
+func runMain(ctx context.Context) int {
+	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	complete := make(chan struct{}, signalChannelSizeCst)
@@ -659,7 +659,7 @@ func runMain(parentCtx context.Context) int {
 	// starting the daemon. The scratch image has no shell/curl, so the binary
 	// self-checks (same pattern as the docker_custom_scrape exporter).
 	if *f.healthcheck {
-		return runHealthcheck(ctx, *f.promListen)
+		return runHealthcheck(runCtx, *f.promListen)
 	}
 
 	c, done := prepareConfig(f)
@@ -707,7 +707,7 @@ func runMain(parentCtx context.Context) int {
 		log.Println("config validation succeeded")
 	}
 
-	daemonRunner(ctx, cancel, c)
+	daemonRunner(runCtx, cancel, c)
 	select {
 	case complete <- struct{}{}:
 	default:


### PR DESCRIPTION
## What

Two functions named their first (context) argument `parentCtx` and the derived child `ctx` — backwards from the Go idiom (incoming = `ctx`, derived children get distinct names).

- **`cmd/xtcp2` `runMain`**: incoming `parentCtx` → `ctx`; the cancellable child becomes `runCtx` (threaded to `runHealthcheck` + `daemonRunner`).
- **`cmd/nsTest` `startPersistentTraffic`**: incoming `parentCtx` → `ctx`; its child was already the distinctly-named `nsCtx`.

Parameter renames only — **no call-site or behavior changes** (renaming a param doesn't change its call signature).

## Scope note

A sweep confirmed **no function takes context in a non-first position**. Five functions take context first but with scoped names (`nsCtx`, `ctxRing`) — `netNamespaceInstance`, `createNetlinkersAndStore`, `iouringProcessResults`, `runPersistentTraffic`, `runTrafficPairs`. Those are the codebase's intentional scoped-context convention (they satisfy "ctx is first"), so they're left as-is. Happy to fold them into strict `ctx` naming if preferred.

## Verification

`go build ./cmd/...` ✅ · `golangci-lint` 0 issues · `go test ./cmd/xtcp2/` ✅ · `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
