### PR TITLE
test(dest): component tests for tcp/udp/http/unix/unixgram/file destinations

### DIFF
--- a/pkg/xtcp/destinations_file_test.go
+++ b/pkg/xtcp/destinations_file_test.go
@@ -1,0 +1,45 @@
+package xtcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFileDest_send drives the file destination and asserts the marshalled
+// payload is appended verbatim to the target file. newFileDest returns the
+// shared writerDest, so Send reports the byte count.
+func TestFileDest_send(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.bin")
+	x := newTestXTCP(t, schemeFile+":"+path)
+	d, err := newFileDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newFileDest: %v", err)
+	}
+
+	payloads := [][]byte{[]byte("first\n"), []byte("second\n")}
+	var want []byte
+	for _, p := range payloads {
+		b := append([]byte(nil), p...)
+		n, err := d.Send(context.Background(), &b)
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		if n != len(p) {
+			t.Errorf("Send n = %d, want %d (byte count)", n, len(p))
+		}
+		want = append(want, p...)
+	}
+	if err := d.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("file content = %q, want %q", got, want)
+	}
+}

--- a/pkg/xtcp/destinations_http_test.go
+++ b/pkg/xtcp/destinations_http_test.go
@@ -1,0 +1,54 @@
+package xtcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestHTTPDest_send drives the http destination against a real httptest server
+// and asserts the marshalled payload arrives verbatim as the POST body. The
+// same factory backs the https scheme.
+func TestHTTPDest_send(t *testing.T) {
+	bodyCh := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		b, _ := io.ReadAll(r.Body)
+		bodyCh <- b
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	// httpDest reads x.config.Dest as the full URL (scheme included).
+	x := newTestXTCP(t, srv.URL)
+	d, err := newHTTPDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newHTTPDest: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	payload := []byte(`{"hello":"http"}`)
+	b := append([]byte(nil), payload...)
+	n, err := d.Send(context.Background(), &b)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Send n = %d, want 1 (one record)", n)
+	}
+
+	select {
+	case got := <-bodyCh:
+		if !bytes.Equal(got, payload) {
+			t.Errorf("POST body = %q, want %q", got, payload)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for the http POST")
+	}
+}

--- a/pkg/xtcp/destinations_tcp_test.go
+++ b/pkg/xtcp/destinations_tcp_test.go
@@ -1,0 +1,61 @@
+package xtcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestTCPDest_send drives the tcp destination against a real in-process TCP
+// listener and asserts the marshalled payload arrives verbatim (framing is the
+// marshaller's job, so tcpDest writes bytes unchanged).
+func TestTCPDest_send(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	got := make(chan []byte, 1)
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		b, _ := io.ReadAll(conn) // returns when the client closes its side
+		got <- b
+	}()
+
+	x := newTestXTCP(t, schemeTCP+":"+ln.Addr().String())
+	d, err := newTCPDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newTCPDest: %v", err)
+	}
+
+	payload := []byte("hello-tcp\n")
+	b := append([]byte(nil), payload...)
+	n, err := d.Send(context.Background(), &b)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Send n = %d, want 1 (one record)", n)
+	}
+	if err := d.Close(); err != nil { // close so the server's ReadAll returns
+		t.Errorf("Close: %v", err)
+	}
+
+	select {
+	case rc := <-got:
+		if !bytes.Equal(rc, payload) {
+			t.Errorf("received %q, want %q", rc, payload)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for the tcp payload")
+	}
+}

--- a/pkg/xtcp/destinations_udp_test.go
+++ b/pkg/xtcp/destinations_udp_test.go
@@ -1,0 +1,47 @@
+package xtcp
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestUDPDest_send drives the udp destination (syscall path — config.IoUring is
+// false in the test XTCP) against a real UDP socket and asserts the datagram
+// arrives verbatim (one Write == one datagram == one record).
+func TestUDPDest_send(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.ListenPacket: %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	x := newTestXTCP(t, "udp:"+pc.LocalAddr().String())
+	d, err := newUDPDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newUDPDest: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	payload := []byte("hello-udp")
+	b := append([]byte(nil), payload...)
+	n, err := d.Send(context.Background(), &b)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Send n = %d, want 1 (one record)", n)
+	}
+
+	_ = pc.SetReadDeadline(time.Now().Add(3 * time.Second))
+	buf := make([]byte, 1500)
+	got, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if !bytes.Equal(buf[:got], payload) {
+		t.Errorf("received %q, want %q", buf[:got], payload)
+	}
+}

--- a/pkg/xtcp/destinations_unix_test.go
+++ b/pkg/xtcp/destinations_unix_test.go
@@ -1,0 +1,72 @@
+package xtcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestUnixDest_send drives the unix (stream) destination against a real
+// AF_UNIX/SOCK_STREAM listener. Unlike tcp, the unix stream destination
+// varint-length-frames each record (net.Buffers{varint(len), payload}) so a
+// stream receiver can split records, so the test decodes that framing.
+func TestUnixDest_send(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("net.Listen(unix): %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	got := make(chan []byte, 1)
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		r := bufio.NewReader(conn)
+		length, rerr := binary.ReadUvarint(r)
+		if rerr != nil {
+			return
+		}
+		payload := make([]byte, length)
+		if _, rerr := io.ReadFull(r, payload); rerr != nil {
+			return
+		}
+		got <- payload
+	}()
+
+	x := newTestXTCP(t, "unix:"+sock)
+	d, err := newUnixDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newUnixDest: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	payload := []byte("hello-unix-stream")
+	b := append([]byte(nil), payload...)
+	n, err := d.Send(context.Background(), &b)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Send n = %d, want 1 (one record)", n)
+	}
+
+	select {
+	case rc := <-got:
+		if !bytes.Equal(rc, payload) {
+			t.Errorf("received %q, want %q", rc, payload)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("timed out waiting for the unix payload")
+	}
+}

--- a/pkg/xtcp/destinations_unixgram_test.go
+++ b/pkg/xtcp/destinations_unixgram_test.go
@@ -1,0 +1,49 @@
+package xtcp
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestUnixGramDest_send drives the unixgram destination against a real
+// AF_UNIX/SOCK_DGRAM socket. One Write == one datagram == one record, written
+// verbatim (no framing needed for datagrams).
+func TestUnixGramDest_send(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "dg.sock")
+	pc, err := net.ListenPacket("unixgram", sock)
+	if err != nil {
+		t.Fatalf("net.ListenPacket(unixgram): %v", err)
+	}
+	t.Cleanup(func() { _ = pc.Close() })
+
+	x := newTestXTCP(t, "unixgram:"+sock)
+	d, err := newUnixGramDest(context.Background(), x)
+	if err != nil {
+		t.Fatalf("newUnixGramDest: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	payload := []byte("hello-dgram")
+	b := append([]byte(nil), payload...)
+	n, err := d.Send(context.Background(), &b)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Send n = %d, want 1 (one record)", n)
+	}
+
+	_ = pc.SetReadDeadline(time.Now().Add(3 * time.Second))
+	buf := make([]byte, 1500)
+	got, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if !bytes.Equal(buf[:got], payload) {
+		t.Errorf("received %q, want %q", buf[:got], payload)
+	}
+}


### PR DESCRIPTION
## Destination coverage 1/N — component tests for network/local outputs

Adds fast, in-process integration tests for the six output destinations that had
**no** test coverage: `tcp`, `udp`, `http` (backs `https`), `unix`, `unixgram`, `file`.

Each test stands up a real listener/server, points the destination's `-dest` at it,
`Send`s a marshalled payload, and asserts the bytes arrive:

| dest | harness | assertion |
|---|---|---|
| tcp | `net.Listen("tcp")` | payload verbatim |
| udp | `net.ListenPacket("udp")` | one datagram == one record (syscall path) |
| unix | `net.Listen("unix")` | decodes the varint length-frame the stream dest prepends |
| unixgram | `net.ListenPacket("unixgram")` | verbatim datagram |
| http | `httptest.Server` | payload == POST body |
| file | temp file | payload appended verbatim |

They reuse the existing `newTestXTCP` helper, run in the default build (no docker / VM),
finish in milliseconds, and slot into `nix flake check`'s go-test-per-package.

First of the destination-coverage series. The message brokers (nats/nsq/valkey) — which
are pub/sub and behind `dest_*` build tags — get real microVM integration flavors in
follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
