### PR TITLE
feat(microvm): resource-snapshot service for the leak-soak

### DIFF
--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -464,7 +464,7 @@ rec {
         # Wait for xtcp2 to be up.
         booted=0
         for _ in $(seq 1 60); do
-          if grep -q 'Prometheus http listener started' "$LOG" 2>/dev/null; then
+          if grep -qE 'Prometheus http listener started|XTCP2_RES_SNAPSHOT' "$LOG" 2>/dev/null; then
             booted=1
             break
           fi
@@ -662,7 +662,7 @@ rec {
 
         booted=0
         for _ in $(seq 1 60); do
-          if grep -q 'Prometheus http listener started' "$LOG" 2>/dev/null; then
+          if grep -qE 'Prometheus http listener started|XTCP2_RES_SNAPSHOT' "$LOG" 2>/dev/null; then
             booted=1
             break
           fi

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -1758,6 +1758,52 @@ in
           };
         };
 
+        # Periodic /proc-based resource snapshots for the leak-soak (and the
+        # io_uring-vs-syscall comparison). Every 30s emit xtcp2's cumulative
+        # user/kernel CPU (utime/stime from /proc/PID/stat), voluntary and
+        # nonvoluntary context switches, RSS, and thread count (/proc/PID/status)
+        # as one XTCP2_RES_SNAPSHOT json line. Diff consecutive lines host-side
+        # to see long-term trends: rss_kb is the memory-growth signal, threads
+        # the OS-thread-leak signal, CPU + ctxt round it out. Gated to the load
+        # flavors (soak / tcp-stress).
+        systemd.services.xtcp2-resource-snapshot = lib.mkIf (isTcpStress || isSoak) {
+          description = "xtcp2 — periodic CPU/ctxt/RSS/thread snapshots (leak-soak)";
+          after = [ "xtcp2.service" ];
+          wants = [ "xtcp2.service" ];
+          wantedBy = [ "multi-user.target" ];
+          path = [
+            pkgs.procps
+            pkgs.gnugrep
+            pkgs.coreutils
+          ];
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = pkgs.writeShellScript "xtcp2-resource-snapshot" ''
+              set -u
+              clk=$(getconf CLK_TCK 2>/dev/null || echo 100)
+              while true; do
+                pid=$(pgrep -x xtcp2 | head -1 || true)
+                if [ -n "''${pid:-}" ] && [ -r "/proc/$pid/stat" ]; then
+                  # /proc/PID/stat: utime=14, stime=15 (clock ticks).
+                  read -r -a st < "/proc/$pid/stat"
+                  utime=''${st[13]}; stime=''${st[14]}
+                  vctx=$(grep -m1 '^voluntary_ctxt_switches' "/proc/$pid/status" | grep -oE '[0-9]+' || echo 0)
+                  nvctx=$(grep -m1 '^nonvoluntary_ctxt_switches' "/proc/$pid/status" | grep -oE '[0-9]+' || echo 0)
+                  rss=$(grep -m1 '^VmRSS' "/proc/$pid/status" | grep -oE '[0-9]+' || echo 0)
+                  threads=$(grep -m1 '^Threads' "/proc/$pid/status" | grep -oE '[0-9]+' || echo 0)
+                  printf 'XTCP2_RES_SNAPSHOT {"t":"%s","clk":%s,"utime":%s,"stime":%s,"vctx":%s,"nvctx":%s,"rss_kb":%s,"threads":%s}\n' \
+                    "$(date -u +%FT%TZ)" "$clk" "''${utime:-0}" "''${stime:-0}" "$vctx" "$nvctx" "$rss" "''${threads:-0}"
+                fi
+                sleep 30
+              done
+            '';
+            Restart = "on-failure";
+            RestartSec = "5s";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
+        };
+
         systemd.services.xtcp2-tcp-stress-load = lib.mkIf isTcpStress {
           description = "xtcp2 tcp-stress — load OCI image into docker";
           after = [ "docker.service" ];


### PR DESCRIPTION
## What

Adds an `xtcp2-resource-snapshot` systemd service (gated to the **soak / tcp-stress** flavors) that every 30s emits one `XTCP2_RES_SNAPSHOT` json line:

```
XTCP2_RES_SNAPSHOT {"t":"...","clk":100,"utime":..,"stime":..,"vctx":..,"nvctx":..,"rss_kb":..,"threads":..}
```

from `/proc/PID/stat` (utime/stime) + `/proc/PID/status` (ctxt switches, RSS, thread count). Diffing consecutive lines host-side gives the long-running leak signals — **`rss_kb`** (memory growth) and **`threads`** (OS-thread leak) — with CPU + ctxt for context. `lib.nix` boot-detection also accepts `XTCP2_RES_SNAPSHOT` as a readiness marker on those flavors.

## Why now

Instrumentation for the namespace-discovery soak — the "does it hold up over time" validation now that Method B keys a per-ns netlinker (socket + goroutines) by inode and reconciles every poll. `rss_kb`/`threads` staying flat over a multi-hour run is the leak proof.

## Provenance

Cleanly extracted from a larger parked WIP (`wip/io-uring-resource-snapshot`). The `/proc` snapshot logic is **verbatim**; I trimmed it for a standalone PR: dropped the unused `curl`/`strace` path deps and loop counter (they were placeholders for a not-yet-implemented `:9088` netlink-counter read + periodic `strace -c` sample) and left out the separable soak-arg tuning. Easy to add those back when that work resumes.

## Verification

`nix-instantiate --parse` OK on both files; gate vars (`isSoak`/`isTcpStress`) confirmed. No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
