### PR TITLE
fix(caps): Method B namespace discovery needs CAP_SYS_PTRACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For the full picture see the [documentation hub](docs/README.md).
 
 ## Quick start
 
-xtcp2 builds and runs with [Nix](https://nixos.org/). It is a Linux-only tool and needs `CAP_NET_ADMIN` (read TCP socket state) and `CAP_SYS_ADMIN` (enter namespaces) — in practice, run it as root or under `sudo`. It refuses to start if the hard-required capabilities are missing, printing exactly what it needs.
+xtcp2 builds and runs with [Nix](https://nixos.org/). It is a Linux-only tool and needs `CAP_NET_ADMIN` (read TCP socket state) and `CAP_SYS_ADMIN` (enter namespaces) — in practice, run it as root or under `sudo`. It refuses to start if the hard-required capabilities are missing, printing exactly what it needs. For multi-namespace visibility it also needs `CAP_SYS_PTRACE`: namespace discovery reads `/proc/<pid>/ns/net` of other processes, which the kernel gates behind `ptrace_may_access` even for root. Without it xtcp2 starts (with a warning) but sees only its own namespace — every container/pod netns is invisible.
 
 ```sh
 # 1. Clone

--- a/docs/network-namespaces.md
+++ b/docs/network-namespaces.md
@@ -46,7 +46,7 @@ The per-namespace reader lives in `pkg/xtcp/ns_net_namespace.go`. Because `setns
 3. Opens a netlink socket — now scoped to that namespace — and runs the [netlinkers](netlink-collection.md#netlinkers).
 4. On exit, restores the original namespace and releases the thread.
 
-Entering a namespace requires `CAP_SYS_ADMIN`; without it every `setns` fails with `EPERM`. See [observability](observability.md#capability-checks).
+Entering a namespace requires `CAP_SYS_ADMIN`; without it every `setns` fails with `EPERM`. **Discovering** namespaces requires `CAP_SYS_PTRACE`: Method B enumerates live namespaces by reading `/proc/<pid>/ns/net`, and the kernel gates that readlink/open behind `ptrace_may_access`, which denies non-dumpable targets (system daemons, `ip netns exec` children) even to root. Without `CAP_SYS_PTRACE` the `/proc` scan sees only xtcp2's own namespace — the daemon starts (with a soft-capability warning) but discovers nothing to enter. See [observability](observability.md#capability-checks).
 
 ## Thread-leak avoidance
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -47,6 +47,7 @@ For always-on profiling, xtcp2 integrates with [Pyroscope](https://pyroscope.io/
 |---|---|---|
 | `CAP_NET_ADMIN` | **fatal** | netlink `inet_diag` queries — without it xtcp2 can read no TCP data at all. |
 | `CAP_SYS_ADMIN` | **fatal** | `setns(CLONE_NEWNET)` into per-namespace sockets — without it every namespace enter/restore fails with `EPERM`. |
+| `CAP_SYS_PTRACE` | warning | Method B **discovery** reads `/proc/<pid>/ns/net` of other processes, gated by `ptrace_may_access` (denied for non-dumpable targets even to root). Without it the `/proc` scan sees only xtcp2's own namespace — the daemon runs but discovers no container/pod netns. |
 | `CAP_NET_RAW` | warning | raw-socket (`-dest udp:…` with `IP_HDRINCL`) writes — the daemon runs without it, but a UDP destination fails at the first packet. |
 | `CAP_SYS_RESOURCE` | warning | raising `RLIMIT_MEMLOCK` for `io_uring` ring memory — without it large `-ioUring` rings may fail to allocate. |
 

--- a/docs/output-and-destinations.md
+++ b/docs/output-and-destinations.md
@@ -92,7 +92,7 @@ Generated Go types live in `pkg/xtcp_flat_record/`. For the full schema referenc
 
 ## Quick recipes
 
-These exercise the analysis-friendly formats and sinks. xtcp2 needs `CAP_NET_ADMIN` + `CAP_SYS_ADMIN` (run as root / `sudo`) and at least one namespace directory to exist (see [network namespaces](network-namespaces.md)); use a low non-zero `-d` (e.g. `-d 1`) so logs stay quiet on stderr while records go to the chosen sink.
+These exercise the analysis-friendly formats and sinks. xtcp2 needs `CAP_NET_ADMIN` + `CAP_SYS_ADMIN` (run as root / `sudo`), plus `CAP_SYS_PTRACE` for multi-namespace discovery (reading `/proc/<pid>/ns/net`; without it only the host namespace is seen — see [network namespaces](network-namespaces.md)); use a low non-zero `-d` (e.g. `-d 1`) so logs stay quiet on stderr while records go to the chosen sink.
 
 **Local binary:**
 

--- a/nix/modules/xtcp2-service.nix
+++ b/nix/modules/xtcp2-service.nix
@@ -57,6 +57,12 @@ in
         "CAP_NET_RAW"
         "CAP_SYS_RESOURCE"
         "CAP_SYS_ADMIN"
+        # Method B discovery reads /proc/<pid>/ns/net of OTHER processes to
+        # enumerate live network namespaces; the kernel gates that behind
+        # ptrace_may_access, which denies non-dumpable targets (system daemons,
+        # `ip netns exec` children) even to root without CAP_SYS_PTRACE. Without
+        # it the /proc scan sees only xtcp2's own ns and discovers nothing.
+        "CAP_SYS_PTRACE"
       ];
       description = ''
         Linux capabilities granted to xtcp2 via AmbientCapabilities +

--- a/pkg/xtcp/init_capabilities.go
+++ b/pkg/xtcp/init_capabilities.go
@@ -42,6 +42,12 @@ var requiredCaps = []requiredCap{
 		reason: "setns(CLONE_NEWNET) into per-namespace netlink sockets; without it, every setns into a new ns AND every restore back to the original fails with EPERM, the openAndSetNSWithRetries retry loop spins through all 10 attempts holding a locked OS thread, and a heavy ns-churn workload exhausts the SetMaxThreads ceiling within a few hours",
 	},
 	{
+		bit:    unix.CAP_SYS_PTRACE,
+		name:   "CAP_SYS_PTRACE",
+		fatal:  false,
+		reason: "Method B namespace discovery reads /proc/<pid>/ns/net of OTHER processes to enumerate live network namespaces. The kernel gates that readlink/open behind ptrace_may_access, which denies non-dumpable targets (most system daemons, and anything spawned via `ip netns exec`) to a process lacking CAP_SYS_PTRACE — even one running as root. Without it, discovery sees ONLY xtcp2's own namespace: every per-container/pod/other netns is invisible and silently unmonitored (the /proc scan's skipped-pid counter climbs while found stays at 1). Grant CAP_SYS_PTRACE for multi-namespace visibility; host-only monitoring works without it",
+	},
+	{
 		bit:    unix.CAP_NET_RAW,
 		name:   "CAP_NET_RAW",
 		fatal:  false,


### PR DESCRIPTION
## The bug

Once #84 unblocked the microvm build, the self-test surfaced a **silent discovery regression**: `NS_LIFECYCLE`, `NS_DOCKER`, `NS_ANONYMOUS` all fail with `inst:0→0` — `netNamespaceInstance` never fires, so no per-namespace netlinker is ever spawned. `NETLINK`/`NS_TRAFFIC` pass (host-only monitoring works).

## Root cause

Method B (`/proc`-scan discovery, #75) enumerates live namespaces by reading **`/proc/<pid>/ns/net` of other processes**. The kernel gates that `readlink`/`open` behind `ptrace_may_access`, which denies **non-dumpable** targets — most system daemons, and anything spawned via `ip netns exec` — to a reader without **`CAP_SYS_PTRACE`**, *even one running as root*. The old dir-scan read world-readable `/run/netns` bind mounts and needed no such cap, so the requirement changed silently under the migration and the cap was never added.

Instrumented diagnostic from the VM (folded into the sentinel temporarily):
```
disc[start=7 found=7 skip=666]   → 7 scans, ~1 found/scan (own ns only), ~95 skipped/scan
```
Every scan finds only xtcp2's own namespace and skips ~95 pids it can't ptrace-read. Reproduced locally as uid 1000: the scanner finds only my own processes' namespaces and skips others — same mechanism.

## Fix

- **`init_capabilities.go`**: add `CAP_SYS_PTRACE` as a **soft-required** capability (warning, not fatal — host-only monitoring is legitimate and works without it). The startup warning names exactly what's degraded; the fatal-path systemd snippet now includes it via `allCapNames()`.
- **`nix/modules/xtcp2-service.nix`**: add `CAP_SYS_PTRACE` to the default cap set (Ambient + BoundingSet) so the reference module and every microvm flavor can actually discover namespaces.
- **docs** (README, network-namespaces, output-and-destinations, observability): document the requirement and the host-only degradation.

## Verification

`go test ./pkg/xtcp/ -run Cap` ✅ · `golangci-lint` 0 issues · `gofmt` clean · `nix-instantiate --parse` OK. A confirming `lifecycle` VM run (NS checks → green) is in progress; I'll post the result.

This is the last blocker before the soak — discovery genuinely wasn't discovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
