### PR TITLE
feat(cmd): xtcp2ctl — operator control CLI

### DIFF
--- a/cmd/xtcp2ctl/xtcp2ctl.go
+++ b/cmd/xtcp2ctl/xtcp2ctl.go
@@ -1,0 +1,320 @@
+// Command xtcp2ctl is the operator control CLI for a running xtcp2 daemon.
+//
+// Where cmd/xtcp2client streams TCP stats out of the XTCPFlatRecordService,
+// xtcp2ctl drives the ConfigService: it changes poll cadence, triggers polls,
+// tunes the S3 upload timing, and applies an arbitrary new config via a
+// soft restart — all without redeploying the container. It's a thin,
+// dependency-light wrapper over the generated ConfigService client; anything
+// it does is equally reachable with grpcurl (see docs/grpc-api.md).
+//
+// Usage:
+//
+//	xtcp2ctl <command> [flags]
+//
+// Commands:
+//
+//	get                  print the daemon's current config (S3 creds redacted)
+//	set-poll-frequency   change the poll frequency + timeout live
+//	trigger-poll         trigger a single poll now
+//	poll-burst           trigger N polls spaced I apart (incident snapshots)
+//	set-s3               change the s3parquet flush timer and/or byte cap live
+//	reconfigure          apply a full config from a file/stdin (soft restart)
+//
+// Every command accepts -target/-port/-d. Run `xtcp2ctl <command> -h` for
+// per-command flags.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/randomizedcoder/xtcp2/pkg/misc"
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+const (
+	targetHostnameCst = "localhost"
+	// grpcPortCst MUST match the xtcp2 daemon's default (cmd/xtcp2
+	// grpcPortCst, currently 8889). Out-of-step ports turn every call into a
+	// silent connection refused.
+	grpcPortCst = "8889"
+
+	// callTimeout bounds a single unary control RPC. reconfigure returns
+	// before the daemon actually re-execs (the daemon delays its shutdown so
+	// the response flushes), so this is comfortably long enough.
+	callTimeout = 15 * time.Second
+)
+
+var (
+	// Passed by "go build -ldflags" for -v.
+	commit  string
+	date    string
+	version string
+)
+
+func main() {
+	misc.DieIfNotLinux()
+	os.Exit(runMain(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runMain dispatches the subcommand. Extracted so tests can drive it with
+// synthetic args + writers against a bufconn server.
+func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		usage(stderr)
+		return 2
+	}
+	switch args[0] {
+	case "-v", "--version", "version":
+		fmt.Fprintf(stdout, "xtcp2ctl commit:%s\tdate(UTC):%s\tversion:%s\n", commit, date, version)
+		return 0
+	case "-h", "-help", "--help", "help":
+		usage(stdout)
+		return 0
+	case "get":
+		return cmdGet(ctx, args[1:], stdout, stderr)
+	case "set-poll-frequency":
+		return cmdSetPollFrequency(ctx, args[1:], stdout, stderr)
+	case "trigger-poll":
+		return cmdTriggerPoll(ctx, args[1:], stdout, stderr)
+	case "poll-burst":
+		return cmdPollBurst(ctx, args[1:], stdout, stderr)
+	case "set-s3":
+		return cmdSetS3(ctx, args[1:], stdout, stderr)
+	case "reconfigure":
+		return cmdReconfigure(ctx, args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "xtcp2ctl: unknown command %q\n\n", args[0])
+		usage(stderr)
+		return 2
+	}
+}
+
+func usage(w io.Writer) {
+	fmt.Fprint(w, `xtcp2ctl — operator control CLI for a running xtcp2 daemon
+
+Usage:
+  xtcp2ctl <command> [flags]
+
+Commands:
+  get                  Print the daemon's current config (S3 creds redacted)
+  set-poll-frequency   Change poll frequency + timeout live (no restart)
+  trigger-poll         Trigger a single poll immediately (no restart)
+  poll-burst           Trigger N polls spaced I apart, e.g. incident snapshots
+  set-s3               Change the s3parquet flush timer / byte cap live (no restart)
+  reconfigure          Apply a full config from a file or stdin (soft restart)
+
+Common flags (all commands):
+  -target string   daemon hostname (default "localhost")
+  -port string     daemon gRPC port (default "8889", must match -grpcPort)
+  -d uint          debug level (default 0)
+
+Run 'xtcp2ctl <command> -h' for per-command flags.
+`)
+}
+
+// commonFlags registers the flags every command shares and returns accessors.
+func commonFlags(fs *flag.FlagSet) (target, port *string) {
+	target = fs.String("target", targetHostnameCst, "daemon hostname")
+	port = fs.String("port", grpcPortCst, "daemon gRPC port (must match the daemon's -grpcPort)")
+	return target, port
+}
+
+// dialFunc is the connection factory, overridable in tests (bufconn).
+var dialFunc = dial
+
+func dial(target string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}
+
+// withClient parses the shared flags, dials, and hands a ready ConfigService
+// client to fn. Centralizes conn lifecycle + error formatting so each command
+// stays a few lines.
+func withClient(ctx context.Context, fs *flag.FlagSet, args []string, stderr io.Writer,
+	fn func(context.Context, xtcp_config.ConfigServiceClient) int) int {
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	target := fs.Lookup("target").Value.String()
+	port := fs.Lookup("port").Value.String()
+
+	conn, err := dialFunc(target + ":" + port)
+	if err != nil {
+		fmt.Fprintf(stderr, "xtcp2ctl: connect %s:%s: %v\n", target, port, err)
+		return 1
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl: conn close: %v\n", cerr)
+		}
+	}()
+
+	callCtx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	return fn(callCtx, xtcp_config.NewConfigServiceClient(conn))
+}
+
+func cmdGet(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("get", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		resp, err := c.Get(ctx, &xtcp_config.GetRequest{})
+		if err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl get: %v\n", err)
+			return 1
+		}
+		return printConfig(stdout, stderr, resp.GetConfig())
+	})
+}
+
+func cmdSetPollFrequency(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("set-poll-frequency", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	frequency := fs.Duration("frequency", 0, "new poll frequency, e.g. 30s (required)")
+	timeout := fs.Duration("timeout", 0, "new per-namespace poll timeout, must be < frequency (required)")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if *frequency <= 0 || *timeout <= 0 {
+			fmt.Fprintln(stderr, "xtcp2ctl set-poll-frequency: -frequency and -timeout are required (>0)")
+			return 2
+		}
+		if _, err := c.SetPollFrequency(ctx, &xtcp_config.SetPollFrequencyRequest{
+			PollFrequency: durationpb.New(*frequency),
+			PollTimeout:   durationpb.New(*timeout),
+		}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl set-poll-frequency: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "ok: poll frequency=%s timeout=%s\n", *frequency, *timeout)
+		return 0
+	})
+}
+
+func cmdTriggerPoll(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("trigger-poll", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if _, err := c.TriggerPoll(ctx, &xtcp_config.TriggerPollRequest{}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl trigger-poll: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: poll triggered")
+		return 0
+	})
+}
+
+func cmdPollBurst(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("poll-burst", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	count := fs.Uint("count", 6, "number of polls in the burst (1-1000)")
+	interval := fs.Duration("interval", 10*time.Second, "spacing between polls; must exceed the daemon's poll timeout")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if _, err := c.TriggerPollBurst(ctx, &xtcp_config.TriggerPollBurstRequest{
+			Count:    uint32(*count),
+			Interval: durationpb.New(*interval),
+		}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl poll-burst: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "ok: burst of %d polls scheduled, %s apart\n", *count, *interval)
+		return 0
+	})
+}
+
+func cmdSetS3(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("set-s3", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	flushInterval := fs.Duration("flush-interval", 0, "new s3parquet staleness-flush timer, e.g. 5s")
+	thresholdBytes := fs.Uint("threshold-bytes", 0, "new s3parquet byte cap before finalize+upload")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		// Only send fields the operator explicitly set. Empty request violates
+		// the server's "at least one" rule, so catch it locally.
+		req := &xtcp_config.SetS3UploadRequest{}
+		set := map[string]bool{}
+		fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+		if set["flush-interval"] {
+			req.S3FlushInterval = durationpb.New(*flushInterval)
+		}
+		if set["threshold-bytes"] {
+			req.S3ParquetFlushThresholdBytes = uint32(*thresholdBytes)
+		}
+		if !set["flush-interval"] && !set["threshold-bytes"] {
+			fmt.Fprintln(stderr, "xtcp2ctl set-s3: set -flush-interval and/or -threshold-bytes")
+			return 2
+		}
+		if _, err := c.SetS3Upload(ctx, req); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl set-s3: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: s3 upload settings updated")
+		return 0
+	})
+}
+
+func cmdReconfigure(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("reconfigure", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	file := fs.String("file", "-", `config JSON file to apply; "-" reads stdin (default)`)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		raw, err := readConfigInput(*file)
+		if err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: read %s: %v\n", *file, err)
+			return 1
+		}
+		cfg := &xtcp_config.XtcpConfig{}
+		if err := protojson.Unmarshal(raw, cfg); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: parse config JSON: %v\n", err)
+			return 1
+		}
+		if _, err := c.Set(ctx, &xtcp_config.SetRequest{Config: cfg}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: reconfigure accepted — daemon is soft-restarting (gRPC/metrics blip for a few seconds)")
+		return 0
+	})
+}
+
+// readConfigInput returns the bytes of the config file, or stdin when path is
+// "-" (or empty). stdinReader is overridable in tests.
+var stdinReader io.Reader = os.Stdin
+
+func readConfigInput(path string) ([]byte, error) {
+	if path == "-" || path == "" {
+		return io.ReadAll(stdinReader)
+	}
+	return os.ReadFile(path)
+}
+
+// printConfig writes cfg as indented protojson — the exact shape reconfigure
+// consumes, so `get | edit | reconfigure` round-trips.
+func printConfig(stdout, stderr io.Writer, cfg *xtcp_config.XtcpConfig) int {
+	if cfg == nil {
+		fmt.Fprintln(stderr, "xtcp2ctl: daemon returned no config")
+		return 1
+	}
+	out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "xtcp2ctl: marshal config: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, string(out))
+	return 0
+}

--- a/cmd/xtcp2ctl/xtcp2ctl_test.go
+++ b/cmd/xtcp2ctl/xtcp2ctl_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// fakeConfigServer records the last request per RPC so tests can assert the CLI
+// translated flags → request correctly. Get returns a fixed config.
+type fakeConfigServer struct {
+	xtcp_config.UnimplementedConfigServiceServer
+	lastSetPollFreq *xtcp_config.SetPollFrequencyRequest
+	lastBurst       *xtcp_config.TriggerPollBurstRequest
+	lastS3          *xtcp_config.SetS3UploadRequest
+	lastSet         *xtcp_config.SetRequest
+	triggered       bool
+}
+
+func (f *fakeConfigServer) Get(context.Context, *xtcp_config.GetRequest) (*xtcp_config.GetResponse, error) {
+	return &xtcp_config.GetResponse{Config: &xtcp_config.XtcpConfig{
+		Dest:          "kafka:127.0.0.1:9092",
+		Tag:           "live-tag",
+		PollFrequency: durationpb.New(10 * time.Second),
+	}}, nil
+}
+
+func (f *fakeConfigServer) SetPollFrequency(_ context.Context, in *xtcp_config.SetPollFrequencyRequest) (*xtcp_config.SetPollFrequencyResponse, error) {
+	f.lastSetPollFreq = in
+	return &xtcp_config.SetPollFrequencyResponse{}, nil
+}
+
+func (f *fakeConfigServer) TriggerPoll(context.Context, *xtcp_config.TriggerPollRequest) (*xtcp_config.TriggerPollResponse, error) {
+	f.triggered = true
+	return &xtcp_config.TriggerPollResponse{}, nil
+}
+
+func (f *fakeConfigServer) TriggerPollBurst(_ context.Context, in *xtcp_config.TriggerPollBurstRequest) (*xtcp_config.TriggerPollBurstResponse, error) {
+	f.lastBurst = in
+	return &xtcp_config.TriggerPollBurstResponse{Count: in.Count, Interval: in.Interval}, nil
+}
+
+func (f *fakeConfigServer) SetS3Upload(_ context.Context, in *xtcp_config.SetS3UploadRequest) (*xtcp_config.SetS3UploadResponse, error) {
+	f.lastS3 = in
+	return &xtcp_config.SetS3UploadResponse{}, nil
+}
+
+func (f *fakeConfigServer) Set(_ context.Context, in *xtcp_config.SetRequest) (*xtcp_config.SetResponse, error) {
+	f.lastSet = in
+	return &xtcp_config.SetResponse{Config: in.Config}, nil
+}
+
+// startFakeServer spins up the fake ConfigService on an in-memory bufconn and
+// points the CLI's dialFunc at it. Returns the server + a cleanup.
+func startFakeServer(t *testing.T) *fakeConfigServer {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	fake := &fakeConfigServer{}
+	xtcp_config.RegisterConfigServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+
+	prevDial := dialFunc
+	dialFunc = func(string) (*grpc.ClientConn, error) {
+		return grpc.NewClient(
+			"passthrough:///bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+	}
+	t.Cleanup(func() {
+		dialFunc = prevDial
+		srv.Stop()
+		_ = lis.Close()
+	})
+	return fake
+}
+
+func run(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	rc := runMain(context.Background(), args, &out, &errb)
+	return rc, out.String(), errb.String()
+}
+
+func TestGet(t *testing.T) {
+	startFakeServer(t)
+	rc, out, errStr := run(t, "get")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if !strings.Contains(out, "live-tag") || !strings.Contains(out, "kafka:127.0.0.1:9092") {
+		t.Errorf("get output missing expected fields:\n%s", out)
+	}
+}
+
+func TestSetPollFrequency(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "set-poll-frequency", "-frequency", "30s", "-timeout", "5s")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastSetPollFreq == nil ||
+		fake.lastSetPollFreq.PollFrequency.AsDuration() != 30*time.Second ||
+		fake.lastSetPollFreq.PollTimeout.AsDuration() != 5*time.Second {
+		t.Errorf("unexpected SetPollFrequency request: %+v", fake.lastSetPollFreq)
+	}
+}
+
+func TestSetPollFrequency_missingArgs(t *testing.T) {
+	startFakeServer(t)
+	if rc, _, _ := run(t, "set-poll-frequency"); rc != 2 {
+		t.Errorf("expected rc=2 for missing args, got %d", rc)
+	}
+}
+
+func TestTriggerPoll(t *testing.T) {
+	fake := startFakeServer(t)
+	if rc, _, errStr := run(t, "trigger-poll"); rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if !fake.triggered {
+		t.Error("TriggerPoll was not called")
+	}
+}
+
+func TestPollBurst(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "poll-burst", "-count", "6", "-interval", "10s")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastBurst == nil || fake.lastBurst.Count != 6 || fake.lastBurst.Interval.AsDuration() != 10*time.Second {
+		t.Errorf("unexpected burst request: %+v", fake.lastBurst)
+	}
+}
+
+func TestSetS3_bothFields(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "set-s3", "-flush-interval", "5s", "-threshold-bytes", "1024")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastS3 == nil || fake.lastS3.S3FlushInterval.AsDuration() != 5*time.Second || fake.lastS3.S3ParquetFlushThresholdBytes != 1024 {
+		t.Errorf("unexpected set-s3 request: %+v", fake.lastS3)
+	}
+}
+
+// Only the flag the operator set is populated; the other stays nil/zero.
+func TestSetS3_onlyInterval(t *testing.T) {
+	fake := startFakeServer(t)
+	if rc, _, errStr := run(t, "set-s3", "-flush-interval", "5s"); rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastS3.S3FlushInterval == nil || fake.lastS3.S3ParquetFlushThresholdBytes != 0 {
+		t.Errorf("expected only interval set: %+v", fake.lastS3)
+	}
+}
+
+func TestSetS3_noFields(t *testing.T) {
+	startFakeServer(t)
+	if rc, _, _ := run(t, "set-s3"); rc != 2 {
+		t.Errorf("expected rc=2 when no fields given, got %d", rc)
+	}
+}
+
+func TestReconfigure_fromStdin(t *testing.T) {
+	fake := startFakeServer(t)
+	prev := stdinReader
+	stdinReader = strings.NewReader(`{"dest":"kafka:127.0.0.1:9092","tag":"INC-9"}`)
+	t.Cleanup(func() { stdinReader = prev })
+
+	rc, out, errStr := run(t, "reconfigure", "-file", "-")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastSet == nil || fake.lastSet.Config.Tag != "INC-9" {
+		t.Errorf("unexpected Set request: %+v", fake.lastSet)
+	}
+	if !strings.Contains(out, "soft-restarting") {
+		t.Errorf("expected soft-restart notice, got: %s", out)
+	}
+}
+
+func TestReconfigure_badJSON(t *testing.T) {
+	startFakeServer(t)
+	prev := stdinReader
+	stdinReader = strings.NewReader(`{not json`)
+	t.Cleanup(func() { stdinReader = prev })
+	if rc, _, _ := run(t, "reconfigure"); rc != 1 {
+		t.Errorf("expected rc=1 for bad JSON, got %d", rc)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	if rc, _, errStr := run(t, "frobnicate"); rc != 2 || !strings.Contains(errStr, "unknown command") {
+		t.Errorf("expected rc=2 + unknown-command message, got rc=%d err=%s", rc, errStr)
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	if rc, _, _ := run(t); rc != 2 {
+		t.Errorf("expected rc=2 for no args, got %d", rc)
+	}
+}

--- a/docs/grpc-api.md
+++ b/docs/grpc-api.md
@@ -6,7 +6,9 @@ xtcp2 exposes a gRPC server (default port `8889`) with two services: one to read
 
 - [The server](#the-server)
 - [ConfigService](#configservice)
+- [Runtime operator control](#runtime-operator-control)
 - [XTCPFlatRecordService](#xtcpflatrecordservice)
+- [The xtcp2ctl control CLI](#the-xtcp2ctl-control-cli)
 - [The xtcp2client binary](#the-xtcp2client-binary)
 - [Using grpcurl](#using-grpcurl)
 - [Configuration](#configuration)
@@ -23,13 +25,34 @@ xtcp2 exposes a gRPC server (default port `8889`) with two services: one to read
 
 Defined in `proto/xtcp_config/v1/xtcp_config.proto`, this service lets you inspect and modify the running daemon's configuration:
 
-| RPC | Purpose |
-|---|---|
-| `Get(GetRequest) → GetResponse` | Return the current `XtcpConfig`. |
-| `Set(SetRequest) → SetResponse` | Replace the configuration. |
-| `SetPollFrequency(SetPollFrequencyRequest) → SetPollFrequencyResponse` | Change just the poll interval without a full `Set`. |
+| RPC | Purpose | Disruption |
+|---|---|---|
+| `Get(GetRequest) → GetResponse` | Return the current `XtcpConfig` (S3 credentials redacted). | none |
+| `SetPollFrequency(SetPollFrequencyRequest) → SetPollFrequencyResponse` | Change the poll frequency + timeout live. | none (hot) |
+| `TriggerPoll(TriggerPollRequest) → TriggerPollResponse` | Trigger a single poll immediately, without changing the cadence. | none (hot) |
+| `TriggerPollBurst(TriggerPollBurstRequest) → TriggerPollBurstResponse` | Schedule `count` polls spaced `interval` apart (e.g. a socket snapshot every 10s for a minute). | none (hot) |
+| `SetS3Upload(SetS3UploadRequest) → SetS3UploadResponse` | Change the s3parquet staleness-flush timer and/or byte cap live. | none (hot) |
+| `Set(SetRequest) → SetResponse` | Apply a full new `XtcpConfig` via a **soft restart** (see below). | brief (soft restart) |
 
 Configuration changes are validated with [buf.validate](https://github.com/bufbuild/protovalidate) CEL constraints declared in the proto (for example, the poll timeout must be shorter than the poll frequency), so invalid updates are rejected at the RPC boundary.
+
+## Runtime operator control
+
+There are two tiers of runtime change, so pick the least disruptive one that does the job:
+
+**Hot changes (no restart, no data loss).** `SetPollFrequency`, `TriggerPoll`, `TriggerPollBurst`, and `SetS3Upload` take effect on a running daemon immediately. The burst RPC is the incident tool: *"take a socket snapshot every 10s for a minute"* is `TriggerPollBurst{count: 6, interval: 10s}`. The polled records flow to whatever destination is configured (and to any connected `PollFlatRecords` stream). `interval` must exceed the daemon's `poll_timeout` so each poll completes before the next fires; the handler rejects a too-short interval.
+
+**Soft restart (`Set`).** Everything else — which record fields are exported, string metadata like `tag`/`location`/`hostname`, the marshaller, the destination — is baked in at startup, so changing it goes through `Set`, which re-execs the daemon in place. This avoids redeploying the container: same PID, same container, new config carried across a `syscall.Exec`. The gRPC/metrics/health endpoints blip for a few seconds while it re-initializes and Prometheus counters reset (`rate()` tolerates resets). Buffered records are flushed before the re-exec, so no data is lost.
+
+The intended flow is **read → edit → apply**:
+
+1. `Get` returns the full running config as JSON (S3 credentials come back blank — they're redacted).
+2. Edit the JSON: flip an `enabledDeserializers` entry (e.g. turn `bbr` on temporarily), set `tag` to an incident ticket, change `location`, etc.
+3. `Set` the edited config. Because empty credential fields are treated as *unchanged*, the redacted round-trip preserves the daemon's S3 keys.
+
+**Exported field groups** are controlled by the `enabledDeserializers` map — each key toggles a whole INET_DIAG attribute group (`info` = the tcp_info struct, `bbr` = the BBR fields, plus `vegas`, `cong`, `meminfo`, `skmem`, `dctcp`, `cgroup`, …). Setting a key to `false` disables that group; the full key list is what the daemon's `-deserializers` flag accepts. Individual fields *within* a group are all-or-nothing except for the CSV/TSV `csvColumns` selector.
+
+> **Security.** The gRPC server has no auth or TLS. `Get` redacts S3 credentials, but any client that can reach the port can reconfigure or restart the daemon. Bind the gRPC port to loopback / a trusted network (see the `-ipv4Ttl` clamp in [Configuration](#configuration)).
 
 ## XTCPFlatRecordService
 
@@ -39,6 +62,49 @@ Defined in `proto/xtcp_flat_record/v1/xtcp_flat_record.proto`:
 |---|---|---|
 | `FlatRecords(FlatRecordsRequest) → stream FlatRecordsResponse` | server streaming | The daemon pushes records to the client as it collects them. |
 | `PollFlatRecords(stream PollFlatRecordsRequest) → stream PollFlatRecordsResponse` | bidirectional streaming | The client drives collection on demand, triggering a poll per request. |
+
+## The xtcp2ctl control CLI
+
+`cmd/xtcp2ctl` is the operator control CLI — a thin wrapper over `ConfigService` for changing a running daemon without redeploying. (Where `xtcp2client` *reads* records, `xtcp2ctl` *changes settings*.) Everything it does is equally reachable with `grpcurl`; it just makes the common actions one-liners.
+
+```sh
+nix build .#xtcp2ctl
+alias xtcp2ctl=./result/bin/xtcp2ctl   # all commands accept -target / -port
+
+# Inspect the running config (S3 creds redacted)
+xtcp2ctl get
+
+# Hot changes — take effect immediately, no restart
+xtcp2ctl set-poll-frequency -frequency 30s -timeout 5s
+xtcp2ctl trigger-poll
+xtcp2ctl poll-burst -count 6 -interval 10s      # snapshot every 10s for a minute
+xtcp2ctl set-s3 -flush-interval 5s              # flush buffered snapshots to S3 promptly
+xtcp2ctl set-s3 -threshold-bytes 1048576        # or lower the byte cap
+```
+
+**Incident workflow — enable BBR detail + tag with a ticket (soft restart):**
+
+```sh
+# 1. capture the current config
+xtcp2ctl get > cfg.json
+
+# 2. edit cfg.json: turn bbr on and stamp a tag. enabledDeserializers wraps a
+#    nested "enabled" map, so the path is .enabledDeserializers.enabled.<key>.
+jq '.enabledDeserializers.enabled.bbr = true | .tag = "INC-1234"' cfg.json > cfg.new.json
+
+# 3. apply — daemon soft-restarts in place (same container), gRPC/metrics blip briefly
+xtcp2ctl reconfigure -file cfg.new.json
+# (reads stdin when -file is "-" or omitted)
+```
+
+| Command | Key flags | Tier |
+|---|---|---|
+| `get` | | none |
+| `set-poll-frequency` | `-frequency`, `-timeout` | hot |
+| `trigger-poll` | | hot |
+| `poll-burst` | `-count`, `-interval` | hot |
+| `set-s3` | `-flush-interval`, `-threshold-bytes` (at least one) | hot |
+| `reconfigure` | `-file` (`-` = stdin) | soft restart |
 
 ## The xtcp2client binary
 
@@ -71,7 +137,23 @@ Because reflection is on, the vendored `grpcurl` (`cmd/grpcurl`) can list and ca
 ```sh
 grpcurl -plaintext 127.0.0.1:8889 list
 grpcurl -plaintext 127.0.0.1:8889 xtcp_config.v1.ConfigService/Get
+
+# Hot changes
+grpcurl -plaintext -d '{"poll_frequency":"30s","poll_timeout":"5s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/SetPollFrequency
+grpcurl -plaintext -d '{}' 127.0.0.1:8889 xtcp_config.v1.ConfigService/TriggerPoll
+grpcurl -plaintext -d '{"count":6,"interval":"10s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/TriggerPollBurst
+grpcurl -plaintext -d '{"s3_flush_interval":"5s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/SetS3Upload
+
+# Soft restart: Get → edit → Set the whole config
+grpcurl -plaintext 127.0.0.1:8889 xtcp_config.v1.ConfigService/Get \
+  | jq '.config.enabledDeserializers.enabled.bbr = true | .config.tag = "INC-1234"' \
+  | grpcurl -plaintext -d @ 127.0.0.1:8889 xtcp_config.v1.ConfigService/Set
 ```
+
+`xtcp2ctl` (above) wraps these same calls with flag-based ergonomics.
 
 ## Configuration
 

--- a/nix/binaries.nix
+++ b/nix/binaries.nix
@@ -52,6 +52,7 @@ let
     "register_schema"
     "xtcp2"
     "xtcp2client"
+    "xtcp2ctl"
     "xtcp2_kafka_client"
   ];
 

--- a/nix/checks/cli-help-smoke.nix
+++ b/nix/checks/cli-help-smoke.nix
@@ -30,6 +30,7 @@ let
     "register_schema"
     "xtcp2"
     "xtcp2client"
+    "xtcp2ctl"
     "xtcp2_kafka_client"
   ];
 

--- a/nix/tests/go-test-per-package.nix
+++ b/nix/tests/go-test-per-package.nix
@@ -43,6 +43,7 @@ let
     "tools-proto-field-audit" = "./tools/proto-field-audit/...";
     "cmd-xtcp2" = "./cmd/xtcp2/...";
     "cmd-xtcp2client" = "./cmd/xtcp2client/...";
+    "cmd-xtcp2ctl" = "./cmd/xtcp2ctl/...";
   };
 
   mkPkgTest =


### PR DESCRIPTION
## `xtcp2ctl` — operator control CLI for the ConfigService

A thin control CLI over the `ConfigService`. Where `cmd/xtcp2client` streams
records, `xtcp2ctl` changes settings. Everything it does is equally reachable
with `grpcurl`; it just makes the common actions one-liners.

```
xtcp2ctl get                                    # config, S3 creds redacted
xtcp2ctl set-poll-frequency -frequency 30s -timeout 5s
xtcp2ctl trigger-poll
xtcp2ctl poll-burst -count 6 -interval 10s      # incident snapshots
xtcp2ctl set-s3 -flush-interval 5s              # flush buffered snapshots promptly
xtcp2ctl reconfigure -file cfg.json             # full config -> soft restart
```

- Registered in `nix/binaries.nix` (ships in the image), the `cli-help-smoke`
  check, and the `go-test-per-package` matrix.
- `docs/grpc-api.md` extended: the new RPCs, the two-tier (hot vs soft-restart)
  model, the `Get` -> edit -> `Set` incident workflow, and `xtcp2ctl` +
  `grpcurl` recipes.
- Tested end-to-end over a real gRPC socket against a `ConfigService` fake;
  bufconn unit suite + `-race`; lint clean.

**Stacked on** `feat/runtime-control-rpcs` (PR 1 of 3) — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
