### PR TITLE
fix(oci): ship CA trust bundle so xtcp2 can verify TLS to S3

### DIFF
--- a/nix/lib/mkOciImage.nix
+++ b/nix/lib/mkOciImage.nix
@@ -28,6 +28,15 @@
 let
   contents = [
     binaries
+    # CA trust bundle. The image is otherwise scratch (binaries only), so
+    # without this Go's crypto/x509 has no roots and HTTPS to real endpoints
+    # — e.g. the s3parquet destination uploading to AWS S3 — fails with
+    # "x509: certificate signed by unknown authority". dockerTools.caCertificates
+    # installs the bundle at every standard path, including Go's default Linux
+    # location /etc/ssl/certs/ca-certificates.crt. (The microVM tests never
+    # caught this: they upload to in-VM MinIO over plain HTTP, so TLS is never
+    # exercised.)
+    pkgs.dockerTools.caCertificates
   ]
   ++ lib.optional (protoFile != null) (
     pkgs.runCommand "xtcp2-proto-payload" { } ''
@@ -49,6 +58,10 @@ pkgs.dockerTools.streamLayeredImage {
   config = {
     Entrypoint = [ entrypoint ];
     ExposedPorts = exposedPortsAttr;
+    # Point Go's crypto/x509 explicitly at the bundle shipped above — belt-and-
+    # suspenders alongside the standard /etc/ssl/certs path, so TLS verification
+    # works even if Go's default search paths ever change.
+    Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt" ];
   }
   // lib.optionalAttrs (healthcheck != null) { Healthcheck = healthcheck; };
 }


### PR DESCRIPTION
## Problem
In production, every s3parquet upload to real AWS S3 fails:
`tls: failed to verify certificate: x509: certificate signed by unknown authority`.

## Cause
The xtcp2 OCI image is scratch-based (binaries + proto only) — it ships **no CA certificates**, so Go's `crypto/x509` has no roots to verify AWS's TLS chain. The microVM soak tests never caught this because they upload to an in-VM MinIO over plain **HTTP**, so TLS was never exercised.

## Fix
Add `pkgs.dockerTools.caCertificates` to the shared image factory (`nix/lib/mkOciImage.nix`) — installs the bundle at every standard path incl. Go's default `/etc/ssl/certs/ca-certificates.crt` — and set `SSL_CERT_FILE` in the image config as an explicit pointer. Fixes all image variants (oci-xtcp2 / -debug / -stripped).

**Verified** in the rebuilt image: `/etc/ssl/certs/ca-certificates.crt` + `ca-bundle.crt` present and `SSL_CERT_FILE` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)