### PR TITLE
fix(logs): quiet per-minute MapCount/LenSyncMap counter logs

### DIFF
--- a/pkg/xtcp/ns_map_count.go
+++ b/pkg/xtcp/ns_map_count.go
@@ -43,8 +43,12 @@ func (x *XTCP) nsMapCountReporter(ctx context.Context, wg *sync.WaitGroup) {
 			x.pG.Set(float64(mc))
 			x.pC.WithLabelValues("mapCountReporter", "tick", "count").Inc()
 
-			if x.debugLevel > 100 {
-				// debug code to check the counters work correctly
+			if x.debugLevel > 1000 {
+				// Very-high-debug counter-sanity logs, superseded by the
+				// x.pG gauge set above — kept only for deep debugging. Gated
+				// above the default -d 111 so they stay silent in normal
+				// operation; LenSyncMap() is an O(n) sync.Map scan, so it
+				// must stay inside this guard.
 				log.Printf("add MapCount(): %d\n", mc)
 				log.Printf("add LenSyncMap(): %d\n", x.LenSyncMap())
 			}


### PR DESCRIPTION
## Problem
Production emits `add MapCount(): N` and `add LenSyncMap(): N` every minute — noise. The data is already the Prometheus gauge `x.pG`, so the logs are redundant.

## Cause
They were gated at `debugLevel > 100`, but the default `-d` is `debugLevelCst = 111` (> 100), so the "high-debug" tier prints by default.

## Fix
Raise the gate to `> 1000` (the codebase's "very high" tier) so they stay silent at the default and reappear only for deep debugging. Also stops the O(n) `LenSyncMap()` sync.Map scan (verification-only per its comment) from running every minute at the default level. No change to the gauge/counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)