### PR TITLE
feat(microvm): surface the resource-snapshot leak trend in the soak summary

### DIFF
--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -513,6 +513,25 @@ rec {
         echo "  xtcp2 panics:     $final_panics"
         echo "  xtcp2 restarts:   $final_restarts"
 
+        # Resource-snapshot trend (XTCP2_RES_SNAPSHOT from the in-VM
+        # xtcp2-resource-snapshot service): rss_kb is the memory-growth signal,
+        # threads the OS-thread-leak signal. Over a churn soak both should stay
+        # bounded, not grow monotonically — a large positive delta is the leak
+        # tell. Reported (not gated): thread count legitimately fluctuates with
+        # per-ns netlinker spawn/teardown, so a human reads the trend.
+        snap_n=$(grep -cE 'XTCP2_RES_SNAPSHOT' "$LOG" 2>/dev/null || true)
+        echo "  res snapshots:    $snap_n"
+        if [ "$snap_n" -ge 2 ]; then
+          first=$(grep -E 'XTCP2_RES_SNAPSHOT' "$LOG" | head -1)
+          last=$(grep -E 'XTCP2_RES_SNAPSHOT' "$LOG" | tail -1)
+          rss0=$(printf '%s' "$first" | grep -oE 'rss_kb":[0-9]+' | grep -oE '[0-9]+' | head -1)
+          rss1=$(printf '%s' "$last"  | grep -oE 'rss_kb":[0-9]+' | grep -oE '[0-9]+' | head -1)
+          thr0=$(printf '%s' "$first" | grep -oE 'threads":[0-9]+' | grep -oE '[0-9]+' | head -1)
+          thr1=$(printf '%s' "$last"  | grep -oE 'threads":[0-9]+' | grep -oE '[0-9]+' | head -1)
+          echo "  rss_kb trend:     ''${rss0:-?} -> ''${rss1:-?}  (delta $(( ''${rss1:-0} - ''${rss0:-0} )) kb)"
+          echo "  threads trend:    ''${thr0:-?} -> ''${thr1:-?}  (delta $(( ''${thr1:-0} - ''${thr0:-0} )))"
+        fi
+
         rc=0
         if [ "$final_panics" -ne 0 ]; then
           echo "FAIL: $final_panics panic(s) in transcript"


### PR DESCRIPTION
## What

#83 added the `xtcp2-resource-snapshot` service that emits `XTCP2_RES_SNAPSHOT` lines (rss_kb, threads, CPU, ctxt) to the VM console every 30s — but the **soak runner never extracted them**. The leak signal was captured in the serial transcript and thrown away; the summary only reported churn/panics/restarts.

This adds the missing runner-side half: the soak summary now reports the **snapshot count** and the **`rss_kb` + `threads` trend** (first → last, with deltas).

```
res snapshots:    6
rss_kb trend:     9572 -> 29916  (delta 20344 kb)
threads trend:    5 -> 31  (delta 26)
```

## Reported, not gated

Thread count legitimately fluctuates with per-ns netlinker spawn/teardown under churn, so this is **informational** — a human reads the trend. Bounded/plateauing over a long run = healthy; a monotonic climb = leak. (The example above is 3-min ramp-up to steady state, not a leak.)

## Context

Surfaced while running the namespace-discovery soak validation: the daemon survived a 5-min churn soak (1815 ns-churn events, 0 panics, 0 restarts), but the leak trend was invisible until this. A 1h soak is running now with this change to get the real memory/thread trend over time.

`nix-instantiate --parse` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
