### PR TITLE
test(microvm): integration coverage for xtcp2ctl runtime control

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -311,6 +311,7 @@ in
       microvm-x86_64-soak = microvms.vmsSoak.x86_64;
       microvm-x86_64-tcp-stress = microvms.vmsTcpStress.x86_64;
       microvm-x86_64-clickhouse-pipeline = microvms.vmsClickPipe.x86_64;
+      microvm-x86_64-clickhouse-pipeline-rate = microvms.vmsClickPipeRate.x86_64;
       microvm-x86_64-clickhouse-pipeline-stress = microvms.vmsClickPipeStress.x86_64;
       microvm-x86_64-clickhouse-pipeline-parquet = microvms.vmsClickPipeParquet.x86_64;
       microvm-x86_64-s3parquet-pipeline = microvms.vmsS3Parquet.x86_64;
@@ -423,6 +424,17 @@ in
     microvm-x86_64-clickhouse-pipeline-stress = {
       type = "app";
       program = "${microvms.clickPipeStress.x86_64.runner}/bin/xtcp2-clickpipe-stress-runner-x86_64";
+    };
+
+    # Runtime-control rate test. Boots the clickhouse-pipeline-rate VM, whose
+    # in-VM monitor drives xtcp2ctl through a baseline→fast→revert poll-frequency
+    # schedule plus a poll-burst, and asserts the ClickHouse ingest RATE responds
+    # and returns. Duration-bounded runner (~9 min); prints the per-phase
+    # XTCP2_RATE_* lines and passes only if every verdict is PASS. Not in
+    # `nix flake check` — holds a KVM slot.
+    microvm-x86_64-clickhouse-pipeline-rate-runner = {
+      type = "app";
+      program = "${microvms.clickPipeRate.x86_64.runner}/bin/xtcp2-clickpipe-rate-runner-x86_64";
     };
 
     # Mixed: clickpipe stack (redpanda + clickhouse) plus MinIO and a

--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -124,6 +124,25 @@ let
       sink = "clickhouse-pipeline";
     };
 
+  # Runtime-control rate test: the clickhouse-pipeline stack + a steady
+  # 100-connection tcp load + an in-VM monitor that drives xtcp2ctl and
+  # asserts the ClickHouse ingest rate responds. Host runner is duration-
+  # bounded (mkClickPipeRateRunner). No tcp-stress image needed.
+  mkOneClickPipeRate =
+    arch:
+    import ./mkVm.nix {
+      inherit
+        pkgs
+        lib
+        microvm
+        nixpkgs
+        arch
+        xtcp2Package
+        xtcp2AllPackage
+        ;
+      sink = "clickhouse-pipeline-rate";
+    };
+
   # Full end-to-end integration stress test: clickhouse-pipeline stack +
   # the tcp-stress socket-load containers. Needs tcpStressImage (to
   # docker-load and spawn the load containers) in addition to the pipeline.
@@ -281,6 +300,8 @@ let
 
   vmsClickPipe = lib.genAttrs constants.supportedArchs mkOneClickPipe;
 
+  vmsClickPipeRate = lib.genAttrs constants.supportedArchs mkOneClickPipeRate;
+
   vmsClickPipeStress = lib.optionalAttrs (tcpStressImage != null) (
     lib.genAttrs constants.supportedArchs mkOneClickPipeStress
   );
@@ -310,7 +331,7 @@ let
       # Surface every sentinel the self-test emits so a real failure in
       # Check 4+ (BINARIES_HELP, GRPC_ROUNDTRIP, NS_*) doesn't hide
       # behind an unhelpful OVERALL_FAIL with no breadcrumbs.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
     };
   });
 
@@ -322,7 +343,7 @@ let
       # The two s3parquet-specific sentinels alongside the baseline set.
       # 240 s timeout because the worker accumulates rows for several
       # poll cycles before triggering the 1 MiB-threshold finalize.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
       timeoutSec = 240;
     };
   });
@@ -339,7 +360,7 @@ let
         # outcome visible. Without this the default filter hides
         # them; the checks still execute (and the daemon exercises the
         # corresponding code paths) but the harness output is misleading.
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
       };
     })
   );
@@ -351,7 +372,7 @@ let
         vm = vmsCoverageIoUring.${arch};
         suffix = "-coverage-iouring";
         scrapeCoverage = true;
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
       };
     })
   );
@@ -383,6 +404,18 @@ let
     runner = microvmLib.mkDiscoveryBenchRunner {
       inherit arch;
       vm = vmsDiscoveryBench.${arch};
+    };
+  });
+
+  # Runtime-control rate test runner: boots the clickhouse-pipeline-rate VM,
+  # waits for the in-VM monitor's XTCP2_RATE_DONE (or --timeout), and passes
+  # only if the ingest rate responded to set-poll-frequency + poll-burst.
+  # No tcpStressImage needed (the steady load is the default-ns tcp_server/
+  # tcp_client pair, not the load containers).
+  clickPipeRate = lib.genAttrs constants.supportedArchs (arch: {
+    runner = microvmLib.mkClickPipeRateRunner {
+      inherit arch;
+      vm = vmsClickPipeRate.${arch};
     };
   });
 
@@ -453,6 +486,7 @@ in
     vmsSoak
     vmsTcpStress
     vmsClickPipe
+    vmsClickPipeRate
     vmsClickPipeStress
     vmsClickPipeParquet
     vmsS3Parquet
@@ -463,6 +497,7 @@ in
     vmsDiscoveryBench
     s3parquetLong
     discoveryBench
+    clickPipeRate
     clickPipeStress
     s3ParquetStress
     s3ParquetLowfreq

--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -834,6 +834,148 @@ rec {
       '';
     };
 
+  # mkClickPipeRateRunner — host runner for the clickhouse-pipeline-rate flavor.
+  # Mirrors mkDiscoveryBenchRunner (boot, tail both consoles, wait for a DONE
+  # sentinel or --timeout, power off). The in-VM xtcp2-clickpipe-rate monitor
+  # drives xtcp2ctl through a poll-frequency schedule and emits XTCP2_RATE_*
+  # sentinels; this runner surfaces the per-phase data lines and passes only if
+  # all three verdicts (INCREASE / REVERT / BURST) are PASS.
+  mkClickPipeRateRunner =
+    {
+      arch,
+      vm,
+    }:
+    let
+      cfg = constants.architectures.${arch};
+    in
+    pkgs.writeShellApplication {
+      name = "xtcp2-clickpipe-rate-runner-${arch}";
+      runtimeInputs = with pkgs; [
+        coreutils
+        gnugrep
+        netcat-gnu
+        procps
+      ];
+      text = ''
+        set -u
+
+        # ~15 min schedule (3×180s windows + settles + burst) + docker/
+        # ClickHouse/Redpanda first-boot pulls. Override with --timeout.
+        TIMEOUT_SEC=1800
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --timeout)   TIMEOUT_SEC="$2"; shift 2 ;;
+            --timeout=*) TIMEOUT_SEC="''${1#--timeout=}"; shift ;;
+            -h|--help)
+              echo "usage: $0 [--timeout <seconds>]"
+              echo "  Boots the clickhouse-pipeline-rate microvm, which drives"
+              echo "  xtcp2ctl through a baseline→fast→revert poll-frequency"
+              echo "  schedule + a poll-burst, and asserts the ClickHouse ingest"
+              echo "  rate responds. Prints the per-phase XTCP2_RATE_* lines."
+              exit 0
+              ;;
+            *) echo "unknown arg: $1" >&2; exit 1 ;;
+          esac
+        done
+
+        SERIAL_PORT=${toString cfg.serialPort}
+        VIRTCON_PORT=${toString cfg.virtioPort}
+        LOG=$(mktemp -t xtcp2-clickpipe-rate-XXXX.log)
+
+        echo "================================================"
+        echo " xtcp2 microvm clickhouse-pipeline-rate — arch=${arch}"
+        echo " timeout: $TIMEOUT_SEC s"
+        echo " transcript: $LOG"
+        echo "================================================"
+
+        QEMU_LOG="''${LOG}.qemu"
+        ${vm}/bin/microvm-run > "$QEMU_LOG" 2>&1 &
+        vm_pid=$!
+
+        nc_serial_pid=""
+        nc_virtcon_pid=""
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$SERIAL_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$SERIAL_PORT" >> "$LOG" 2>&1 &
+            nc_serial_pid=$!
+            break
+          fi
+          sleep 1
+        done
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$VIRTCON_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$VIRTCON_PORT" >> "$LOG" 2>&1 &
+            nc_virtcon_pid=$!
+            break
+          fi
+          sleep 1
+        done
+
+        trap '
+          if kill -0 "$vm_pid" 2>/dev/null; then
+            ( printf "systemctl poweroff\n" | nc -q 1 127.0.0.1 "$SERIAL_PORT" ) >/dev/null 2>&1 || true
+            sleep 10
+            kill "$vm_pid" 2>/dev/null || true
+            wait "$vm_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_serial_pid" ] && kill -0 "$nc_serial_pid" 2>/dev/null; then
+            kill "$nc_serial_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_virtcon_pid" ] && kill -0 "$nc_virtcon_pid" 2>/dev/null; then
+            kill "$nc_virtcon_pid" 2>/dev/null || true
+          fi
+        ' EXIT
+
+        # Wait for the schedule to finish (XTCP2_RATE_DONE) or the timeout.
+        elapsed=0
+        done_seen=0
+        while [ "$elapsed" -lt "$TIMEOUT_SEC" ]; do
+          if ! kill -0 "$vm_pid" 2>/dev/null; then
+            echo "FATAL: qemu died at t=$elapsed s; tail of transcript:"
+            tail -n 40 "$LOG"
+            exit 2
+          fi
+          if grep -q 'XTCP2_RATE_DONE' "$LOG" 2>/dev/null; then
+            done_seen=1
+            break
+          fi
+          sleep 5
+          elapsed=$((elapsed + 5))
+        done
+
+        if [ "$done_seen" -ne 1 ]; then
+          echo "FATAL: XTCP2_RATE_DONE not seen within $TIMEOUT_SEC s"
+          tail -n 40 "$LOG" 2>/dev/null || true
+          exit 2
+        fi
+
+        echo ""
+        echo "================================================"
+        echo " clickhouse-pipeline-rate results"
+        echo "================================================"
+        grep -E 'XTCP2_RATE_(START|BASELINE|FAST|REVERT|BURST) ' "$LOG" 2>/dev/null || true
+        grep -E 'XTCP2_RATE_(CADENCE|PREDICT|DELIVERY|SOCKETS|BURST|OVERALL)_(PASS|FAIL)' "$LOG" 2>/dev/null || true
+
+        rc=0
+        if grep -qE 'XTCP2_RATE_(CADENCE|PREDICT|DELIVERY|SOCKETS|BURST|OVERALL)_FAIL' "$LOG" 2>/dev/null; then
+          echo "FAIL: at least one rate verdict failed"
+          rc=1
+        elif grep -q 'XTCP2_RATE_CADENCE_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_PREDICT_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_DELIVERY_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_SOCKETS_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_BURST_PASS' "$LOG" 2>/dev/null; then
+          echo "PASS: predicted ClickHouse rows from the socket estimate matched actual across baseline/fast/revert + burst"
+        else
+          echo "FAIL: not all rate verdict sentinels present"
+          rc=1
+        fi
+        echo ""
+        echo "Full transcript kept at: $LOG"
+        exit "$rc"
+      '';
+    };
+
   mkSoakRunner =
     {
       arch,

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -87,6 +87,14 @@ let
   # poll frequency + low socket count. Lighter than stress (no dedicated disks,
   # no retention).
   isS3ParquetLowfreq = sink == "s3parquet-lowfreq";
+  # clickhouse-pipeline-rate = the runtime-control behavioral test: the
+  # clickhouse-pipeline stack (redpanda + clickhouse + kafka + xtcp2) PLUS a
+  # steady 100-connection tcp_server/tcp_client load (a stable rate
+  # denominator). A dedicated in-VM monitor drives xtcp2ctl through a
+  # baseline→fast→revert poll-frequency schedule plus a poll-burst, and asserts
+  # the RATE of rows arriving in xtcp.xtcp_flat_records responds and returns —
+  # end-to-end proof the operator-control CLI changes live daemon behavior.
+  isClickPipeRate = sink == "clickhouse-pipeline-rate";
   # discovery-bench = a root VM that runs the namespace-discovery A/B grid
   # (tools/discovery-bench -mode grid) against a real kernel, then powers off.
   # No downstream/dockerd — it only needs ip netns + many cheap processes.
@@ -95,7 +103,7 @@ let
   # mem budget, daemon args base) is shared.
   isAnyS3Parquet = isS3Parquet || isS3ParquetLong || isCapCheckFail || isClickPipeParquet || isS3ParquetStress || isS3ParquetLowfreq;
   # All flavors that bring up the redpanda + clickhouse docker stack.
-  isAnyClickPipe = isClickPipe || isClickPipeParquet || isClickPipeStress;
+  isAnyClickPipe = isClickPipe || isClickPipeParquet || isClickPipeStress || isClickPipeRate;
   # Flavors that spawn the tcp-stress socket-load containers.
   isAnyTcpStressLoad = isTcpStress || isClickPipeStress || isS3ParquetStress || isS3ParquetLowfreq;
   # Anything that needs dockerd inside the VM (the tcp-stress load containers
@@ -800,6 +808,172 @@ let
     '';
   };
 
+  # clickhouse-pipeline-rate flavor: the runtime-control behavioral test.
+  # A dedicated monitor drives xtcp2ctl through a poll-frequency schedule and
+  # asserts the RATE of rows arriving in xtcp.xtcp_flat_records responds:
+  #   BASELINE(10s) → FAST(1s, ~10× faster) → REVERT(10s, back down)
+  # then a poll-burst (6 polls, 10s apart) with the ticker parked. Rate is the
+  # ClickHouse row-count delta over a fixed window (default 60s); a steady
+  # 100-connection tcp load keeps rows-per-poll stable so rate tracks only the
+  # frequency. Emits per-phase data + PASS/FAIL verdict sentinels + a terminal
+  # XTCP2_RATE_DONE the host runner (lib.nix mkClickPipeRateRunner) waits on.
+  clickPipeRateScript = pkgs.writeShellApplication {
+    name = "xtcp2-clickpipe-rate";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+      docker
+      gawk
+      gnugrep
+      xtcp2AllPackage # provides xtcp2ctl
+    ];
+    text = ''
+      # Never abort mid-schedule — we want to reach XTCP2_RATE_DONE so the host
+      # runner never blocks to timeout on a single transient hiccup.
+      set +e
+
+      WINDOW=''${RATE_WINDOW_SEC:-180}  # per-phase measurement window (seconds)
+      SETTLE=''${RATE_SETTLE_SEC:-30}   # settle after a frequency change before measuring
+      TOL=''${RATE_TOL_PCT:-10}         # ± tolerance percent for the quantitative asserts
+      GPORT=${toString cfg.grpcPort}
+      PROM="http://127.0.0.1:${toString cfg.promPort}/metrics"
+
+      ch_rows() {
+        docker exec clickhouse clickhouse-client --password ${clickPipeChPassword} \
+          -q 'SELECT count() FROM xtcp.xtcp_flat_records' 2>/dev/null | tr -dc '0-9'
+      }
+      # Sum a Poller counter row (function="Poller",variable=$1) from /metrics.
+      # Handles integer or scientific-notation values (awk coerces both).
+      poller_counter() {
+        curl --silent --fail --max-time 3 "$PROM" 2>/dev/null \
+          | awk -v v="variable=\"$1\"" '
+              /^xtcp_counts/ && index($0,"function=\"Poller\"")>0 && index($0,v)>0 { s += $NF + 0 }
+              END { printf "%d", s+0 }'
+      }
+      setfreq() { xtcp2ctl set-poll-frequency -frequency "$1" -timeout "$2" -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1; }
+      # within_tol ACTUAL EXPECTED → true when |actual-expected|*100/expected <= TOL.
+      within_tol() {
+        local a="$1" e="$2" d
+        [ "$e" -le 0 ] && return 1
+        d=$(( a >= e ? a - e : e - a ))
+        [ $(( d * 100 / e )) -le "$TOL" ]
+      }
+      verdict() { # NAME OK MSG
+        if [ "$2" -eq 1 ]; then echo "XTCP2_RATE_''${1}_PASS ($3)"; else echo "XTCP2_RATE_''${1}_FAIL ($3)"; fi
+      }
+
+      # measure PHASE FREQ_SECONDS → samples (ClickHouse rows, produced rows,
+      # poll count) across one window and sets the globals M_CH / M_PRODUCED /
+      # M_POLLS / M_EXPECTED / M_N. N = produced/polls = sockets-per-poll (the
+      # daemon's own socket estimate). Jitter is disabled, so M_POLLS ≈ W/f.
+      measure() {
+        local phase="$1" fsec="$2" t0 e0 k0 t1 e1 k1
+        t0=$(ch_rows); t0=''${t0:-0}; e0=$(poller_counter envelopeRows); k0=$(poller_counter ticker)
+        sleep "$WINDOW"
+        t1=$(ch_rows); t1=''${t1:-0}; e1=$(poller_counter envelopeRows); k1=$(poller_counter ticker)
+        M_CH=$(( t1 - t0 )); M_PRODUCED=$(( e1 - e0 )); M_POLLS=$(( k1 - k0 ))
+        M_EXPECTED=$(( WINDOW / fsec ))
+        if [ "$M_POLLS" -gt 0 ]; then M_N=$(( M_PRODUCED / M_POLLS )); else M_N=0; fi
+        echo "XTCP2_RATE_$phase $(date -u +%FT%TZ) freq=''${fsec}s window=''${WINDOW}s polls=$M_POLLS expected_polls=$M_EXPECTED sockets_per_poll=$M_N produced=$M_PRODUCED ch_delta=$M_CH"
+      }
+
+      echo "XTCP2_RATE_START $(date -u +%FT%TZ) window=''${WINDOW}s settle=''${SETTLE}s tol=''${TOL}% grpc=$GPORT"
+
+      # ── Ready gate: xtcp2 metrics up AND rows already flowing into ClickHouse.
+      ready=0
+      for _ in $(seq 1 90); do
+        if curl --silent --fail --max-time 3 "$PROM" 2>/dev/null | grep -q '^xtcp_'; then
+          r=$(ch_rows); r=''${r:-0}
+          if [ "$r" -gt 0 ]; then ready=1; break; fi
+        fi
+        sleep 2
+      done
+      if [ "$ready" -ne 1 ]; then
+        echo "XTCP2_RATE_OVERALL_FAIL (pipeline not ready: no rows in ClickHouse within 180s)"
+        echo "XTCP2_RATE_DONE"
+        exit 1
+      fi
+
+      # ── Phase 1: BASELINE (10s) — defines the reference socket estimate.
+      setfreq 10s 2s;   sleep "$SETTLE"; measure BASELINE 10
+      base_polls=$M_POLLS; base_exp=$M_EXPECTED; base_ch=$M_CH; base_prod=$M_PRODUCED; NCALIB=$M_N
+      # ── Phase 2: FAST (1s) — ~10× the poll rate.
+      setfreq 1s 500ms; sleep "$SETTLE"; measure FAST 1
+      fast_polls=$M_POLLS; fast_exp=$M_EXPECTED; fast_ch=$M_CH; fast_prod=$M_PRODUCED; fast_n=$M_N
+      # ── Phase 3: REVERT (10s) — rate returns to baseline.
+      setfreq 10s 2s;   sleep "$SETTLE"; measure REVERT 10
+      rev_polls=$M_POLLS; rev_exp=$M_EXPECTED; rev_ch=$M_CH; rev_prod=$M_PRODUCED; rev_n=$M_N
+
+      # CADENCE: the actual poll count each window matched window/frequency —
+      # i.e. set-poll-frequency really changed the poll rate (quantitatively).
+      cad_ok=1
+      within_tol "$base_polls" "$base_exp" || cad_ok=0
+      within_tol "$fast_polls" "$fast_exp" || cad_ok=0
+      within_tol "$rev_polls" "$rev_exp"  || cad_ok=0
+      verdict CADENCE "$cad_ok" "polls vs W/f: base=$base_polls/$base_exp fast=$fast_polls/$fast_exp revert=$rev_polls/$rev_exp"
+
+      # PREDICT (the headline): ClickHouse rows in the FAST and REVERT windows
+      # matched the prediction from the socket estimate + the known frequency:
+      # expected = NCALIB × (window/freq).
+      fast_pred=$(( NCALIB * fast_exp )); rev_pred=$(( NCALIB * rev_exp ))
+      pred_ok=1
+      within_tol "$fast_ch" "$fast_pred" || pred_ok=0
+      within_tol "$rev_ch" "$rev_pred"  || pred_ok=0
+      verdict PREDICT "$pred_ok" "ch vs N*W/f (N=$NCALIB): fast=$fast_ch/$fast_pred revert=$rev_ch/$rev_pred"
+
+      # DELIVERY: every row the daemon produced reached ClickHouse (no loss /
+      # consumer stall) — ch_delta ≈ produced each phase.
+      del_ok=1
+      within_tol "$base_ch" "$base_prod" || del_ok=0
+      within_tol "$fast_ch" "$fast_prod" || del_ok=0
+      within_tol "$rev_ch" "$rev_prod"  || del_ok=0
+      verdict DELIVERY "$del_ok" "ch vs produced: base=$base_ch/$base_prod fast=$fast_ch/$fast_prod revert=$rev_ch/$rev_prod"
+
+      # SOCKETS: the socket estimate stayed stable across phases, so the rate
+      # change is attributable to frequency, not socket drift.
+      soc_ok=1
+      within_tol "$fast_n" "$NCALIB" || soc_ok=0
+      within_tol "$rev_n" "$NCALIB"  || soc_ok=0
+      verdict SOCKETS "$soc_ok" "sockets/poll stable: calib=$NCALIB fast=$fast_n revert=$rev_n"
+
+      # ── Phase 4: BURST. Park the ticker at 1h (1s timeout lets a 10s burst
+      # interval satisfy interval>poll_timeout). Measure one poll's rows via the
+      # daemon counter (no lag), then fire 6 polls 10s apart and confirm the
+      # poll counter advanced by >=6 and 6× the rows were produced AND delivered.
+      setfreq 3600s 1s; sleep "$SETTLE"
+      pe0=$(poller_counter envelopeRows)
+      xtcp2ctl trigger-poll -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1
+      sleep 8
+      pe1=$(poller_counter envelopeRows)
+      perpoll=$(( pe1 - pe0 ))
+
+      pr0=$(poller_counter pollRequestCh); be0=$(poller_counter envelopeRows)
+      bc0=$(ch_rows); bc0=''${bc0:-0}
+      xtcp2ctl poll-burst -count 6 -interval 10s -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1
+      sleep 80   # 6 × 10s spacing + ClickHouse consume lag
+      pr1=$(poller_counter pollRequestCh); be1=$(poller_counter envelopeRows)
+      bc1=$(ch_rows); bc1=''${bc1:-0}
+      pollreq_delta=$(( pr1 - pr0 )); burst_prod=$(( be1 - be0 )); burst_ch=$(( bc1 - bc0 ))
+      burst_exp=$(( 6 * perpoll ))
+      echo "XTCP2_RATE_BURST $(date -u +%FT%TZ) perpoll=$perpoll pollreq_delta=$pollreq_delta produced=$burst_prod ch_delta=$burst_ch expected=$burst_exp"
+
+      burst_ok=1
+      [ "$pollreq_delta" -ge 6 ] || burst_ok=0
+      [ "$perpoll" -gt 0 ] || burst_ok=0
+      within_tol "$burst_prod" "$burst_exp" || burst_ok=0
+      within_tol "$burst_ch" "$burst_prod"  || burst_ok=0
+      verdict BURST "$burst_ok" "6 polls: pollreq_delta=$pollreq_delta produced=$burst_prod/~$burst_exp ch=$burst_ch"
+
+      if [ "$cad_ok" -eq 1 ] && [ "$pred_ok" -eq 1 ] && [ "$del_ok" -eq 1 ] \
+         && [ "$soc_ok" -eq 1 ] && [ "$burst_ok" -eq 1 ]; then
+        echo "XTCP2_RATE_OVERALL_PASS"
+      else
+        echo "XTCP2_RATE_OVERALL_FAIL (cadence=$cad_ok predict=$pred_ok delivery=$del_ok sockets=$soc_ok burst=$burst_ok)"
+      fi
+      echo "XTCP2_RATE_DONE"
+    '';
+  };
+
   # s3parquet flavor: in-VM MinIO + bucket bootstrap. The xtcp2 daemon
   # talks to MinIO directly via the minio-go client; no proto-desc file
   # or unixgram socket required. The long-soak variant additionally
@@ -1114,6 +1288,18 @@ let
     "2s"
     "-kafkaSchemaUrl"
     "http://localhost:18081"
+  ];
+
+  # clickhouse-pipeline-rate flavor: same kafka pipeline, but poll jitter is
+  # DISABLED so each measurement window's poll count is exactly window/frequency.
+  # The rate monitor predicts expected rows = sockets_per_poll × (window/freq)
+  # and asserts ClickHouse matches within tolerance — jitter's ±20% cadence
+  # variance would defeat that tight prediction. The rate *behavior* is
+  # identical; only the variance is removed. The monitor overrides -frequency
+  # at runtime via xtcp2ctl, so the 5s here is just the pre-baseline cadence.
+  xtcp2ClickPipeRateArgs = xtcp2ClickPipeArgs ++ [
+    "-pollJitterPct"
+    "0"
   ];
 
   xtcp2CoverageArgs =
@@ -1543,6 +1729,10 @@ in
           extraArgs =
             if isCoverage then
               xtcp2CoverageArgs
+            else if isClickPipeRate then
+              # Rate test: kafka pipeline with poll jitter disabled for a
+              # deterministic per-window poll count (see xtcp2ClickPipeRateArgs).
+              xtcp2ClickPipeRateArgs
             else if isAnyClickPipe then
               # Phase E: produce to redpanda → clickhouse via kafka dest.
               # The mixed flavor uses these args for its primary xtcp2
@@ -1630,7 +1820,7 @@ in
         # is-active xtcp2` for 30 s, robust to xtcp2 starting directly at
         # boot or via a systemd.path gate. Skipped on long-running flavors
         # (soak / s3parquet-long), which run heartbeat services instead.
-        systemd.services.xtcp2-self-test = lib.mkIf (!isSoak && !isS3ParquetLong) {
+        systemd.services.xtcp2-self-test = lib.mkIf (!isSoak && !isS3ParquetLong && !isClickPipeRate) {
           description = "xtcp2 microvm self-test";
           after = [
             "xtcp2.service"
@@ -1751,7 +1941,7 @@ in
         # bytes-sent / segs-out for the parser to chew on. The two units
         # below run alongside the nsTest churn for the soak flavor.
         systemd.services.xtcp2-soak-tcp-server =
-          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet)
+          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet || isClickPipeRate)
             {
               description = "xtcp2 soak — tcp_server echo listeners";
               after = [ "network-online.target" ];
@@ -1826,7 +2016,7 @@ in
         };
 
         systemd.services.xtcp2-soak-tcp-client =
-          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet)
+          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet || isClickPipeRate)
             {
               description = "xtcp2 soak — tcp_client traffic generators";
               # tcp_server takes a moment to bind all N ports — gate the
@@ -2185,6 +2375,32 @@ in
             ExecStart = "${clickPipeMonitorScript}/bin/xtcp2-clickpipe-monitor";
             Restart = "on-failure";
             RestartSec = "10s";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
+        };
+
+        # clickhouse-pipeline-rate flavor: the runtime-control rate test driver.
+        # Runs the baseline→fast→revert→burst schedule against the live daemon
+        # via xtcp2ctl and prints XTCP2_RATE_* sentinels the host runner scrapes.
+        # Ordered after the pipeline is up + xtcp2 is serving gRPC.
+        systemd.services.xtcp2-clickpipe-rate = lib.mkIf isClickPipeRate {
+          description = "xtcp2 clickhouse-pipeline-rate — runtime-control rate test";
+          after = [
+            "xtcp2-clickpipe-up.service"
+            "xtcp2.service"
+            "xtcp2-soak-tcp-client.service"
+          ];
+          requires = [ "xtcp2-clickpipe-up.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            # oneshot: the schedule runs once to XTCP2_RATE_DONE and exits.
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${clickPipeRateScript}/bin/xtcp2-clickpipe-rate";
+            # ~15 min schedule (3×180s windows + settles + burst) + readiness
+            # headroom. The host runner's --timeout bounds the overall run.
+            TimeoutStartSec = "1900";
             StandardOutput = "journal+console";
             StandardError = "journal+console";
           };

--- a/nix/microvms/self-test.nix
+++ b/nix/microvms/self-test.nix
@@ -26,6 +26,17 @@
 #                                              Deserialize on real netlink
 #                                              bytes — the main reason this
 #                                              exists)
+#   XTCP2_SELF_TEST_CTL_HOT_{PASS,FAIL}        xtcp2ctl set-poll-frequency is
+#                                              reflected by a later `get` and
+#                                              bumps the Poller ticker.Reset
+#                                              counter (hot change, no restart)
+#   XTCP2_SELF_TEST_CTL_TRIGGER_{PASS,FAIL}    xtcp2ctl trigger-poll + poll-burst
+#                                              advance the Poller pollRequestCh
+#                                              counter with the ticker parked
+#   XTCP2_SELF_TEST_CTL_RESTART_{PASS,FAIL}    xtcp2ctl reconfigure = in-place
+#                                              soft restart (syscall.Exec): same
+#                                              MainPID, `get` + streamed records
+#                                              carry the new tag (non-coverage)
 #   XTCP2_SELF_TEST_NS_ANONYMOUS_{PASS,FAIL}   an anonymous `unshare -n` netns
 #                                              (no /run/netns bind mount) held by
 #                                              a live process is discovered by
@@ -106,6 +117,7 @@ pkgs.writeShellApplication {
     docker # only used by Check 11/12 (clickhouse-pipeline); harmless otherwise
     minio-client # mc — only used by Check 13/14 (s3parquet); harmless otherwise
     duckdb # used by Check 14 to decode the Parquet file
+    jq # used by Check 19 to edit the config JSON for the reconfigure soft restart
   ];
   text = ''
     set +e   # never exit early — we want all checks to run
@@ -226,6 +238,7 @@ pkgs.writeShellApplication {
     binaries=(
       xtcp2
       xtcp2client
+      xtcp2ctl
       xtcp2_kafka_client
       clickhouse_protobuflist
       clickhouse_protobuflist_db
@@ -253,7 +266,7 @@ pkgs.writeShellApplication {
       fi
     done
     if [ "$check4" -eq 0 ]; then
-      echo "XTCP2_SELF_TEST_BINARIES_HELP_PASS  (10 binaries OK)"
+      echo "XTCP2_SELF_TEST_BINARIES_HELP_PASS  (11 binaries OK)"
     else
       echo "XTCP2_SELF_TEST_BINARIES_HELP_FAIL  (failed:$failed_help)"
       overall_ok=0
@@ -638,6 +651,118 @@ pkgs.writeShellApplication {
         echo "XTCP2_SELF_TEST_CLICKHOUSE_PARQUET_FAIL  (rows=$parquetRows)"
       fi
       if [ "$check15" -ne 0 ]; then overall_ok=0; fi
+    ''}
+
+    # ─── Checks 17-19: xtcp2ctl runtime operator control ─────────────────
+    # Prove the new control CLI actually CHANGES daemon behavior, not just
+    # that the RPC returns OK. Run LAST because check 17 parks the poll ticker
+    # at 1h (to isolate check 18), which would starve the kafka/s3 checks above
+    # if it ran earlier.
+    #   17 CTL_HOT     — set-poll-frequency is reflected by a later `get` AND
+    #                    bumps the Poller ticker.Reset counter (poller re-read
+    #                    config and reset its ticker).
+    #   18 CTL_TRIGGER — with the ticker parked at 1h, trigger-poll + poll-burst
+    #                    are the ONLY thing that can advance the Poller
+    #                    pollRequestCh counter, so a clean delta proves the
+    #                    on-demand polls really ran.
+    #   19 CTL_RESTART — reconfigure (soft restart via syscall.Exec) with a new
+    #                    tag: MainPID is unchanged (in-place re-exec, NOT a
+    #                    systemd restart), `get` reflects the new tag, and freshly
+    #                    streamed records carry it. Skipped under coverage (a
+    #                    re-exec drops pre-exec -cover counters).
+    CTL=(-target 127.0.0.1 -port ${toString grpcPort})
+
+    echo "--- check 17: xtcp2ctl set-poll-frequency (hot change, no restart) ---"
+    check17=1
+    if command -v xtcp2ctl >/dev/null 2>&1; then
+      before_reset=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="ticker.Reset"')
+      # Park the ticker at 1h with a 1s timeout: the long frequency isolates
+      # check 18, and the small timeout lets the burst there use a 2s interval
+      # (burst interval must exceed poll_timeout).
+      xtcp2ctl set-poll-frequency -frequency 3600s -timeout 1s "''${CTL[@]}" >/tmp/ctl.log 2>&1
+      sp_rc=$?
+      got=$(xtcp2ctl get "''${CTL[@]}" 2>/dev/null)
+      after_reset=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="ticker.Reset"')
+      if [ "$sp_rc" -eq 0 ] && printf '%s' "$got" | grep -q '"3600s"' && [ "$after_reset" -gt "$before_reset" ]; then
+        echo "XTCP2_SELF_TEST_CTL_HOT_PASS  (get shows 3600s, ticker.Reset $before_reset→$after_reset)"
+        check17=0
+      else
+        echo "XTCP2_SELF_TEST_CTL_HOT_FAIL  (sp_rc=$sp_rc, ticker.Reset $before_reset→$after_reset)"
+        printf '%s\n' "$got" | head -n 3
+      fi
+    else
+      echo "XTCP2_SELF_TEST_CTL_HOT_FAIL  (xtcp2ctl not on PATH)"
+    fi
+    if [ "$check17" -ne 0 ]; then overall_ok=0; fi
+
+    echo "--- check 18: xtcp2ctl trigger-poll + poll-burst drive on-demand polls ---"
+    check18=1
+    if command -v xtcp2ctl >/dev/null 2>&1; then
+      sleep 3   # let any in-flight poll from the pre-3600s cadence drain
+      before_poll=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="pollRequestCh"')
+      xtcp2ctl trigger-poll "''${CTL[@]}" >/dev/null 2>&1
+      xtcp2ctl poll-burst -count 4 -interval 2s "''${CTL[@]}" >/dev/null 2>&1
+      sleep 10  # 4 polls × 2s spacing + slack
+      after_poll=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="pollRequestCh"')
+      delta=$((after_poll - before_poll))
+      # Ticker parked at 1h, so 1 (trigger) + 4 (burst) = 5 on-demand pokes are
+      # the only possible source. Require >=4 (tolerate one timing slip).
+      if [ "$delta" -ge 4 ]; then
+        echo "XTCP2_SELF_TEST_CTL_TRIGGER_PASS  (pollRequestCh +$delta from trigger+burst, ticker parked)"
+        check18=0
+      else
+        echo "XTCP2_SELF_TEST_CTL_TRIGGER_FAIL  (pollRequestCh +$delta, expected >=4)"
+      fi
+    else
+      echo "XTCP2_SELF_TEST_CTL_TRIGGER_FAIL  (xtcp2ctl not on PATH)"
+    fi
+    if [ "$check18" -ne 0 ]; then overall_ok=0; fi
+
+    ${lib.optionalString (!coverageEnabled) ''
+      echo "--- check 19: xtcp2ctl reconfigure = soft restart (same PID, new tag in records) ---"
+      check19=1
+      if command -v xtcp2ctl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        reconf_tag="INC-SELFTEST-9f3a"
+        pid_before=$(systemctl show -p MainPID --value xtcp2)
+        xtcp2ctl get "''${CTL[@]}" > /tmp/xtcp2-cfg.json 2>/dev/null
+        jq --arg t "$reconf_tag" '.tag = $t' /tmp/xtcp2-cfg.json > /tmp/xtcp2-cfg.new.json 2>/tmp/jq.err
+        if [ ! -s /tmp/xtcp2-cfg.new.json ]; then
+          echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (could not build new config: $(head -n1 /tmp/jq.err 2>/dev/null))"
+        else
+          xtcp2ctl reconfigure -file /tmp/xtcp2-cfg.new.json "''${CTL[@]}" >/tmp/reconf.log 2>&1
+          # Wait for the daemon to re-exec and come back serving the new tag.
+          back=0
+          for _ in $(seq 1 30); do
+            if xtcp2ctl get "''${CTL[@]}" 2>/dev/null | grep -q "$reconf_tag"; then back=1; break; fi
+            sleep 1
+          done
+          pid_after=$(systemctl show -p MainPID --value xtcp2)
+          # Freshly streamed records must carry the new tag. Give the daemon a
+          # live socket to report, then poll-stream briefly and grep the output.
+          nc -l 127.0.0.1 17325 >/dev/null 2>&1 &
+          rl=$!
+          ( echo hi | nc -w 6 127.0.0.1 17325 >/dev/null 2>&1 ) &
+          rc_pid=$!
+          sleep 1
+          timeout 6s xtcp2client -poll -pollFrequency 1s -json \
+            -target 127.0.0.1 -port ${toString grpcPort} >/tmp/xtcp2client-tag.log 2>&1
+          kill "$rl" "$rc_pid" 2>/dev/null || true
+          rec_ok=0
+          if grep -q "$reconf_tag" /tmp/xtcp2client-tag.log 2>/dev/null; then rec_ok=1; fi
+
+          if [ "$back" -eq 1 ] && [ -n "$pid_after" ] && [ "$pid_after" = "$pid_before" ] \
+             && systemctl is-active --quiet xtcp2 && [ "$rec_ok" -eq 1 ]; then
+            echo "XTCP2_SELF_TEST_CTL_RESTART_PASS  (soft restart: MainPID stayed $pid_before, records now carry tag=$reconf_tag)"
+            check19=0
+          else
+            echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (back=$back, pid $pid_before→$pid_after, active=$(systemctl is-active xtcp2 || true), recTag=$rec_ok)"
+            head -n 5 /tmp/reconf.log 2>/dev/null || true
+          fi
+        fi
+      else
+        echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (xtcp2ctl or jq not on PATH)"
+      fi
+      if [ "$check19" -ne 0 ]; then overall_ok=0; fi
     ''}
 
     echo "================================================"


### PR DESCRIPTION
## Integration coverage for xtcp2ctl runtime control

### Self-test (basic lifecycle VM) — Checks 17-19
Drive `xtcp2ctl` against the live daemon and assert behavior actually changes,
not just that the RPC returns OK:
- **CTL_HOT** — `set-poll-frequency` reflected by a later `get` + a
  `ticker.Reset` counter bump.
- **CTL_TRIGGER** — `trigger-poll` + `poll-burst` advance the `pollRequestCh`
  counter with the ticker parked (isolated proof the on-demand polls ran).
- **CTL_RESTART** — `reconfigure` = in-place soft restart: same systemd
  MainPID (`syscall.Exec`, not a service restart), and `get` + streamed
  records carry the new tag. Skipped under coverage (a re-exec drops pre-exec
  counters).

### New flavor `clickhouse-pipeline-rate`
xtcp2 -> Redpanda -> ClickHouse plus a steady 100-connection TCP load, with an
in-VM monitor that drives `xtcp2ctl` through a baseline(10s) -> fast(1s) ->
revert(10s) -> poll-burst schedule (poll jitter disabled for a deterministic
poll count). It **estimates sockets-per-poll from the daemon's own counters**
(`N = envelopeRows / ticker`) and asserts the ClickHouse ingest rate matches
the prediction `N x (window/freq)`:

| verdict | asserts |
|---|---|
| CADENCE | actual polls approx `W/f` each phase |
| PREDICT | ClickHouse rows approx `N x W/f` (fast + revert) |
| DELIVERY | ClickHouse delta approx produced (no loss) |
| SOCKETS | `N` stable across phases |
| BURST | 6 polls produced + delivered `6xN` rows |

Host runner mirrors `mkDiscoveryBenchRunner` (wait for `XTCP2_RATE_DONE` or
`--timeout`). Env-tunable windows/tolerance; kept out of `nix flake check`
(KVM-slot cost). Run with
`nix run .#microvm-x86_64-clickhouse-pipeline-rate-runner`.

**Verified on real hardware (KVM):** predicted ClickHouse rows matched actual
within ~2% across all phases (fast 25465/25920, revert 2524/2592), poll count
exactly `W/f` (18/18, 181/180, 18/18) -> `OVERALL_PASS`.

**Stacked on** `feat/xtcp2ctl-cli` (PR 3 of 3) — review/merge PRs 1 and 2 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
