### PR TITLE
test(inttest): assert container-id enrichment end-to-end (stress flavor)

### DIFF
--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -393,6 +393,7 @@ rec {
         rows_first=$(printf '%s' "$first_line" | grep -oE 'rows=[0-9]+' | cut -d= -f2 || true)
         rows_last=$(printf '%s' "$last_line" | grep -oE 'rows=[0-9]+' | cut -d= -f2 || true)
         netns_last=$(printf '%s' "$last_line" | grep -oE 'netns=[0-9]+' | cut -d= -f2 || true)
+        cid_last=$(printf '%s' "$last_line" | grep -oE 'container_id=[0-9]+' | cut -d= -f2 || true)
         kexc_last=$(printf '%s' "$last_line" | grep -oE 'kafka_exc=[0-9]+' | cut -d= -f2 || true)
         disk_last=$(printf '%s' "$last_line" | grep -oE 'disk=[0-9]+' | cut -d= -f2 || true)
         # Peak disk seen across the whole run, not just the last sample —
@@ -402,6 +403,7 @@ rec {
         rows_first=''${rows_first:-0}
         rows_last=''${rows_last:-0}
         netns_last=''${netns_last:-0}
+        cid_last=''${cid_last:-0}
         kexc_last=''${kexc_last:-0}
         disk_last=''${disk_last:-0}
         disk_peak=''${disk_peak:-0}
@@ -412,6 +414,7 @@ rec {
         echo "  stress containers FAILED:      $cfailed"
         echo "  clickhouse rows first -> last: $rows_first -> $rows_last"
         echo "  distinct netns (last sample):  $netns_last"
+        echo "  distinct container_id (last):  $cid_last"
         echo "  kafka consumer exceptions:     $kexc_last"
         echo "  docker disk % (last / peak):    $disk_last / $disk_peak"
         echo "  panics in transcript:          $panics"
@@ -435,6 +438,7 @@ rec {
         [ "$rows_last" -lt 1 ] && { echo "FAIL: 0 rows reached ClickHouse — no records made it end-to-end"; rc=1; }
         [ "$rows_last" -le "$rows_first" ] && { echo "FAIL: ClickHouse rows did not grow ($rows_first -> $rows_last) — records stopped flowing"; rc=1; }
         [ "$netns_last" -lt 2 ] && { echo "FAIL: records from only $netns_last distinct netns — per-container discovery not proven end-to-end"; rc=1; }
+        [ "$cid_last" -lt 1 ] && { echo "FAIL: 0 distinct container_id — container-id enrichment (-resolveContainerId) not proven end-to-end"; rc=1; }
         [ "$kexc_last" -ne 0 ] && { echo "FAIL: $kexc_last kafka consumer exception(s) — ClickHouse ingestion stalled (likely MEMORY_LIMIT_EXCEEDED)"; rc=1; }
         # Disk saturation on /var/lib/docker freezes offset commits and back-
         # pressures the producer — ingestion plateaus while looking like a

--- a/nix/microvms/mkVm.nix
+++ b/nix/microvms/mkVm.nix
@@ -824,6 +824,13 @@ let
         # once xtcp2 discovers it and its records reach ClickHouse.
         nsc=$(docker exec clickhouse clickhouse-client --password ${clickPipeChPassword} \
           -q 'SELECT uniqExact(netns_inode) FROM xtcp.xtcp_flat_records' 2>/dev/null || echo 0)
+        # Distinct non-empty container_id = per-container ENRICHMENT proof.
+        # With -resolveContainerId (the stress flavor), records from the
+        # tcp-stress load containers' sockets carry the owning docker
+        # container_id, resolved from the socket's cgroup v2 id (pkg/cgroupid).
+        # 0 when resolution is disabled (the other clickpipe flavors).
+        cid=$(docker exec clickhouse clickhouse-client --password ${clickPipeChPassword} \
+          -q 'SELECT uniqExact(container_id) FROM xtcp.xtcp_flat_records WHERE length(container_id) > 0' 2>/dev/null || echo 0)
         # Kafka consumer health: a non-zero count here means the Kafka-engine
         # consumer hit an exception (e.g. MEMORY_LIMIT_EXCEEDED) — the signal
         # that ingestion has stalled. 0 = healthy end-to-end ingest.
@@ -849,7 +856,7 @@ let
         # host runner can assert on it. Integer percent (no % sign).
         disk=$(df --output=pcent /var/lib/docker 2>/dev/null | tail -1 | tr -dc '0-9')
         disk=''${disk:-0}
-        echo "XTCP2_CLICKPIPE_ROWS $(date -u +%FT%TZ) rows=$rows netns=$nsc kafka_exc=$kexc reb=$reb msgs=$msgs disk=$disk"
+        echo "XTCP2_CLICKPIPE_ROWS $(date -u +%FT%TZ) rows=$rows netns=$nsc container_id=$cid kafka_exc=$kexc reb=$reb msgs=$msgs disk=$disk"
         # Deep-dive diagnostics for the consumer-detach stall — ONLY when
         # something looks wrong, so a healthy multi-hour soak stays quiet.
         # Trouble = a consumer exception, or the cumulative messages-read
@@ -1411,6 +1418,15 @@ let
     "0"
   ];
 
+  # clickhouse-pipeline-stress: same kafka pipeline, but enable container-id
+  # resolution so records from the tcp-stress load containers carry their
+  # docker container_id/runtime (resolved from the socket's cgroup v2 id via
+  # pkg/cgroupid). The stress monitor asserts distinct container_ids land in
+  # ClickHouse — the enrichment analog of the netns-diversity check.
+  xtcp2ClickPipeStressArgs = xtcp2ClickPipeArgs ++ [
+    "-resolveContainerId"
+  ];
+
   # clickhouse-http flavor: xtcp2 inserts DIRECTLY into ClickHouse over HTTP,
   # no Kafka. The http dest POSTs the marshalled batch to the VERBATIM -dest
   # URL (destinations_http.go), so the whole ClickHouse insert is baked into
@@ -1928,6 +1944,9 @@ in
               # bypassing Kafka (must come before isAnyClickPipe, which it is
               # a member of, so it doesn't fall into the kafka-dest branch).
               xtcp2ClickHttpArgs
+            else if isClickPipeStress then
+              # Kafka pipeline + container-id resolution (before isAnyClickPipe).
+              xtcp2ClickPipeStressArgs
             else if isAnyClickPipe then
               # Phase E: produce to redpanda → clickhouse via kafka dest.
               # The mixed flavor uses these args for its primary xtcp2


### PR DESCRIPTION
## What & why

Prove that xtcp2's **container-id enrichment** (`-resolveContainerId`) works end-to-end: records from the tcp-stress load containers' sockets should carry the owning docker `container_id`/`runtime`, resolved from the socket's cgroup v2 id via `pkg/cgroupid`. The stress flavor already proves per-container *discovery* (distinct netns); this adds the *enrichment* proof.

## Change

- Enable **`-resolveContainerId`** on the `clickhouse-pipeline-stress` flavor (`xtcp2ClickPipeStressArgs`).
- The in-VM monitor now queries `uniqExact(container_id)` (`length(container_id) > 0`) and emits `container_id=<count>` alongside the existing `netns=<count>`.
- The stress runner asserts `container_id >= 1` — the enrichment analog of the netns-diversity check.

## Verification

- **De-risked first (no VM):** `pkg/cgroupid` resolves a real host docker container — `cgroup docker-<id>.scope → container_id + runtime="docker"`.
- **8m stress run:** `distinct container_id (last): 22` (distinct netns 69, rows 131084→351777). The enrichment lands real container_ids in ClickHouse.

**Note on the run's overall exit:** it reports `FAIL: no stress containers spawned` (`spawned:0 FAILED:20`) — the **pre-existing** container-spawn-*counter* flake documented for short stress runs (reproduces on `origin/main`). It's clearly a mis-tracked counter, not real: 69 netns + 22 container_ids demonstrably landed. My new `container_id >= 1` assertion passed. Unrelated to this change.

Third of the coverage-expansion series (PR1 #108, PR2 #109 merged). Straight off `main`. Next: PR4 (raw-socket e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)