### PR TITLE
chore: land xtcp2ctl CLI + integration tests on main (stacked-merge recovery)

### DIFF
--- a/cmd/xtcp2ctl/xtcp2ctl.go
+++ b/cmd/xtcp2ctl/xtcp2ctl.go
@@ -1,0 +1,320 @@
+// Command xtcp2ctl is the operator control CLI for a running xtcp2 daemon.
+//
+// Where cmd/xtcp2client streams TCP stats out of the XTCPFlatRecordService,
+// xtcp2ctl drives the ConfigService: it changes poll cadence, triggers polls,
+// tunes the S3 upload timing, and applies an arbitrary new config via a
+// soft restart — all without redeploying the container. It's a thin,
+// dependency-light wrapper over the generated ConfigService client; anything
+// it does is equally reachable with grpcurl (see docs/grpc-api.md).
+//
+// Usage:
+//
+//	xtcp2ctl <command> [flags]
+//
+// Commands:
+//
+//	get                  print the daemon's current config (S3 creds redacted)
+//	set-poll-frequency   change the poll frequency + timeout live
+//	trigger-poll         trigger a single poll now
+//	poll-burst           trigger N polls spaced I apart (incident snapshots)
+//	set-s3               change the s3parquet flush timer and/or byte cap live
+//	reconfigure          apply a full config from a file/stdin (soft restart)
+//
+// Every command accepts -target/-port/-d. Run `xtcp2ctl <command> -h` for
+// per-command flags.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/randomizedcoder/xtcp2/pkg/misc"
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+const (
+	targetHostnameCst = "localhost"
+	// grpcPortCst MUST match the xtcp2 daemon's default (cmd/xtcp2
+	// grpcPortCst, currently 8889). Out-of-step ports turn every call into a
+	// silent connection refused.
+	grpcPortCst = "8889"
+
+	// callTimeout bounds a single unary control RPC. reconfigure returns
+	// before the daemon actually re-execs (the daemon delays its shutdown so
+	// the response flushes), so this is comfortably long enough.
+	callTimeout = 15 * time.Second
+)
+
+var (
+	// Passed by "go build -ldflags" for -v.
+	commit  string
+	date    string
+	version string
+)
+
+func main() {
+	misc.DieIfNotLinux()
+	os.Exit(runMain(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runMain dispatches the subcommand. Extracted so tests can drive it with
+// synthetic args + writers against a bufconn server.
+func runMain(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		usage(stderr)
+		return 2
+	}
+	switch args[0] {
+	case "-v", "--version", "version":
+		fmt.Fprintf(stdout, "xtcp2ctl commit:%s\tdate(UTC):%s\tversion:%s\n", commit, date, version)
+		return 0
+	case "-h", "-help", "--help", "help":
+		usage(stdout)
+		return 0
+	case "get":
+		return cmdGet(ctx, args[1:], stdout, stderr)
+	case "set-poll-frequency":
+		return cmdSetPollFrequency(ctx, args[1:], stdout, stderr)
+	case "trigger-poll":
+		return cmdTriggerPoll(ctx, args[1:], stdout, stderr)
+	case "poll-burst":
+		return cmdPollBurst(ctx, args[1:], stdout, stderr)
+	case "set-s3":
+		return cmdSetS3(ctx, args[1:], stdout, stderr)
+	case "reconfigure":
+		return cmdReconfigure(ctx, args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "xtcp2ctl: unknown command %q\n\n", args[0])
+		usage(stderr)
+		return 2
+	}
+}
+
+func usage(w io.Writer) {
+	fmt.Fprint(w, `xtcp2ctl — operator control CLI for a running xtcp2 daemon
+
+Usage:
+  xtcp2ctl <command> [flags]
+
+Commands:
+  get                  Print the daemon's current config (S3 creds redacted)
+  set-poll-frequency   Change poll frequency + timeout live (no restart)
+  trigger-poll         Trigger a single poll immediately (no restart)
+  poll-burst           Trigger N polls spaced I apart, e.g. incident snapshots
+  set-s3               Change the s3parquet flush timer / byte cap live (no restart)
+  reconfigure          Apply a full config from a file or stdin (soft restart)
+
+Common flags (all commands):
+  -target string   daemon hostname (default "localhost")
+  -port string     daemon gRPC port (default "8889", must match -grpcPort)
+  -d uint          debug level (default 0)
+
+Run 'xtcp2ctl <command> -h' for per-command flags.
+`)
+}
+
+// commonFlags registers the flags every command shares and returns accessors.
+func commonFlags(fs *flag.FlagSet) (target, port *string) {
+	target = fs.String("target", targetHostnameCst, "daemon hostname")
+	port = fs.String("port", grpcPortCst, "daemon gRPC port (must match the daemon's -grpcPort)")
+	return target, port
+}
+
+// dialFunc is the connection factory, overridable in tests (bufconn).
+var dialFunc = dial
+
+func dial(target string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+}
+
+// withClient parses the shared flags, dials, and hands a ready ConfigService
+// client to fn. Centralizes conn lifecycle + error formatting so each command
+// stays a few lines.
+func withClient(ctx context.Context, fs *flag.FlagSet, args []string, stderr io.Writer,
+	fn func(context.Context, xtcp_config.ConfigServiceClient) int) int {
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	target := fs.Lookup("target").Value.String()
+	port := fs.Lookup("port").Value.String()
+
+	conn, err := dialFunc(target + ":" + port)
+	if err != nil {
+		fmt.Fprintf(stderr, "xtcp2ctl: connect %s:%s: %v\n", target, port, err)
+		return 1
+	}
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl: conn close: %v\n", cerr)
+		}
+	}()
+
+	callCtx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	return fn(callCtx, xtcp_config.NewConfigServiceClient(conn))
+}
+
+func cmdGet(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("get", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		resp, err := c.Get(ctx, &xtcp_config.GetRequest{})
+		if err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl get: %v\n", err)
+			return 1
+		}
+		return printConfig(stdout, stderr, resp.GetConfig())
+	})
+}
+
+func cmdSetPollFrequency(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("set-poll-frequency", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	frequency := fs.Duration("frequency", 0, "new poll frequency, e.g. 30s (required)")
+	timeout := fs.Duration("timeout", 0, "new per-namespace poll timeout, must be < frequency (required)")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if *frequency <= 0 || *timeout <= 0 {
+			fmt.Fprintln(stderr, "xtcp2ctl set-poll-frequency: -frequency and -timeout are required (>0)")
+			return 2
+		}
+		if _, err := c.SetPollFrequency(ctx, &xtcp_config.SetPollFrequencyRequest{
+			PollFrequency: durationpb.New(*frequency),
+			PollTimeout:   durationpb.New(*timeout),
+		}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl set-poll-frequency: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "ok: poll frequency=%s timeout=%s\n", *frequency, *timeout)
+		return 0
+	})
+}
+
+func cmdTriggerPoll(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("trigger-poll", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if _, err := c.TriggerPoll(ctx, &xtcp_config.TriggerPollRequest{}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl trigger-poll: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: poll triggered")
+		return 0
+	})
+}
+
+func cmdPollBurst(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("poll-burst", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	count := fs.Uint("count", 6, "number of polls in the burst (1-1000)")
+	interval := fs.Duration("interval", 10*time.Second, "spacing between polls; must exceed the daemon's poll timeout")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		if _, err := c.TriggerPollBurst(ctx, &xtcp_config.TriggerPollBurstRequest{
+			Count:    uint32(*count),
+			Interval: durationpb.New(*interval),
+		}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl poll-burst: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "ok: burst of %d polls scheduled, %s apart\n", *count, *interval)
+		return 0
+	})
+}
+
+func cmdSetS3(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("set-s3", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	flushInterval := fs.Duration("flush-interval", 0, "new s3parquet staleness-flush timer, e.g. 5s")
+	thresholdBytes := fs.Uint("threshold-bytes", 0, "new s3parquet byte cap before finalize+upload")
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		// Only send fields the operator explicitly set. Empty request violates
+		// the server's "at least one" rule, so catch it locally.
+		req := &xtcp_config.SetS3UploadRequest{}
+		set := map[string]bool{}
+		fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+		if set["flush-interval"] {
+			req.S3FlushInterval = durationpb.New(*flushInterval)
+		}
+		if set["threshold-bytes"] {
+			req.S3ParquetFlushThresholdBytes = uint32(*thresholdBytes)
+		}
+		if !set["flush-interval"] && !set["threshold-bytes"] {
+			fmt.Fprintln(stderr, "xtcp2ctl set-s3: set -flush-interval and/or -threshold-bytes")
+			return 2
+		}
+		if _, err := c.SetS3Upload(ctx, req); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl set-s3: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: s3 upload settings updated")
+		return 0
+	})
+}
+
+func cmdReconfigure(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("reconfigure", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	commonFlags(fs)
+	file := fs.String("file", "-", `config JSON file to apply; "-" reads stdin (default)`)
+	return withClient(ctx, fs, args, stderr, func(ctx context.Context, c xtcp_config.ConfigServiceClient) int {
+		raw, err := readConfigInput(*file)
+		if err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: read %s: %v\n", *file, err)
+			return 1
+		}
+		cfg := &xtcp_config.XtcpConfig{}
+		if err := protojson.Unmarshal(raw, cfg); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: parse config JSON: %v\n", err)
+			return 1
+		}
+		if _, err := c.Set(ctx, &xtcp_config.SetRequest{Config: cfg}); err != nil {
+			fmt.Fprintf(stderr, "xtcp2ctl reconfigure: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "ok: reconfigure accepted — daemon is soft-restarting (gRPC/metrics blip for a few seconds)")
+		return 0
+	})
+}
+
+// readConfigInput returns the bytes of the config file, or stdin when path is
+// "-" (or empty). stdinReader is overridable in tests.
+var stdinReader io.Reader = os.Stdin
+
+func readConfigInput(path string) ([]byte, error) {
+	if path == "-" || path == "" {
+		return io.ReadAll(stdinReader)
+	}
+	return os.ReadFile(path)
+}
+
+// printConfig writes cfg as indented protojson — the exact shape reconfigure
+// consumes, so `get | edit | reconfigure` round-trips.
+func printConfig(stdout, stderr io.Writer, cfg *xtcp_config.XtcpConfig) int {
+	if cfg == nil {
+		fmt.Fprintln(stderr, "xtcp2ctl: daemon returned no config")
+		return 1
+	}
+	out, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "xtcp2ctl: marshal config: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, string(out))
+	return 0
+}

--- a/cmd/xtcp2ctl/xtcp2ctl_test.go
+++ b/cmd/xtcp2ctl/xtcp2ctl_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/randomizedcoder/xtcp2/pkg/xtcp_config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// fakeConfigServer records the last request per RPC so tests can assert the CLI
+// translated flags → request correctly. Get returns a fixed config.
+type fakeConfigServer struct {
+	xtcp_config.UnimplementedConfigServiceServer
+	lastSetPollFreq *xtcp_config.SetPollFrequencyRequest
+	lastBurst       *xtcp_config.TriggerPollBurstRequest
+	lastS3          *xtcp_config.SetS3UploadRequest
+	lastSet         *xtcp_config.SetRequest
+	triggered       bool
+}
+
+func (f *fakeConfigServer) Get(context.Context, *xtcp_config.GetRequest) (*xtcp_config.GetResponse, error) {
+	return &xtcp_config.GetResponse{Config: &xtcp_config.XtcpConfig{
+		Dest:          "kafka:127.0.0.1:9092",
+		Tag:           "live-tag",
+		PollFrequency: durationpb.New(10 * time.Second),
+	}}, nil
+}
+
+func (f *fakeConfigServer) SetPollFrequency(_ context.Context, in *xtcp_config.SetPollFrequencyRequest) (*xtcp_config.SetPollFrequencyResponse, error) {
+	f.lastSetPollFreq = in
+	return &xtcp_config.SetPollFrequencyResponse{}, nil
+}
+
+func (f *fakeConfigServer) TriggerPoll(context.Context, *xtcp_config.TriggerPollRequest) (*xtcp_config.TriggerPollResponse, error) {
+	f.triggered = true
+	return &xtcp_config.TriggerPollResponse{}, nil
+}
+
+func (f *fakeConfigServer) TriggerPollBurst(_ context.Context, in *xtcp_config.TriggerPollBurstRequest) (*xtcp_config.TriggerPollBurstResponse, error) {
+	f.lastBurst = in
+	return &xtcp_config.TriggerPollBurstResponse{Count: in.Count, Interval: in.Interval}, nil
+}
+
+func (f *fakeConfigServer) SetS3Upload(_ context.Context, in *xtcp_config.SetS3UploadRequest) (*xtcp_config.SetS3UploadResponse, error) {
+	f.lastS3 = in
+	return &xtcp_config.SetS3UploadResponse{}, nil
+}
+
+func (f *fakeConfigServer) Set(_ context.Context, in *xtcp_config.SetRequest) (*xtcp_config.SetResponse, error) {
+	f.lastSet = in
+	return &xtcp_config.SetResponse{Config: in.Config}, nil
+}
+
+// startFakeServer spins up the fake ConfigService on an in-memory bufconn and
+// points the CLI's dialFunc at it. Returns the server + a cleanup.
+func startFakeServer(t *testing.T) *fakeConfigServer {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	fake := &fakeConfigServer{}
+	xtcp_config.RegisterConfigServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+
+	prevDial := dialFunc
+	dialFunc = func(string) (*grpc.ClientConn, error) {
+		return grpc.NewClient(
+			"passthrough:///bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+	}
+	t.Cleanup(func() {
+		dialFunc = prevDial
+		srv.Stop()
+		_ = lis.Close()
+	})
+	return fake
+}
+
+func run(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	rc := runMain(context.Background(), args, &out, &errb)
+	return rc, out.String(), errb.String()
+}
+
+func TestGet(t *testing.T) {
+	startFakeServer(t)
+	rc, out, errStr := run(t, "get")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if !strings.Contains(out, "live-tag") || !strings.Contains(out, "kafka:127.0.0.1:9092") {
+		t.Errorf("get output missing expected fields:\n%s", out)
+	}
+}
+
+func TestSetPollFrequency(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "set-poll-frequency", "-frequency", "30s", "-timeout", "5s")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastSetPollFreq == nil ||
+		fake.lastSetPollFreq.PollFrequency.AsDuration() != 30*time.Second ||
+		fake.lastSetPollFreq.PollTimeout.AsDuration() != 5*time.Second {
+		t.Errorf("unexpected SetPollFrequency request: %+v", fake.lastSetPollFreq)
+	}
+}
+
+func TestSetPollFrequency_missingArgs(t *testing.T) {
+	startFakeServer(t)
+	if rc, _, _ := run(t, "set-poll-frequency"); rc != 2 {
+		t.Errorf("expected rc=2 for missing args, got %d", rc)
+	}
+}
+
+func TestTriggerPoll(t *testing.T) {
+	fake := startFakeServer(t)
+	if rc, _, errStr := run(t, "trigger-poll"); rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if !fake.triggered {
+		t.Error("TriggerPoll was not called")
+	}
+}
+
+func TestPollBurst(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "poll-burst", "-count", "6", "-interval", "10s")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastBurst == nil || fake.lastBurst.Count != 6 || fake.lastBurst.Interval.AsDuration() != 10*time.Second {
+		t.Errorf("unexpected burst request: %+v", fake.lastBurst)
+	}
+}
+
+func TestSetS3_bothFields(t *testing.T) {
+	fake := startFakeServer(t)
+	rc, _, errStr := run(t, "set-s3", "-flush-interval", "5s", "-threshold-bytes", "1024")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastS3 == nil || fake.lastS3.S3FlushInterval.AsDuration() != 5*time.Second || fake.lastS3.S3ParquetFlushThresholdBytes != 1024 {
+		t.Errorf("unexpected set-s3 request: %+v", fake.lastS3)
+	}
+}
+
+// Only the flag the operator set is populated; the other stays nil/zero.
+func TestSetS3_onlyInterval(t *testing.T) {
+	fake := startFakeServer(t)
+	if rc, _, errStr := run(t, "set-s3", "-flush-interval", "5s"); rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastS3.S3FlushInterval == nil || fake.lastS3.S3ParquetFlushThresholdBytes != 0 {
+		t.Errorf("expected only interval set: %+v", fake.lastS3)
+	}
+}
+
+func TestSetS3_noFields(t *testing.T) {
+	startFakeServer(t)
+	if rc, _, _ := run(t, "set-s3"); rc != 2 {
+		t.Errorf("expected rc=2 when no fields given, got %d", rc)
+	}
+}
+
+func TestReconfigure_fromStdin(t *testing.T) {
+	fake := startFakeServer(t)
+	prev := stdinReader
+	stdinReader = strings.NewReader(`{"dest":"kafka:127.0.0.1:9092","tag":"INC-9"}`)
+	t.Cleanup(func() { stdinReader = prev })
+
+	rc, out, errStr := run(t, "reconfigure", "-file", "-")
+	if rc != 0 {
+		t.Fatalf("rc=%d stderr=%s", rc, errStr)
+	}
+	if fake.lastSet == nil || fake.lastSet.Config.Tag != "INC-9" {
+		t.Errorf("unexpected Set request: %+v", fake.lastSet)
+	}
+	if !strings.Contains(out, "soft-restarting") {
+		t.Errorf("expected soft-restart notice, got: %s", out)
+	}
+}
+
+func TestReconfigure_badJSON(t *testing.T) {
+	startFakeServer(t)
+	prev := stdinReader
+	stdinReader = strings.NewReader(`{not json`)
+	t.Cleanup(func() { stdinReader = prev })
+	if rc, _, _ := run(t, "reconfigure"); rc != 1 {
+		t.Errorf("expected rc=1 for bad JSON, got %d", rc)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	if rc, _, errStr := run(t, "frobnicate"); rc != 2 || !strings.Contains(errStr, "unknown command") {
+		t.Errorf("expected rc=2 + unknown-command message, got rc=%d err=%s", rc, errStr)
+	}
+}
+
+func TestNoArgs(t *testing.T) {
+	if rc, _, _ := run(t); rc != 2 {
+		t.Errorf("expected rc=2 for no args, got %d", rc)
+	}
+}

--- a/docs/grpc-api.md
+++ b/docs/grpc-api.md
@@ -6,7 +6,9 @@ xtcp2 exposes a gRPC server (default port `8889`) with two services: one to read
 
 - [The server](#the-server)
 - [ConfigService](#configservice)
+- [Runtime operator control](#runtime-operator-control)
 - [XTCPFlatRecordService](#xtcpflatrecordservice)
+- [The xtcp2ctl control CLI](#the-xtcp2ctl-control-cli)
 - [The xtcp2client binary](#the-xtcp2client-binary)
 - [Using grpcurl](#using-grpcurl)
 - [Configuration](#configuration)
@@ -23,13 +25,34 @@ xtcp2 exposes a gRPC server (default port `8889`) with two services: one to read
 
 Defined in `proto/xtcp_config/v1/xtcp_config.proto`, this service lets you inspect and modify the running daemon's configuration:
 
-| RPC | Purpose |
-|---|---|
-| `Get(GetRequest) → GetResponse` | Return the current `XtcpConfig`. |
-| `Set(SetRequest) → SetResponse` | Replace the configuration. |
-| `SetPollFrequency(SetPollFrequencyRequest) → SetPollFrequencyResponse` | Change just the poll interval without a full `Set`. |
+| RPC | Purpose | Disruption |
+|---|---|---|
+| `Get(GetRequest) → GetResponse` | Return the current `XtcpConfig` (S3 credentials redacted). | none |
+| `SetPollFrequency(SetPollFrequencyRequest) → SetPollFrequencyResponse` | Change the poll frequency + timeout live. | none (hot) |
+| `TriggerPoll(TriggerPollRequest) → TriggerPollResponse` | Trigger a single poll immediately, without changing the cadence. | none (hot) |
+| `TriggerPollBurst(TriggerPollBurstRequest) → TriggerPollBurstResponse` | Schedule `count` polls spaced `interval` apart (e.g. a socket snapshot every 10s for a minute). | none (hot) |
+| `SetS3Upload(SetS3UploadRequest) → SetS3UploadResponse` | Change the s3parquet staleness-flush timer and/or byte cap live. | none (hot) |
+| `Set(SetRequest) → SetResponse` | Apply a full new `XtcpConfig` via a **soft restart** (see below). | brief (soft restart) |
 
 Configuration changes are validated with [buf.validate](https://github.com/bufbuild/protovalidate) CEL constraints declared in the proto (for example, the poll timeout must be shorter than the poll frequency), so invalid updates are rejected at the RPC boundary.
+
+## Runtime operator control
+
+There are two tiers of runtime change, so pick the least disruptive one that does the job:
+
+**Hot changes (no restart, no data loss).** `SetPollFrequency`, `TriggerPoll`, `TriggerPollBurst`, and `SetS3Upload` take effect on a running daemon immediately. The burst RPC is the incident tool: *"take a socket snapshot every 10s for a minute"* is `TriggerPollBurst{count: 6, interval: 10s}`. The polled records flow to whatever destination is configured (and to any connected `PollFlatRecords` stream). `interval` must exceed the daemon's `poll_timeout` so each poll completes before the next fires; the handler rejects a too-short interval.
+
+**Soft restart (`Set`).** Everything else — which record fields are exported, string metadata like `tag`/`location`/`hostname`, the marshaller, the destination — is baked in at startup, so changing it goes through `Set`, which re-execs the daemon in place. This avoids redeploying the container: same PID, same container, new config carried across a `syscall.Exec`. The gRPC/metrics/health endpoints blip for a few seconds while it re-initializes and Prometheus counters reset (`rate()` tolerates resets). Buffered records are flushed before the re-exec, so no data is lost.
+
+The intended flow is **read → edit → apply**:
+
+1. `Get` returns the full running config as JSON (S3 credentials come back blank — they're redacted).
+2. Edit the JSON: flip an `enabledDeserializers` entry (e.g. turn `bbr` on temporarily), set `tag` to an incident ticket, change `location`, etc.
+3. `Set` the edited config. Because empty credential fields are treated as *unchanged*, the redacted round-trip preserves the daemon's S3 keys.
+
+**Exported field groups** are controlled by the `enabledDeserializers` map — each key toggles a whole INET_DIAG attribute group (`info` = the tcp_info struct, `bbr` = the BBR fields, plus `vegas`, `cong`, `meminfo`, `skmem`, `dctcp`, `cgroup`, …). Setting a key to `false` disables that group; the full key list is what the daemon's `-deserializers` flag accepts. Individual fields *within* a group are all-or-nothing except for the CSV/TSV `csvColumns` selector.
+
+> **Security.** The gRPC server has no auth or TLS. `Get` redacts S3 credentials, but any client that can reach the port can reconfigure or restart the daemon. Bind the gRPC port to loopback / a trusted network (see the `-ipv4Ttl` clamp in [Configuration](#configuration)).
 
 ## XTCPFlatRecordService
 
@@ -39,6 +62,49 @@ Defined in `proto/xtcp_flat_record/v1/xtcp_flat_record.proto`:
 |---|---|---|
 | `FlatRecords(FlatRecordsRequest) → stream FlatRecordsResponse` | server streaming | The daemon pushes records to the client as it collects them. |
 | `PollFlatRecords(stream PollFlatRecordsRequest) → stream PollFlatRecordsResponse` | bidirectional streaming | The client drives collection on demand, triggering a poll per request. |
+
+## The xtcp2ctl control CLI
+
+`cmd/xtcp2ctl` is the operator control CLI — a thin wrapper over `ConfigService` for changing a running daemon without redeploying. (Where `xtcp2client` *reads* records, `xtcp2ctl` *changes settings*.) Everything it does is equally reachable with `grpcurl`; it just makes the common actions one-liners.
+
+```sh
+nix build .#xtcp2ctl
+alias xtcp2ctl=./result/bin/xtcp2ctl   # all commands accept -target / -port
+
+# Inspect the running config (S3 creds redacted)
+xtcp2ctl get
+
+# Hot changes — take effect immediately, no restart
+xtcp2ctl set-poll-frequency -frequency 30s -timeout 5s
+xtcp2ctl trigger-poll
+xtcp2ctl poll-burst -count 6 -interval 10s      # snapshot every 10s for a minute
+xtcp2ctl set-s3 -flush-interval 5s              # flush buffered snapshots to S3 promptly
+xtcp2ctl set-s3 -threshold-bytes 1048576        # or lower the byte cap
+```
+
+**Incident workflow — enable BBR detail + tag with a ticket (soft restart):**
+
+```sh
+# 1. capture the current config
+xtcp2ctl get > cfg.json
+
+# 2. edit cfg.json: turn bbr on and stamp a tag. enabledDeserializers wraps a
+#    nested "enabled" map, so the path is .enabledDeserializers.enabled.<key>.
+jq '.enabledDeserializers.enabled.bbr = true | .tag = "INC-1234"' cfg.json > cfg.new.json
+
+# 3. apply — daemon soft-restarts in place (same container), gRPC/metrics blip briefly
+xtcp2ctl reconfigure -file cfg.new.json
+# (reads stdin when -file is "-" or omitted)
+```
+
+| Command | Key flags | Tier |
+|---|---|---|
+| `get` | | none |
+| `set-poll-frequency` | `-frequency`, `-timeout` | hot |
+| `trigger-poll` | | hot |
+| `poll-burst` | `-count`, `-interval` | hot |
+| `set-s3` | `-flush-interval`, `-threshold-bytes` (at least one) | hot |
+| `reconfigure` | `-file` (`-` = stdin) | soft restart |
 
 ## The xtcp2client binary
 
@@ -71,7 +137,23 @@ Because reflection is on, the vendored `grpcurl` (`cmd/grpcurl`) can list and ca
 ```sh
 grpcurl -plaintext 127.0.0.1:8889 list
 grpcurl -plaintext 127.0.0.1:8889 xtcp_config.v1.ConfigService/Get
+
+# Hot changes
+grpcurl -plaintext -d '{"poll_frequency":"30s","poll_timeout":"5s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/SetPollFrequency
+grpcurl -plaintext -d '{}' 127.0.0.1:8889 xtcp_config.v1.ConfigService/TriggerPoll
+grpcurl -plaintext -d '{"count":6,"interval":"10s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/TriggerPollBurst
+grpcurl -plaintext -d '{"s3_flush_interval":"5s"}' \
+  127.0.0.1:8889 xtcp_config.v1.ConfigService/SetS3Upload
+
+# Soft restart: Get → edit → Set the whole config
+grpcurl -plaintext 127.0.0.1:8889 xtcp_config.v1.ConfigService/Get \
+  | jq '.config.enabledDeserializers.enabled.bbr = true | .config.tag = "INC-1234"' \
+  | grpcurl -plaintext -d @ 127.0.0.1:8889 xtcp_config.v1.ConfigService/Set
 ```
+
+`xtcp2ctl` (above) wraps these same calls with flag-based ergonomics.
 
 ## Configuration
 

--- a/nix/binaries.nix
+++ b/nix/binaries.nix
@@ -52,6 +52,7 @@ let
     "register_schema"
     "xtcp2"
     "xtcp2client"
+    "xtcp2ctl"
     "xtcp2_kafka_client"
   ];
 

--- a/nix/checks/cli-help-smoke.nix
+++ b/nix/checks/cli-help-smoke.nix
@@ -30,6 +30,7 @@ let
     "register_schema"
     "xtcp2"
     "xtcp2client"
+    "xtcp2ctl"
     "xtcp2_kafka_client"
   ];
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -311,6 +311,7 @@ in
       microvm-x86_64-soak = microvms.vmsSoak.x86_64;
       microvm-x86_64-tcp-stress = microvms.vmsTcpStress.x86_64;
       microvm-x86_64-clickhouse-pipeline = microvms.vmsClickPipe.x86_64;
+      microvm-x86_64-clickhouse-pipeline-rate = microvms.vmsClickPipeRate.x86_64;
       microvm-x86_64-clickhouse-pipeline-stress = microvms.vmsClickPipeStress.x86_64;
       microvm-x86_64-clickhouse-pipeline-parquet = microvms.vmsClickPipeParquet.x86_64;
       microvm-x86_64-s3parquet-pipeline = microvms.vmsS3Parquet.x86_64;
@@ -423,6 +424,17 @@ in
     microvm-x86_64-clickhouse-pipeline-stress = {
       type = "app";
       program = "${microvms.clickPipeStress.x86_64.runner}/bin/xtcp2-clickpipe-stress-runner-x86_64";
+    };
+
+    # Runtime-control rate test. Boots the clickhouse-pipeline-rate VM, whose
+    # in-VM monitor drives xtcp2ctl through a baseline→fast→revert poll-frequency
+    # schedule plus a poll-burst, and asserts the ClickHouse ingest RATE responds
+    # and returns. Duration-bounded runner (~9 min); prints the per-phase
+    # XTCP2_RATE_* lines and passes only if every verdict is PASS. Not in
+    # `nix flake check` — holds a KVM slot.
+    microvm-x86_64-clickhouse-pipeline-rate-runner = {
+      type = "app";
+      program = "${microvms.clickPipeRate.x86_64.runner}/bin/xtcp2-clickpipe-rate-runner-x86_64";
     };
 
     # Mixed: clickpipe stack (redpanda + clickhouse) plus MinIO and a

--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -124,6 +124,25 @@ let
       sink = "clickhouse-pipeline";
     };
 
+  # Runtime-control rate test: the clickhouse-pipeline stack + a steady
+  # 100-connection tcp load + an in-VM monitor that drives xtcp2ctl and
+  # asserts the ClickHouse ingest rate responds. Host runner is duration-
+  # bounded (mkClickPipeRateRunner). No tcp-stress image needed.
+  mkOneClickPipeRate =
+    arch:
+    import ./mkVm.nix {
+      inherit
+        pkgs
+        lib
+        microvm
+        nixpkgs
+        arch
+        xtcp2Package
+        xtcp2AllPackage
+        ;
+      sink = "clickhouse-pipeline-rate";
+    };
+
   # Full end-to-end integration stress test: clickhouse-pipeline stack +
   # the tcp-stress socket-load containers. Needs tcpStressImage (to
   # docker-load and spawn the load containers) in addition to the pipeline.
@@ -281,6 +300,8 @@ let
 
   vmsClickPipe = lib.genAttrs constants.supportedArchs mkOneClickPipe;
 
+  vmsClickPipeRate = lib.genAttrs constants.supportedArchs mkOneClickPipeRate;
+
   vmsClickPipeStress = lib.optionalAttrs (tcpStressImage != null) (
     lib.genAttrs constants.supportedArchs mkOneClickPipeStress
   );
@@ -310,7 +331,7 @@ let
       # Surface every sentinel the self-test emits so a real failure in
       # Check 4+ (BINARIES_HELP, GRPC_ROUNDTRIP, NS_*) doesn't hide
       # behind an unhelpful OVERALL_FAIL with no breadcrumbs.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
     };
   });
 
@@ -322,7 +343,7 @@ let
       # The two s3parquet-specific sentinels alongside the baseline set.
       # 240 s timeout because the worker accumulates rows for several
       # poll cycles before triggering the 1 MiB-threshold finalize.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
+      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
       timeoutSec = 240;
     };
   });
@@ -339,7 +360,7 @@ let
         # outcome visible. Without this the default filter hides
         # them; the checks still execute (and the daemon exercises the
         # corresponding code paths) but the harness output is misleading.
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
       };
     })
   );
@@ -351,7 +372,7 @@ let
         vm = vmsCoverageIoUring.${arch};
         suffix = "-coverage-iouring";
         scrapeCoverage = true;
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|OVERALL";
+        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
       };
     })
   );
@@ -383,6 +404,18 @@ let
     runner = microvmLib.mkDiscoveryBenchRunner {
       inherit arch;
       vm = vmsDiscoveryBench.${arch};
+    };
+  });
+
+  # Runtime-control rate test runner: boots the clickhouse-pipeline-rate VM,
+  # waits for the in-VM monitor's XTCP2_RATE_DONE (or --timeout), and passes
+  # only if the ingest rate responded to set-poll-frequency + poll-burst.
+  # No tcpStressImage needed (the steady load is the default-ns tcp_server/
+  # tcp_client pair, not the load containers).
+  clickPipeRate = lib.genAttrs constants.supportedArchs (arch: {
+    runner = microvmLib.mkClickPipeRateRunner {
+      inherit arch;
+      vm = vmsClickPipeRate.${arch};
     };
   });
 
@@ -453,6 +486,7 @@ in
     vmsSoak
     vmsTcpStress
     vmsClickPipe
+    vmsClickPipeRate
     vmsClickPipeStress
     vmsClickPipeParquet
     vmsS3Parquet
@@ -463,6 +497,7 @@ in
     vmsDiscoveryBench
     s3parquetLong
     discoveryBench
+    clickPipeRate
     clickPipeStress
     s3ParquetStress
     s3ParquetLowfreq

--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -834,6 +834,148 @@ rec {
       '';
     };
 
+  # mkClickPipeRateRunner — host runner for the clickhouse-pipeline-rate flavor.
+  # Mirrors mkDiscoveryBenchRunner (boot, tail both consoles, wait for a DONE
+  # sentinel or --timeout, power off). The in-VM xtcp2-clickpipe-rate monitor
+  # drives xtcp2ctl through a poll-frequency schedule and emits XTCP2_RATE_*
+  # sentinels; this runner surfaces the per-phase data lines and passes only if
+  # all three verdicts (INCREASE / REVERT / BURST) are PASS.
+  mkClickPipeRateRunner =
+    {
+      arch,
+      vm,
+    }:
+    let
+      cfg = constants.architectures.${arch};
+    in
+    pkgs.writeShellApplication {
+      name = "xtcp2-clickpipe-rate-runner-${arch}";
+      runtimeInputs = with pkgs; [
+        coreutils
+        gnugrep
+        netcat-gnu
+        procps
+      ];
+      text = ''
+        set -u
+
+        # ~15 min schedule (3×180s windows + settles + burst) + docker/
+        # ClickHouse/Redpanda first-boot pulls. Override with --timeout.
+        TIMEOUT_SEC=1800
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --timeout)   TIMEOUT_SEC="$2"; shift 2 ;;
+            --timeout=*) TIMEOUT_SEC="''${1#--timeout=}"; shift ;;
+            -h|--help)
+              echo "usage: $0 [--timeout <seconds>]"
+              echo "  Boots the clickhouse-pipeline-rate microvm, which drives"
+              echo "  xtcp2ctl through a baseline→fast→revert poll-frequency"
+              echo "  schedule + a poll-burst, and asserts the ClickHouse ingest"
+              echo "  rate responds. Prints the per-phase XTCP2_RATE_* lines."
+              exit 0
+              ;;
+            *) echo "unknown arg: $1" >&2; exit 1 ;;
+          esac
+        done
+
+        SERIAL_PORT=${toString cfg.serialPort}
+        VIRTCON_PORT=${toString cfg.virtioPort}
+        LOG=$(mktemp -t xtcp2-clickpipe-rate-XXXX.log)
+
+        echo "================================================"
+        echo " xtcp2 microvm clickhouse-pipeline-rate — arch=${arch}"
+        echo " timeout: $TIMEOUT_SEC s"
+        echo " transcript: $LOG"
+        echo "================================================"
+
+        QEMU_LOG="''${LOG}.qemu"
+        ${vm}/bin/microvm-run > "$QEMU_LOG" 2>&1 &
+        vm_pid=$!
+
+        nc_serial_pid=""
+        nc_virtcon_pid=""
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$SERIAL_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$SERIAL_PORT" >> "$LOG" 2>&1 &
+            nc_serial_pid=$!
+            break
+          fi
+          sleep 1
+        done
+        for _ in $(seq 1 30); do
+          if nc -z 127.0.0.1 "$VIRTCON_PORT" 2>/dev/null; then
+            nc 127.0.0.1 "$VIRTCON_PORT" >> "$LOG" 2>&1 &
+            nc_virtcon_pid=$!
+            break
+          fi
+          sleep 1
+        done
+
+        trap '
+          if kill -0 "$vm_pid" 2>/dev/null; then
+            ( printf "systemctl poweroff\n" | nc -q 1 127.0.0.1 "$SERIAL_PORT" ) >/dev/null 2>&1 || true
+            sleep 10
+            kill "$vm_pid" 2>/dev/null || true
+            wait "$vm_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_serial_pid" ] && kill -0 "$nc_serial_pid" 2>/dev/null; then
+            kill "$nc_serial_pid" 2>/dev/null || true
+          fi
+          if [ -n "$nc_virtcon_pid" ] && kill -0 "$nc_virtcon_pid" 2>/dev/null; then
+            kill "$nc_virtcon_pid" 2>/dev/null || true
+          fi
+        ' EXIT
+
+        # Wait for the schedule to finish (XTCP2_RATE_DONE) or the timeout.
+        elapsed=0
+        done_seen=0
+        while [ "$elapsed" -lt "$TIMEOUT_SEC" ]; do
+          if ! kill -0 "$vm_pid" 2>/dev/null; then
+            echo "FATAL: qemu died at t=$elapsed s; tail of transcript:"
+            tail -n 40 "$LOG"
+            exit 2
+          fi
+          if grep -q 'XTCP2_RATE_DONE' "$LOG" 2>/dev/null; then
+            done_seen=1
+            break
+          fi
+          sleep 5
+          elapsed=$((elapsed + 5))
+        done
+
+        if [ "$done_seen" -ne 1 ]; then
+          echo "FATAL: XTCP2_RATE_DONE not seen within $TIMEOUT_SEC s"
+          tail -n 40 "$LOG" 2>/dev/null || true
+          exit 2
+        fi
+
+        echo ""
+        echo "================================================"
+        echo " clickhouse-pipeline-rate results"
+        echo "================================================"
+        grep -E 'XTCP2_RATE_(START|BASELINE|FAST|REVERT|BURST) ' "$LOG" 2>/dev/null || true
+        grep -E 'XTCP2_RATE_(CADENCE|PREDICT|DELIVERY|SOCKETS|BURST|OVERALL)_(PASS|FAIL)' "$LOG" 2>/dev/null || true
+
+        rc=0
+        if grep -qE 'XTCP2_RATE_(CADENCE|PREDICT|DELIVERY|SOCKETS|BURST|OVERALL)_FAIL' "$LOG" 2>/dev/null; then
+          echo "FAIL: at least one rate verdict failed"
+          rc=1
+        elif grep -q 'XTCP2_RATE_CADENCE_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_PREDICT_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_DELIVERY_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_SOCKETS_PASS' "$LOG" 2>/dev/null \
+          && grep -q 'XTCP2_RATE_BURST_PASS' "$LOG" 2>/dev/null; then
+          echo "PASS: predicted ClickHouse rows from the socket estimate matched actual across baseline/fast/revert + burst"
+        else
+          echo "FAIL: not all rate verdict sentinels present"
+          rc=1
+        fi
+        echo ""
+        echo "Full transcript kept at: $LOG"
+        exit "$rc"
+      '';
+    };
+
   mkSoakRunner =
     {
       arch,

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -87,6 +87,14 @@ let
   # poll frequency + low socket count. Lighter than stress (no dedicated disks,
   # no retention).
   isS3ParquetLowfreq = sink == "s3parquet-lowfreq";
+  # clickhouse-pipeline-rate = the runtime-control behavioral test: the
+  # clickhouse-pipeline stack (redpanda + clickhouse + kafka + xtcp2) PLUS a
+  # steady 100-connection tcp_server/tcp_client load (a stable rate
+  # denominator). A dedicated in-VM monitor drives xtcp2ctl through a
+  # baseline→fast→revert poll-frequency schedule plus a poll-burst, and asserts
+  # the RATE of rows arriving in xtcp.xtcp_flat_records responds and returns —
+  # end-to-end proof the operator-control CLI changes live daemon behavior.
+  isClickPipeRate = sink == "clickhouse-pipeline-rate";
   # discovery-bench = a root VM that runs the namespace-discovery A/B grid
   # (tools/discovery-bench -mode grid) against a real kernel, then powers off.
   # No downstream/dockerd — it only needs ip netns + many cheap processes.
@@ -95,7 +103,7 @@ let
   # mem budget, daemon args base) is shared.
   isAnyS3Parquet = isS3Parquet || isS3ParquetLong || isCapCheckFail || isClickPipeParquet || isS3ParquetStress || isS3ParquetLowfreq;
   # All flavors that bring up the redpanda + clickhouse docker stack.
-  isAnyClickPipe = isClickPipe || isClickPipeParquet || isClickPipeStress;
+  isAnyClickPipe = isClickPipe || isClickPipeParquet || isClickPipeStress || isClickPipeRate;
   # Flavors that spawn the tcp-stress socket-load containers.
   isAnyTcpStressLoad = isTcpStress || isClickPipeStress || isS3ParquetStress || isS3ParquetLowfreq;
   # Anything that needs dockerd inside the VM (the tcp-stress load containers
@@ -800,6 +808,172 @@ let
     '';
   };
 
+  # clickhouse-pipeline-rate flavor: the runtime-control behavioral test.
+  # A dedicated monitor drives xtcp2ctl through a poll-frequency schedule and
+  # asserts the RATE of rows arriving in xtcp.xtcp_flat_records responds:
+  #   BASELINE(10s) → FAST(1s, ~10× faster) → REVERT(10s, back down)
+  # then a poll-burst (6 polls, 10s apart) with the ticker parked. Rate is the
+  # ClickHouse row-count delta over a fixed window (default 60s); a steady
+  # 100-connection tcp load keeps rows-per-poll stable so rate tracks only the
+  # frequency. Emits per-phase data + PASS/FAIL verdict sentinels + a terminal
+  # XTCP2_RATE_DONE the host runner (lib.nix mkClickPipeRateRunner) waits on.
+  clickPipeRateScript = pkgs.writeShellApplication {
+    name = "xtcp2-clickpipe-rate";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+      docker
+      gawk
+      gnugrep
+      xtcp2AllPackage # provides xtcp2ctl
+    ];
+    text = ''
+      # Never abort mid-schedule — we want to reach XTCP2_RATE_DONE so the host
+      # runner never blocks to timeout on a single transient hiccup.
+      set +e
+
+      WINDOW=''${RATE_WINDOW_SEC:-180}  # per-phase measurement window (seconds)
+      SETTLE=''${RATE_SETTLE_SEC:-30}   # settle after a frequency change before measuring
+      TOL=''${RATE_TOL_PCT:-10}         # ± tolerance percent for the quantitative asserts
+      GPORT=${toString cfg.grpcPort}
+      PROM="http://127.0.0.1:${toString cfg.promPort}/metrics"
+
+      ch_rows() {
+        docker exec clickhouse clickhouse-client --password ${clickPipeChPassword} \
+          -q 'SELECT count() FROM xtcp.xtcp_flat_records' 2>/dev/null | tr -dc '0-9'
+      }
+      # Sum a Poller counter row (function="Poller",variable=$1) from /metrics.
+      # Handles integer or scientific-notation values (awk coerces both).
+      poller_counter() {
+        curl --silent --fail --max-time 3 "$PROM" 2>/dev/null \
+          | awk -v v="variable=\"$1\"" '
+              /^xtcp_counts/ && index($0,"function=\"Poller\"")>0 && index($0,v)>0 { s += $NF + 0 }
+              END { printf "%d", s+0 }'
+      }
+      setfreq() { xtcp2ctl set-poll-frequency -frequency "$1" -timeout "$2" -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1; }
+      # within_tol ACTUAL EXPECTED → true when |actual-expected|*100/expected <= TOL.
+      within_tol() {
+        local a="$1" e="$2" d
+        [ "$e" -le 0 ] && return 1
+        d=$(( a >= e ? a - e : e - a ))
+        [ $(( d * 100 / e )) -le "$TOL" ]
+      }
+      verdict() { # NAME OK MSG
+        if [ "$2" -eq 1 ]; then echo "XTCP2_RATE_''${1}_PASS ($3)"; else echo "XTCP2_RATE_''${1}_FAIL ($3)"; fi
+      }
+
+      # measure PHASE FREQ_SECONDS → samples (ClickHouse rows, produced rows,
+      # poll count) across one window and sets the globals M_CH / M_PRODUCED /
+      # M_POLLS / M_EXPECTED / M_N. N = produced/polls = sockets-per-poll (the
+      # daemon's own socket estimate). Jitter is disabled, so M_POLLS ≈ W/f.
+      measure() {
+        local phase="$1" fsec="$2" t0 e0 k0 t1 e1 k1
+        t0=$(ch_rows); t0=''${t0:-0}; e0=$(poller_counter envelopeRows); k0=$(poller_counter ticker)
+        sleep "$WINDOW"
+        t1=$(ch_rows); t1=''${t1:-0}; e1=$(poller_counter envelopeRows); k1=$(poller_counter ticker)
+        M_CH=$(( t1 - t0 )); M_PRODUCED=$(( e1 - e0 )); M_POLLS=$(( k1 - k0 ))
+        M_EXPECTED=$(( WINDOW / fsec ))
+        if [ "$M_POLLS" -gt 0 ]; then M_N=$(( M_PRODUCED / M_POLLS )); else M_N=0; fi
+        echo "XTCP2_RATE_$phase $(date -u +%FT%TZ) freq=''${fsec}s window=''${WINDOW}s polls=$M_POLLS expected_polls=$M_EXPECTED sockets_per_poll=$M_N produced=$M_PRODUCED ch_delta=$M_CH"
+      }
+
+      echo "XTCP2_RATE_START $(date -u +%FT%TZ) window=''${WINDOW}s settle=''${SETTLE}s tol=''${TOL}% grpc=$GPORT"
+
+      # ── Ready gate: xtcp2 metrics up AND rows already flowing into ClickHouse.
+      ready=0
+      for _ in $(seq 1 90); do
+        if curl --silent --fail --max-time 3 "$PROM" 2>/dev/null | grep -q '^xtcp_'; then
+          r=$(ch_rows); r=''${r:-0}
+          if [ "$r" -gt 0 ]; then ready=1; break; fi
+        fi
+        sleep 2
+      done
+      if [ "$ready" -ne 1 ]; then
+        echo "XTCP2_RATE_OVERALL_FAIL (pipeline not ready: no rows in ClickHouse within 180s)"
+        echo "XTCP2_RATE_DONE"
+        exit 1
+      fi
+
+      # ── Phase 1: BASELINE (10s) — defines the reference socket estimate.
+      setfreq 10s 2s;   sleep "$SETTLE"; measure BASELINE 10
+      base_polls=$M_POLLS; base_exp=$M_EXPECTED; base_ch=$M_CH; base_prod=$M_PRODUCED; NCALIB=$M_N
+      # ── Phase 2: FAST (1s) — ~10× the poll rate.
+      setfreq 1s 500ms; sleep "$SETTLE"; measure FAST 1
+      fast_polls=$M_POLLS; fast_exp=$M_EXPECTED; fast_ch=$M_CH; fast_prod=$M_PRODUCED; fast_n=$M_N
+      # ── Phase 3: REVERT (10s) — rate returns to baseline.
+      setfreq 10s 2s;   sleep "$SETTLE"; measure REVERT 10
+      rev_polls=$M_POLLS; rev_exp=$M_EXPECTED; rev_ch=$M_CH; rev_prod=$M_PRODUCED; rev_n=$M_N
+
+      # CADENCE: the actual poll count each window matched window/frequency —
+      # i.e. set-poll-frequency really changed the poll rate (quantitatively).
+      cad_ok=1
+      within_tol "$base_polls" "$base_exp" || cad_ok=0
+      within_tol "$fast_polls" "$fast_exp" || cad_ok=0
+      within_tol "$rev_polls" "$rev_exp"  || cad_ok=0
+      verdict CADENCE "$cad_ok" "polls vs W/f: base=$base_polls/$base_exp fast=$fast_polls/$fast_exp revert=$rev_polls/$rev_exp"
+
+      # PREDICT (the headline): ClickHouse rows in the FAST and REVERT windows
+      # matched the prediction from the socket estimate + the known frequency:
+      # expected = NCALIB × (window/freq).
+      fast_pred=$(( NCALIB * fast_exp )); rev_pred=$(( NCALIB * rev_exp ))
+      pred_ok=1
+      within_tol "$fast_ch" "$fast_pred" || pred_ok=0
+      within_tol "$rev_ch" "$rev_pred"  || pred_ok=0
+      verdict PREDICT "$pred_ok" "ch vs N*W/f (N=$NCALIB): fast=$fast_ch/$fast_pred revert=$rev_ch/$rev_pred"
+
+      # DELIVERY: every row the daemon produced reached ClickHouse (no loss /
+      # consumer stall) — ch_delta ≈ produced each phase.
+      del_ok=1
+      within_tol "$base_ch" "$base_prod" || del_ok=0
+      within_tol "$fast_ch" "$fast_prod" || del_ok=0
+      within_tol "$rev_ch" "$rev_prod"  || del_ok=0
+      verdict DELIVERY "$del_ok" "ch vs produced: base=$base_ch/$base_prod fast=$fast_ch/$fast_prod revert=$rev_ch/$rev_prod"
+
+      # SOCKETS: the socket estimate stayed stable across phases, so the rate
+      # change is attributable to frequency, not socket drift.
+      soc_ok=1
+      within_tol "$fast_n" "$NCALIB" || soc_ok=0
+      within_tol "$rev_n" "$NCALIB"  || soc_ok=0
+      verdict SOCKETS "$soc_ok" "sockets/poll stable: calib=$NCALIB fast=$fast_n revert=$rev_n"
+
+      # ── Phase 4: BURST. Park the ticker at 1h (1s timeout lets a 10s burst
+      # interval satisfy interval>poll_timeout). Measure one poll's rows via the
+      # daemon counter (no lag), then fire 6 polls 10s apart and confirm the
+      # poll counter advanced by >=6 and 6× the rows were produced AND delivered.
+      setfreq 3600s 1s; sleep "$SETTLE"
+      pe0=$(poller_counter envelopeRows)
+      xtcp2ctl trigger-poll -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1
+      sleep 8
+      pe1=$(poller_counter envelopeRows)
+      perpoll=$(( pe1 - pe0 ))
+
+      pr0=$(poller_counter pollRequestCh); be0=$(poller_counter envelopeRows)
+      bc0=$(ch_rows); bc0=''${bc0:-0}
+      xtcp2ctl poll-burst -count 6 -interval 10s -target 127.0.0.1 -port "$GPORT" >/dev/null 2>&1
+      sleep 80   # 6 × 10s spacing + ClickHouse consume lag
+      pr1=$(poller_counter pollRequestCh); be1=$(poller_counter envelopeRows)
+      bc1=$(ch_rows); bc1=''${bc1:-0}
+      pollreq_delta=$(( pr1 - pr0 )); burst_prod=$(( be1 - be0 )); burst_ch=$(( bc1 - bc0 ))
+      burst_exp=$(( 6 * perpoll ))
+      echo "XTCP2_RATE_BURST $(date -u +%FT%TZ) perpoll=$perpoll pollreq_delta=$pollreq_delta produced=$burst_prod ch_delta=$burst_ch expected=$burst_exp"
+
+      burst_ok=1
+      [ "$pollreq_delta" -ge 6 ] || burst_ok=0
+      [ "$perpoll" -gt 0 ] || burst_ok=0
+      within_tol "$burst_prod" "$burst_exp" || burst_ok=0
+      within_tol "$burst_ch" "$burst_prod"  || burst_ok=0
+      verdict BURST "$burst_ok" "6 polls: pollreq_delta=$pollreq_delta produced=$burst_prod/~$burst_exp ch=$burst_ch"
+
+      if [ "$cad_ok" -eq 1 ] && [ "$pred_ok" -eq 1 ] && [ "$del_ok" -eq 1 ] \
+         && [ "$soc_ok" -eq 1 ] && [ "$burst_ok" -eq 1 ]; then
+        echo "XTCP2_RATE_OVERALL_PASS"
+      else
+        echo "XTCP2_RATE_OVERALL_FAIL (cadence=$cad_ok predict=$pred_ok delivery=$del_ok sockets=$soc_ok burst=$burst_ok)"
+      fi
+      echo "XTCP2_RATE_DONE"
+    '';
+  };
+
   # s3parquet flavor: in-VM MinIO + bucket bootstrap. The xtcp2 daemon
   # talks to MinIO directly via the minio-go client; no proto-desc file
   # or unixgram socket required. The long-soak variant additionally
@@ -1114,6 +1288,18 @@ let
     "2s"
     "-kafkaSchemaUrl"
     "http://localhost:18081"
+  ];
+
+  # clickhouse-pipeline-rate flavor: same kafka pipeline, but poll jitter is
+  # DISABLED so each measurement window's poll count is exactly window/frequency.
+  # The rate monitor predicts expected rows = sockets_per_poll × (window/freq)
+  # and asserts ClickHouse matches within tolerance — jitter's ±20% cadence
+  # variance would defeat that tight prediction. The rate *behavior* is
+  # identical; only the variance is removed. The monitor overrides -frequency
+  # at runtime via xtcp2ctl, so the 5s here is just the pre-baseline cadence.
+  xtcp2ClickPipeRateArgs = xtcp2ClickPipeArgs ++ [
+    "-pollJitterPct"
+    "0"
   ];
 
   xtcp2CoverageArgs =
@@ -1543,6 +1729,10 @@ in
           extraArgs =
             if isCoverage then
               xtcp2CoverageArgs
+            else if isClickPipeRate then
+              # Rate test: kafka pipeline with poll jitter disabled for a
+              # deterministic per-window poll count (see xtcp2ClickPipeRateArgs).
+              xtcp2ClickPipeRateArgs
             else if isAnyClickPipe then
               # Phase E: produce to redpanda → clickhouse via kafka dest.
               # The mixed flavor uses these args for its primary xtcp2
@@ -1630,7 +1820,7 @@ in
         # is-active xtcp2` for 30 s, robust to xtcp2 starting directly at
         # boot or via a systemd.path gate. Skipped on long-running flavors
         # (soak / s3parquet-long), which run heartbeat services instead.
-        systemd.services.xtcp2-self-test = lib.mkIf (!isSoak && !isS3ParquetLong) {
+        systemd.services.xtcp2-self-test = lib.mkIf (!isSoak && !isS3ParquetLong && !isClickPipeRate) {
           description = "xtcp2 microvm self-test";
           after = [
             "xtcp2.service"
@@ -1751,7 +1941,7 @@ in
         # bytes-sent / segs-out for the parser to chew on. The two units
         # below run alongside the nsTest churn for the soak flavor.
         systemd.services.xtcp2-soak-tcp-server =
-          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet)
+          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet || isClickPipeRate)
             {
               description = "xtcp2 soak — tcp_server echo listeners";
               after = [ "network-online.target" ];
@@ -1826,7 +2016,7 @@ in
         };
 
         systemd.services.xtcp2-soak-tcp-client =
-          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet)
+          lib.mkIf (isSoak || isS3ParquetLong || isClickPipeParquet || isClickPipeRate)
             {
               description = "xtcp2 soak — tcp_client traffic generators";
               # tcp_server takes a moment to bind all N ports — gate the
@@ -2185,6 +2375,32 @@ in
             ExecStart = "${clickPipeMonitorScript}/bin/xtcp2-clickpipe-monitor";
             Restart = "on-failure";
             RestartSec = "10s";
+            StandardOutput = "journal+console";
+            StandardError = "journal+console";
+          };
+        };
+
+        # clickhouse-pipeline-rate flavor: the runtime-control rate test driver.
+        # Runs the baseline→fast→revert→burst schedule against the live daemon
+        # via xtcp2ctl and prints XTCP2_RATE_* sentinels the host runner scrapes.
+        # Ordered after the pipeline is up + xtcp2 is serving gRPC.
+        systemd.services.xtcp2-clickpipe-rate = lib.mkIf isClickPipeRate {
+          description = "xtcp2 clickhouse-pipeline-rate — runtime-control rate test";
+          after = [
+            "xtcp2-clickpipe-up.service"
+            "xtcp2.service"
+            "xtcp2-soak-tcp-client.service"
+          ];
+          requires = [ "xtcp2-clickpipe-up.service" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            # oneshot: the schedule runs once to XTCP2_RATE_DONE and exits.
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${clickPipeRateScript}/bin/xtcp2-clickpipe-rate";
+            # ~15 min schedule (3×180s windows + settles + burst) + readiness
+            # headroom. The host runner's --timeout bounds the overall run.
+            TimeoutStartSec = "1900";
             StandardOutput = "journal+console";
             StandardError = "journal+console";
           };

--- a/nix/microvms/self-test.nix
+++ b/nix/microvms/self-test.nix
@@ -26,6 +26,17 @@
 #                                              Deserialize on real netlink
 #                                              bytes — the main reason this
 #                                              exists)
+#   XTCP2_SELF_TEST_CTL_HOT_{PASS,FAIL}        xtcp2ctl set-poll-frequency is
+#                                              reflected by a later `get` and
+#                                              bumps the Poller ticker.Reset
+#                                              counter (hot change, no restart)
+#   XTCP2_SELF_TEST_CTL_TRIGGER_{PASS,FAIL}    xtcp2ctl trigger-poll + poll-burst
+#                                              advance the Poller pollRequestCh
+#                                              counter with the ticker parked
+#   XTCP2_SELF_TEST_CTL_RESTART_{PASS,FAIL}    xtcp2ctl reconfigure = in-place
+#                                              soft restart (syscall.Exec): same
+#                                              MainPID, `get` + streamed records
+#                                              carry the new tag (non-coverage)
 #   XTCP2_SELF_TEST_NS_ANONYMOUS_{PASS,FAIL}   an anonymous `unshare -n` netns
 #                                              (no /run/netns bind mount) held by
 #                                              a live process is discovered by
@@ -106,6 +117,7 @@ pkgs.writeShellApplication {
     docker # only used by Check 11/12 (clickhouse-pipeline); harmless otherwise
     minio-client # mc — only used by Check 13/14 (s3parquet); harmless otherwise
     duckdb # used by Check 14 to decode the Parquet file
+    jq # used by Check 19 to edit the config JSON for the reconfigure soft restart
   ];
   text = ''
     set +e   # never exit early — we want all checks to run
@@ -226,6 +238,7 @@ pkgs.writeShellApplication {
     binaries=(
       xtcp2
       xtcp2client
+      xtcp2ctl
       xtcp2_kafka_client
       clickhouse_protobuflist
       clickhouse_protobuflist_db
@@ -253,7 +266,7 @@ pkgs.writeShellApplication {
       fi
     done
     if [ "$check4" -eq 0 ]; then
-      echo "XTCP2_SELF_TEST_BINARIES_HELP_PASS  (10 binaries OK)"
+      echo "XTCP2_SELF_TEST_BINARIES_HELP_PASS  (11 binaries OK)"
     else
       echo "XTCP2_SELF_TEST_BINARIES_HELP_FAIL  (failed:$failed_help)"
       overall_ok=0
@@ -638,6 +651,118 @@ pkgs.writeShellApplication {
         echo "XTCP2_SELF_TEST_CLICKHOUSE_PARQUET_FAIL  (rows=$parquetRows)"
       fi
       if [ "$check15" -ne 0 ]; then overall_ok=0; fi
+    ''}
+
+    # ─── Checks 17-19: xtcp2ctl runtime operator control ─────────────────
+    # Prove the new control CLI actually CHANGES daemon behavior, not just
+    # that the RPC returns OK. Run LAST because check 17 parks the poll ticker
+    # at 1h (to isolate check 18), which would starve the kafka/s3 checks above
+    # if it ran earlier.
+    #   17 CTL_HOT     — set-poll-frequency is reflected by a later `get` AND
+    #                    bumps the Poller ticker.Reset counter (poller re-read
+    #                    config and reset its ticker).
+    #   18 CTL_TRIGGER — with the ticker parked at 1h, trigger-poll + poll-burst
+    #                    are the ONLY thing that can advance the Poller
+    #                    pollRequestCh counter, so a clean delta proves the
+    #                    on-demand polls really ran.
+    #   19 CTL_RESTART — reconfigure (soft restart via syscall.Exec) with a new
+    #                    tag: MainPID is unchanged (in-place re-exec, NOT a
+    #                    systemd restart), `get` reflects the new tag, and freshly
+    #                    streamed records carry it. Skipped under coverage (a
+    #                    re-exec drops pre-exec -cover counters).
+    CTL=(-target 127.0.0.1 -port ${toString grpcPort})
+
+    echo "--- check 17: xtcp2ctl set-poll-frequency (hot change, no restart) ---"
+    check17=1
+    if command -v xtcp2ctl >/dev/null 2>&1; then
+      before_reset=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="ticker.Reset"')
+      # Park the ticker at 1h with a 1s timeout: the long frequency isolates
+      # check 18, and the small timeout lets the burst there use a 2s interval
+      # (burst interval must exceed poll_timeout).
+      xtcp2ctl set-poll-frequency -frequency 3600s -timeout 1s "''${CTL[@]}" >/tmp/ctl.log 2>&1
+      sp_rc=$?
+      got=$(xtcp2ctl get "''${CTL[@]}" 2>/dev/null)
+      after_reset=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="ticker.Reset"')
+      if [ "$sp_rc" -eq 0 ] && printf '%s' "$got" | grep -q '"3600s"' && [ "$after_reset" -gt "$before_reset" ]; then
+        echo "XTCP2_SELF_TEST_CTL_HOT_PASS  (get shows 3600s, ticker.Reset $before_reset→$after_reset)"
+        check17=0
+      else
+        echo "XTCP2_SELF_TEST_CTL_HOT_FAIL  (sp_rc=$sp_rc, ticker.Reset $before_reset→$after_reset)"
+        printf '%s\n' "$got" | head -n 3
+      fi
+    else
+      echo "XTCP2_SELF_TEST_CTL_HOT_FAIL  (xtcp2ctl not on PATH)"
+    fi
+    if [ "$check17" -ne 0 ]; then overall_ok=0; fi
+
+    echo "--- check 18: xtcp2ctl trigger-poll + poll-burst drive on-demand polls ---"
+    check18=1
+    if command -v xtcp2ctl >/dev/null 2>&1; then
+      sleep 3   # let any in-flight poll from the pre-3600s cadence drain
+      before_poll=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="pollRequestCh"')
+      xtcp2ctl trigger-poll "''${CTL[@]}" >/dev/null 2>&1
+      xtcp2ctl poll-burst -count 4 -interval 2s "''${CTL[@]}" >/dev/null 2>&1
+      sleep 10  # 4 polls × 2s spacing + slack
+      after_poll=$(metric_value "xtcp_counts" 'function="Poller"' 'variable="pollRequestCh"')
+      delta=$((after_poll - before_poll))
+      # Ticker parked at 1h, so 1 (trigger) + 4 (burst) = 5 on-demand pokes are
+      # the only possible source. Require >=4 (tolerate one timing slip).
+      if [ "$delta" -ge 4 ]; then
+        echo "XTCP2_SELF_TEST_CTL_TRIGGER_PASS  (pollRequestCh +$delta from trigger+burst, ticker parked)"
+        check18=0
+      else
+        echo "XTCP2_SELF_TEST_CTL_TRIGGER_FAIL  (pollRequestCh +$delta, expected >=4)"
+      fi
+    else
+      echo "XTCP2_SELF_TEST_CTL_TRIGGER_FAIL  (xtcp2ctl not on PATH)"
+    fi
+    if [ "$check18" -ne 0 ]; then overall_ok=0; fi
+
+    ${lib.optionalString (!coverageEnabled) ''
+      echo "--- check 19: xtcp2ctl reconfigure = soft restart (same PID, new tag in records) ---"
+      check19=1
+      if command -v xtcp2ctl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+        reconf_tag="INC-SELFTEST-9f3a"
+        pid_before=$(systemctl show -p MainPID --value xtcp2)
+        xtcp2ctl get "''${CTL[@]}" > /tmp/xtcp2-cfg.json 2>/dev/null
+        jq --arg t "$reconf_tag" '.tag = $t' /tmp/xtcp2-cfg.json > /tmp/xtcp2-cfg.new.json 2>/tmp/jq.err
+        if [ ! -s /tmp/xtcp2-cfg.new.json ]; then
+          echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (could not build new config: $(head -n1 /tmp/jq.err 2>/dev/null))"
+        else
+          xtcp2ctl reconfigure -file /tmp/xtcp2-cfg.new.json "''${CTL[@]}" >/tmp/reconf.log 2>&1
+          # Wait for the daemon to re-exec and come back serving the new tag.
+          back=0
+          for _ in $(seq 1 30); do
+            if xtcp2ctl get "''${CTL[@]}" 2>/dev/null | grep -q "$reconf_tag"; then back=1; break; fi
+            sleep 1
+          done
+          pid_after=$(systemctl show -p MainPID --value xtcp2)
+          # Freshly streamed records must carry the new tag. Give the daemon a
+          # live socket to report, then poll-stream briefly and grep the output.
+          nc -l 127.0.0.1 17325 >/dev/null 2>&1 &
+          rl=$!
+          ( echo hi | nc -w 6 127.0.0.1 17325 >/dev/null 2>&1 ) &
+          rc_pid=$!
+          sleep 1
+          timeout 6s xtcp2client -poll -pollFrequency 1s -json \
+            -target 127.0.0.1 -port ${toString grpcPort} >/tmp/xtcp2client-tag.log 2>&1
+          kill "$rl" "$rc_pid" 2>/dev/null || true
+          rec_ok=0
+          if grep -q "$reconf_tag" /tmp/xtcp2client-tag.log 2>/dev/null; then rec_ok=1; fi
+
+          if [ "$back" -eq 1 ] && [ -n "$pid_after" ] && [ "$pid_after" = "$pid_before" ] \
+             && systemctl is-active --quiet xtcp2 && [ "$rec_ok" -eq 1 ]; then
+            echo "XTCP2_SELF_TEST_CTL_RESTART_PASS  (soft restart: MainPID stayed $pid_before, records now carry tag=$reconf_tag)"
+            check19=0
+          else
+            echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (back=$back, pid $pid_before→$pid_after, active=$(systemctl is-active xtcp2 || true), recTag=$rec_ok)"
+            head -n 5 /tmp/reconf.log 2>/dev/null || true
+          fi
+        fi
+      else
+        echo "XTCP2_SELF_TEST_CTL_RESTART_FAIL  (xtcp2ctl or jq not on PATH)"
+      fi
+      if [ "$check19" -ne 0 ]; then overall_ok=0; fi
     ''}
 
     echo "================================================"

--- a/nix/tests/go-test-per-package.nix
+++ b/nix/tests/go-test-per-package.nix
@@ -43,6 +43,7 @@ let
     "tools-proto-field-audit" = "./tools/proto-field-audit/...";
     "cmd-xtcp2" = "./cmd/xtcp2/...";
     "cmd-xtcp2client" = "./cmd/xtcp2client/...";
+    "cmd-xtcp2ctl" = "./cmd/xtcp2ctl/...";
   };
 
   mkPkgTest =


### PR DESCRIPTION
## Land xtcp2ctl CLI + integration tests on `main` (stacked-merge recovery)

PRs #94 and #95 were merged, but because they were a **stacked** stack their
bases were still the intermediate branches (`#94`→`feat/runtime-control-rpcs`,
`#95`→`feat/xtcp2ctl-cli`) rather than `main`. So their content merged into
those branches, not into `main` — only #93 actually reached `main`.

This PR brings the already-reviewed #94 + #95 content onto `main`. The diff is
exactly those 11 files (PR #93 is already on `main`, so no overlap / conflicts):

- **#94** — `cmd/xtcp2ctl` control CLI, `docs/grpc-api.md`, nix binary/check
  registration.
- **#95** — self-test Checks 17-19 + the `clickhouse-pipeline-rate` flavor
  (verified green on real KVM hardware).

No new code — this is purely the merge-target recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
