### PR TITLE
fix(microvm): fast + robust soak trend extraction on long transcripts

### DIFF
--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -515,15 +515,22 @@ rec {
 
         # Resource-snapshot trend (XTCP2_RES_SNAPSHOT from the in-VM
         # xtcp2-resource-snapshot service): rss_kb is the memory-growth signal,
-        # threads the OS-thread-leak signal. Over a churn soak both should stay
-        # bounded, not grow monotonically — a large positive delta is the leak
-        # tell. Reported (not gated): thread count legitimately fluctuates with
-        # per-ns netlinker spawn/teardown, so a human reads the trend.
+        # threads the OS-thread-leak signal. The first sample is cold-start, so
+        # the first->last delta always includes ramp-up to steady state (the
+        # daemon spawns per-ns netlinkers as it discovers the churn set) — a
+        # healthy run ramps then PLATEAUS. The leak tell is continued growth late
+        # in the run, so on a suspicious delta check whether rss_kb/threads are
+        # still climbing near the end (full per-30s series is in the transcript).
+        # Reported, not gated.
         snap_n=$(grep -cE 'XTCP2_RES_SNAPSHOT' "$LOG" 2>/dev/null || true)
         echo "  res snapshots:    $snap_n"
-        if [ "$snap_n" -ge 2 ]; then
-          first=$(grep -E 'XTCP2_RES_SNAPSHOT' "$LOG" | head -1)
-          last=$(grep -E 'XTCP2_RES_SNAPSHOT' "$LOG" | tail -1)
+        if [ "''${snap_n:-0}" -ge 2 ]; then
+          # -m1 (stop at first) + tac|-m1 (first from the end) so we never scan
+          # the whole transcript, which is hundreds of MB on a multi-hour soak
+          # (a plain `grep|tail -1` there is slow enough to race VM teardown and
+          # drop these lines from the summary). Guarded so set -e can't abort.
+          first=$(grep -am1 'XTCP2_RES_SNAPSHOT' "$LOG" 2>/dev/null || true)
+          last=$(tac "$LOG" 2>/dev/null | grep -am1 'XTCP2_RES_SNAPSHOT' || true)
           rss0=$(printf '%s' "$first" | grep -oE 'rss_kb":[0-9]+' | grep -oE '[0-9]+' | head -1)
           rss1=$(printf '%s' "$last"  | grep -oE 'rss_kb":[0-9]+' | grep -oE '[0-9]+' | head -1)
           thr0=$(printf '%s' "$first" | grep -oE 'threads":[0-9]+' | grep -oE '[0-9]+' | head -1)


### PR DESCRIPTION
## What

The #86 in-summary `rss_kb`/`threads` trend used `grep … | tail -1`, which scans the **entire** serial transcript — hundreds of MB on a multi-hour soak (**471 MB** for the 1h validation run). That's slow enough to race the VM-teardown trap, so the trend lines were **dropped from the 1h summary** (the data was intact in the transcript, just never surfaced — I had to extract it by hand).

## Fix

Read from the ends instead of scanning the whole file:
- `grep -am1 …` for the first snapshot
- `tac … | grep -am1 …` for the last

On the real 471 MB transcript this runs in **~0.5s** (measured) and yields identical values (`11504→34704` kb, `7→34` threads). Guarded with `|| true` so `set -e` can't abort the summary, and the `snap_n` test uses a default so an empty count can't error.

Also clarified the comment: the first→last delta spans **cold-start ramp-up**, so a large delta isn't the leak tell by itself — continued *late* growth is. (The 1h run ramped to ~34 MB / 34 threads by ~10 min, then held flat for the remaining 50 min — bounded, no leak.)

## Verification

`nix-instantiate --parse` OK; extraction validated against the actual 471 MB 1h-soak transcript (0.5s, correct output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
