### PR TITLE
fix(nix): update goVendorHash after fsnotify removal (unblocks microvm builds)

### DIFF
--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -106,5 +106,5 @@
   # Go vendor hash. Update by running `nix build .#xtcp2` and pasting the
   # `got:` value from the hash mismatch error. Used by every Nix check that
   # needs deps in the sandbox (see nix/lib/goModules.nix).
-  goVendorHash = "sha256-KpZrd1NhcLMEFrNehiGBwt7sKFZlwa+uankR1itYizw=";
+  goVendorHash = "sha256-gvORPkTs1uJZhcSNWLdJzELX8FEE5QosfS6hP0N9n2E=";
 }


### PR DESCRIPTION
## What

The microvm integration suite fails to build — **every** VM/binary build errors with:

```
go: inconsistent vendoring in /build/…source:
    gopkg.in/fsnotify.v1@v1.4.7: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
```

## Root cause

PR #75 removed `fsnotify` from `go.mod` when it replaced the dir-scan/inotify discovery with the `/proc` scan (Method B), but the Nix `goVendorHash` (`nix/versions.nix`) was never recomputed. The Go-module vendor dir is a **fixed-output derivation keyed by that hash**, so Nix kept serving the *pre-removal* vendor tree — which still lists `gopkg.in/fsnotify.v1` as explicit in `vendor/modules.txt` — against the new `go.mod` that no longer requires it. `go build -mod=vendor` then rejects the mismatch.

`go.mod`/`go.sum` and the source tree are already clean of fsnotify; only the pinned hash was stale.

## Fix

Recompute `goVendorHash` for the current `go.mod`/`go.sum`:
`sha256-KpZrd1…` → `sha256-gvORPk…`. `nix build .#xtcp2` now passes vendoring and builds to completion (exit 0).

## Impact

This is a prerequisite for the long-running integration runs — the `lifecycle` green gate can't even build without it. Recommend merging ahead of the soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
