### PR TITLE
fix(xtcp2client): reconnect -poll stream on break (soft-restart resilience)

### DIFF
--- a/cmd/xtcp2client/xtcp2client.go
+++ b/cmd/xtcp2client/xtcp2client.go
@@ -167,49 +167,88 @@ func pollMode(ctx context.Context, addr string, complete *chan struct{}, pollFre
 		log.Printf("pollMode starting")
 	}
 
+	// Reconnect loop: each pollSession owns one dial + one PollFlatRecords
+	// stream and runs until that stream breaks. A dropped connection — e.g.
+	// the daemon soft-restarts / re-execs, or the network blips — ends the
+	// session, and we back off (ctx-cancellable) and re-dial rather than
+	// going silent. This mirrors listenMode's singleStreamingClient. Only
+	// ctx cancellation or the complete signal stops the loop.
+	for i := 0; ; i++ {
+		if !pollSession(ctx, addr, complete, pollFrequency, printer, debugLevel) {
+			return
+		}
+
+		sleepTime := reconnectTimeVar + (time.Duration(FastRandN(JitterSleepMaxMs)) * time.Millisecond)
+		if debugLevel > 10 {
+			log.Printf("pollMode: stream broke, reconnecting i:%d after %0.3fs", i, sleepTime.Seconds())
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-*complete:
+			return
+		case <-time.After(sleepTime):
+		}
+	}
+}
+
+// pollSession runs a single PollFlatRecords connection: dial, open the bidi
+// stream, send an immediate poll request, then send one request per tick
+// while a receiver goroutine prints incoming records. It returns true if the
+// session ended because the stream/connection broke (the caller should
+// reconnect), or false if ctx was canceled or the complete signal fired (the
+// caller should stop).
+func pollSession(ctx context.Context, addr string, complete *chan struct{}, pollFrequency time.Duration, printer *recordPrinter, debugLevel uint) (reconnect bool) {
+
 	conn := newGRPCClient(addr)
-	// Close the conn + Stop the ticker on the way out. Previously
-	// pollMode returned with both leaked — fine in a one-shot CLI run
-	// but the daemon-embedded usage (and the test harness) leaked one
-	// conn + one *time.Ticker per pollMode invocation.
 	defer func() {
 		if cerr := conn.Close(); cerr != nil {
-			log.Printf("pollMode: conn close: %v", cerr)
+			log.Printf("pollSession: conn close: %v", cerr)
 		}
 	}()
 
 	client := xtcp_flat_record.NewXTCPFlatRecordServiceClient(conn)
 
+	// Session-scoped ctx so the receiver goroutine and the send loop tear
+	// each other down the moment either notices the stream is gone.
+	sessionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := client.PollFlatRecords(sessionCtx)
+	if err != nil {
+		// Demoted from log.Fatalf: a dial/open failure is reconnectable —
+		// return true so the caller backs off and re-dials.
+		log.Printf("pollSession: client.PollFlatRecords err: %v", err)
+		return true
+	}
+
+	// Receiver goroutine: prints records until the stream ends, then cancels
+	// sessionCtx so the send loop below notices immediately.
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		pollStreamRecv(sessionCtx, printer, &stream, debugLevel)
+	}()
+
 	ticker := time.NewTicker(pollFrequency)
 	defer ticker.Stop()
 
-	// shortCtx, cancel := context.WithTimeout(ctx, pollFrequency-time.Duration(10*time.Millisecond))
-	// defer cancel()
-
-	stream, err := client.PollFlatRecords(ctx)
-	if err != nil {
-		// Demoted from log.Fatalf: Fatalf calls os.Exit so the deferred
-		// ticker.Stop() above would never run. Log + return so the
-		// defers fire and the caller can decide what to do next.
-		log.Printf("pollMode: client.PollFlatRecords err: %v", err)
-		return
-	}
-
-	// recvCh := make(chan *xtcp_flat_record.FlatRecordsResponse)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go pollStreamRecv(ctx, wg, printer, &stream, debugLevel)
-
 	// Kick an immediate poll request so records start flowing on connect
 	// instead of only after a full pollFrequency (the first ticker tick).
-	// This pokes the daemon's on-demand poll right away and makes -poll
-	// responsive from the first second. A failed initial send is non-fatal:
-	// the daemon also self-polls on its own cadence, and the ticker loop
-	// below handles a broken stream (and ctx cancellation) uniformly.
+	// The daemon also self-polls on its own cadence, so a failed initial
+	// send just means we reconnect.
 	if serr := stream.Send(&xtcp_flat_record.PollFlatRecordsRequest{}); serr != nil {
-		log.Printf("pollMode: initial stream.Send err:%v", serr)
+		log.Printf("pollSession: initial stream.Send err:%v — reconnecting", serr)
+		cancel()
+		wg.Wait()
+		return true
 	}
 
+	// Default: the session ends by reconnecting. Only an explicit stop
+	// signal (parent ctx / complete) flips this to false.
+	reconnect = true
 breakPoint:
 	for i := 0; ; i++ {
 
@@ -219,82 +258,74 @@ breakPoint:
 
 		select {
 		case <-ctx.Done():
+			reconnect = false
 			break breakPoint
 
 		case <-*complete:
+			reconnect = false
+			break breakPoint
+
+		case <-sessionCtx.Done():
+			// The receiver saw the stream end (io.EOF / error) and canceled
+			// sessionCtx — reconnect. But sessionCtx is also canceled when
+			// the parent ctx is, so if the parent is done we must stop, not
+			// reconnect.
+			if ctxDone(ctx) {
+				reconnect = false
+			}
 			break breakPoint
 
 		case <-ticker.C:
 			if serr := stream.Send(&xtcp_flat_record.PollFlatRecordsRequest{}); serr != nil {
-				log.Printf("pollMode i:%d stream.Send err:%v — stopping poll loop", i, serr)
+				log.Printf("pollMode i:%d stream.Send err:%v — reconnecting", i, serr)
 				break breakPoint
 			}
 			if debugLevel > 10 {
 				log.Printf("pollMode i:%d <-ticker.C, send", i)
 			}
-			// default:
-			// non-blocking
 		}
 
 	}
 
+	cancel()
 	wg.Wait()
+	return reconnect
 }
 
 func pollStreamRecv(
 	ctx context.Context,
-	wg *sync.WaitGroup,
 	printer *recordPrinter,
-	// recvCh chan *xtcp_flat_record.FlatRecordsResponse,
 	stream *grpc.BidiStreamingClient[xtcp_flat_record.PollFlatRecordsRequest, xtcp_flat_record.PollFlatRecordsResponse],
 	debugLevel uint) {
-
-	defer wg.Done()
 
 	if debugLevel > 10 {
 		log.Printf("pollStreamRecv started")
 	}
 
-breakPoint:
 	for i := 0; ; i++ {
 		pollFlatRecordsResponse, err := (*stream).Recv()
 		if debugLevel > 10 {
 			log.Printf("pollStreamRecv i:%d .Recv()", i)
 		}
-		if err == io.EOF {
-			if debugLevel > 10 {
-				log.Println("pollStreamRecv io.EOF")
-			}
-			break breakPoint
-		}
-
 		if err != nil {
+			// io.EOF = the server closed the stream (e.g. daemon restart);
+			// any other error = a broken stream. A gRPC stream never recovers
+			// once Recv errors, so return and let pollSession reconnect. (The
+			// old code retried Recv on the dead stream forever, which never
+			// produced another record and only kept the loop busy.)
 			if debugLevel > 10 {
-				log.Printf("pollStreamRecv err:%v", err)
+				if err == io.EOF {
+					log.Println("pollStreamRecv io.EOF")
+				} else {
+					log.Printf("pollStreamRecv err:%v", err)
+				}
 			}
-
-			// A broken stream typically returns the same error immediately
-			// on every subsequent Recv (e.g. "rpc error: stream closed").
-			// The previous code looped without backoff, pegging a CPU core
-			// at 100% until ctx was canceled. Sleep briefly between
-			// retries so the loop is ctx-cancellable AND non-spinny.
-			select {
-			case <-ctx.Done():
-				break breakPoint
-			case <-time.After(100 * time.Millisecond):
-			}
-			continue
+			return
 		}
-		// log.Printf("rec:%v", rec)
 		printPollFlatRecordsResponse(pollFlatRecordsResponse, 1, printer, debugLevel)
 
-		// recvCh <- rec
-
-		select {
-		case <-ctx.Done():
-			break breakPoint
-		default:
-			// non-blocking
+		if ctxDone(ctx) {
+			return
 		}
 	}
 }

--- a/cmd/xtcp2client/xtcp2client_test.go
+++ b/cmd/xtcp2client/xtcp2client_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -368,6 +369,82 @@ func TestPollMode_recordingServer(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Skip("pollMode doesn't exit on cancel alone")
+	}
+}
+
+// countingPollServer records how many PollFlatRecords streams are opened
+// and ends each one immediately (returns nil → the client sees io.EOF),
+// simulating a daemon that drops the stream — e.g. a soft-restart re-exec.
+// A resilient -poll client must re-dial and open a NEW stream each time; a
+// client with no reconnect connects once and then stops.
+type countingPollServer struct {
+	xtcp_flat_record.UnimplementedXTCPFlatRecordServiceServer
+	conns atomic.Int32
+}
+
+func (s *countingPollServer) PollFlatRecords(_ xtcp_flat_record.XTCPFlatRecordService_PollFlatRecordsServer) error {
+	s.conns.Add(1)
+	return nil // end the stream immediately, forcing the client to reconnect
+}
+
+func startPollServer(t *testing.T, impl xtcp_flat_record.XTCPFlatRecordServiceServer) (addr string, cleanup func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	xtcp_flat_record.RegisterXTCPFlatRecordServiceServer(srv, impl)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	return lis.Addr().String(), func() {
+		srv.Stop()
+		_ = lis.Close()
+	}
+}
+
+// TestPollMode_reconnectsOnStreamBreak: when the daemon drops the poll
+// stream (server ends each RPC immediately), a long-running -poll client
+// must re-dial and open a fresh stream rather than going silent. The server
+// counts connections; the client should make several. Pre-fix pollMode
+// opens exactly one stream then returns, so conns stays 1 → this fails.
+func TestPollMode_reconnectsOnStreamBreak(t *testing.T) {
+	srv := &countingPollServer{}
+	addr, cleanup := startPollServer(t, srv)
+	defer cleanup()
+
+	// Shrink the reconnect backoff + jitter so the test doesn't wait the
+	// production 10s between re-dials.
+	origReconnect, origJitter := reconnectTimeVar, JitterSleepMaxMs
+	reconnectTimeVar = 20 * time.Millisecond
+	JitterSleepMaxMs = 1
+	defer func() { reconnectTimeVar, JitterSleepMaxMs = origReconnect, origJitter }()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	complete := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		pollMode(ctx, addr, &complete, 50*time.Millisecond, nullPrinter(), 0)
+		close(done)
+	}()
+
+	// Wait for the client to reconnect at least twice.
+	deadline := time.Now().Add(3 * time.Second)
+	for srv.conns.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	got := srv.conns.Load()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("pollMode did not exit after ctx cancel")
+	}
+
+	if got < 2 {
+		t.Errorf("PollFlatRecords connections = %d, want >= 2 (client must reconnect after the stream breaks)", got)
 	}
 }
 


### PR DESCRIPTION
## What & why

`xtcp2client -poll` dialed once and opened a single `PollFlatRecords` stream. When that stream broke — the daemon soft-restarts / re-execs (same PID, new process; drops the gRPC conn), or a network blip — the client went **permanently silent**: `pollStreamRecv` looped on `Recv` errors forever (a gRPC stream never recovers once `Recv` errors), and the send loop exited. Unlike `listenMode` (whose `singleStreamingClient` re-dials per iteration), `-poll` had no reconnect. This is the gap flagged during the `-poll` validation work.

## Change (client-only, `cmd/xtcp2client`)

- **`pollMode` → outer reconnect loop + `pollSession`.** Each `pollSession` owns one dial + one stream and runs until it breaks; the loop then backs off (ctx-cancellable, `reconnectTimeVar` + jitter — the same knobs `singleStreamingClient` uses) and re-dials. Only ctx cancellation or the `complete` signal stops it.
- A **session-scoped ctx** lets the receiver goroutine and the send loop tear each other down the instant either notices the stream is gone.
- **`pollStreamRecv`** now returns on `io.EOF`/error instead of futilely retrying `Recv` on a dead stream. The immediate-first-send is preserved (per session).

## Tests

- **`TestPollMode_reconnectsOnStreamBreak`** (RED→GREEN): a server that ends every poll stream immediately. Pre-fix the client connected once (`conns=1`); now it re-dials (`conns≥2`).
- Existing poll tests (`dialAndCancel`, `completeChannel`, `recordingServer`, `pollModeCancellable`) still pass.

## Verification

- `go test -race ./cmd/xtcp2client` ✅
- `golangci-lint` (tier-1 + comprehensive), `gofmt`, `go-vet` ✅
- lifecycle microVM: `POLL_STREAM_PASS (204 records)`, `OVERALL_PASS` — sustained real-TCP streaming path intact.

Straight off `main`, not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)