### PR TITLE
feat(metrics): S3 upload error-class + dropped-data counters

### DIFF
--- a/pkg/xtcp/destinations_s3parquet.go
+++ b/pkg/xtcp/destinations_s3parquet.go
@@ -524,6 +524,11 @@ func (d *s3ParquetDest) uploadWithRetry(ctx context.Context, key string, buf *by
 			d.bucket, key, attempt, d.maxAttempts, errMsg)
 		if d.x.pC != nil {
 			d.x.pC.WithLabelValues("destS3Parquet", "uploadRetry", "error").Inc()
+			// Same failed attempt, broken down by a BOUNDED error class (never
+			// the raw error text) so cardinality stays fixed — lets a dashboard
+			// tell a TLS/cert failure apart from a timeout, DNS, or refused
+			// connection. See classifyUploadErr for the closed set of classes.
+			d.x.pC.WithLabelValues("destS3Parquet", "uploadErrorClass", classifyUploadErr(err)).Inc()
 		}
 		if attempt == d.maxAttempts {
 			break
@@ -536,9 +541,56 @@ func (d *s3ParquetDest) uploadWithRetry(ctx context.Context, key string, buf *by
 	}
 	if d.x.pC != nil {
 		d.x.pC.WithLabelValues("destS3Parquet", "upload", "error").Inc()
+		// Quantify the data loss with fixed label values: upload/error counts
+		// the dropped OBJECT; these count the rows/bytes lost inside it, so a
+		// prolonged S3 outage's data loss is measurable, not just log-visible.
+		d.x.pC.WithLabelValues("destS3Parquet", "uploadRowsDropped", "error").Add(float64(rows))
+		d.x.pC.WithLabelValues("destS3Parquet", "uploadBytesDropped", "error").Add(float64(size))
 	}
 	log.Printf("destS3Parquet PUT %s/%s permanently failed after %d attempts; dropping %d rows",
 		d.bucket, key, d.maxAttempts, rows)
+}
+
+// s3 upload-error classes — a fixed, bounded set used as the `type` label of
+// the "uploadErrorClass" counter. Every upload error maps to exactly one of
+// these constants; the raw error string is NEVER used as a label value, so the
+// metric's cardinality is capped at this closed set no matter what S3 returns.
+const (
+	s3ErrClassTLS      = "tls"      // cert/verify failures (x509, tls:)
+	s3ErrClassTimeout  = "timeout"  // deadline exceeded / i/o timeout
+	s3ErrClassCanceled = "canceled" // context canceled (shutdown)
+	s3ErrClassDNS      = "dns"      // name resolution failure
+	s3ErrClassRefused  = "refused"  // connection refused
+	s3ErrClassOther    = "other"    // anything else (default)
+)
+
+// classifyUploadErr maps a PutObject failure to one of the fixed s3ErrClass*
+// categories. Context errors are matched structurally via errors.Is; the rest
+// fall back to substring checks on stable Go/minio error text. Anything
+// unrecognized is "other" — the label value is always drawn from the closed
+// const set above, so it cannot explode metric cardinality.
+func classifyUploadErr(err error) string {
+	switch {
+	case err == nil:
+		return s3ErrClassOther
+	case errors.Is(err, context.Canceled):
+		return s3ErrClassCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return s3ErrClassTimeout
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "x509:") || strings.Contains(msg, "tls:"):
+		return s3ErrClassTLS
+	case strings.Contains(msg, "no such host"):
+		return s3ErrClassDNS
+	case strings.Contains(msg, "connection refused"):
+		return s3ErrClassRefused
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return s3ErrClassTimeout
+	default:
+		return s3ErrClassOther
+	}
 }
 
 // backoffWindow returns min(cap, base<<(attempt-1)) for attempt>=1, computed

--- a/pkg/xtcp/destinations_s3parquet_classify_test.go
+++ b/pkg/xtcp/destinations_s3parquet_classify_test.go
@@ -1,0 +1,48 @@
+//go:build dest_s3parquet
+
+package xtcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestClassifyUploadErr pins the bounded set of upload-error classes so the
+// uploadErrorClass counter can never grow beyond these label values, and so a
+// production error (e.g. the AWS-S3 TLS verify failure) lands in the expected
+// bucket. Every case must return one of the s3ErrClass* constants.
+func TestClassifyUploadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, s3ErrClassOther},
+		{"canceled", context.Canceled, s3ErrClassCanceled},
+		{"deadline", context.DeadlineExceeded, s3ErrClassTimeout},
+		{"deadline wrapped", fmt.Errorf("PutObject: %w", context.DeadlineExceeded), s3ErrClassTimeout},
+		{"tls x509", errors.New(`tls: failed to verify certificate: x509: certificate signed by unknown authority`), s3ErrClassTLS},
+		{"dns", errors.New(`dial tcp: lookup runpod-xtcp-dev.s3.amazonaws.com: no such host`), s3ErrClassDNS},
+		{"refused", errors.New(`dial tcp 10.0.0.1:443: connect: connection refused`), s3ErrClassRefused},
+		{"io timeout", errors.New(`Put "https://…": read tcp: i/o timeout`), s3ErrClassTimeout},
+		{"other", errors.New(`AccessDenied: you do not have permission to access this resource`), s3ErrClassOther},
+	}
+	// Guard: the classifier must only ever emit values from this closed set.
+	allowed := map[string]bool{
+		s3ErrClassTLS: true, s3ErrClassTimeout: true, s3ErrClassCanceled: true,
+		s3ErrClassDNS: true, s3ErrClassRefused: true, s3ErrClassOther: true,
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyUploadErr(tt.err)
+			if got != tt.want {
+				t.Errorf("classifyUploadErr(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+			if !allowed[got] {
+				t.Errorf("classifyUploadErr(%v) returned unbounded label %q (cardinality risk)", tt.err, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Makes the s3parquet upload failures observable (the same TLS failures fixed in the OCI CA-bundle PR were firing silently because nothing watched the existing retry counters).

Adds to `xtcp_counts{function,variable,type}` (schema unchanged, existing counters untouched):

- **`uploadRowsDropped` / `uploadBytesDropped`** — data-loss *volume* on terminal failure (previously only dropped *objects* were counted).
- **`uploadErrorClass`** — failure breakdown whose `type` label is a **bounded** enum from `classifyUploadErr`: `tls / timeout / canceled / dns / refused / other`. The raw error string is **never** used as a label value, so cardinality is capped at that closed set. A table test asserts the classifier only ever emits those values.

So a TLS/cert problem now shows as `uploadErrorClass{type="tls"}`, distinct from a timeout. gofmt/vet/golangci-lint clean; tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)