### PR TITLE
refactor(inttest): factor lifecycle sentinel regex into baseSentinels

### DIFF
--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -432,10 +432,8 @@ let
     fullTest = microvmLib.mkLifecycleFullTest {
       inherit arch;
       vm = vms.${arch};
-      # Surface every sentinel the self-test emits so a real failure in
-      # Check 4+ (BINARIES_HELP, GRPC_ROUNDTRIP, NS_*) doesn't hide
-      # behind an unhelpful OVERALL_FAIL with no breadcrumbs.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
+      # No flavor-specific tokens; baseSentinels already surfaces every
+      # check the minimal self-test emits (Check 4+ breadcrumbs included).
     };
   });
 
@@ -447,7 +445,7 @@ let
       # Baseline sentinels plus the valkey consume-back verdict. Valkey boots
       # fast (native server, no docker), but the self-test waits up to ~60 s for
       # the subscriber to accumulate messages, so keep a generous timeout.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|VALKEY_CONSUME|OVERALL";
+      extraSentinels = [ "VALKEY_CONSUME" ];
       timeoutSec = 240;
     };
   });
@@ -462,7 +460,7 @@ let
         inherit arch;
         vm = vmsAttr.${arch};
         suffix = suffixName;
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|RAW_SOCKET|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
+        extraSentinels = [ "RAW_SOCKET" ];
         timeoutSec = 240;
       };
     });
@@ -476,7 +474,7 @@ let
       inherit arch;
       vm = vmsNats.${arch};
       suffix = "-nats";
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|NATS_CONSUME|OVERALL";
+      extraSentinels = [ "NATS_CONSUME" ];
       timeoutSec = 240;
     };
   });
@@ -486,7 +484,7 @@ let
       inherit arch;
       vm = vmsNsq.${arch};
       suffix = "-nsq";
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|NSQ_CONSUME|OVERALL";
+      extraSentinels = [ "NSQ_CONSUME" ];
       timeoutSec = 240;
     };
   });
@@ -499,7 +497,10 @@ let
       # The two s3parquet-specific sentinels alongside the baseline set.
       # 240 s timeout because the worker accumulates rows for several
       # poll cycles before triggering the 1 MiB-threshold finalize.
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|S3PARQUET_FILES|S3PARQUET_ROWS|OVERALL";
+      extraSentinels = [
+        "S3PARQUET_FILES"
+        "S3PARQUET_ROWS"
+      ];
       timeoutSec = 240;
     };
   });
@@ -513,7 +514,7 @@ let
       inherit arch;
       vm = vmsClickHttp.${arch};
       suffix = "-clickhouse-http";
-      sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|CLICKHOUSE_HTTP|OVERALL";
+      extraSentinels = [ "CLICKHOUSE_HTTP" ];
       timeoutSec = 1200;
     };
   });
@@ -525,12 +526,8 @@ let
         vm = vmsCoverage.${arch};
         suffix = "-coverage";
         scrapeCoverage = true;
-        # Surface the new NS_LIFECYCLE + NS_TRAFFIC sentinels from
-        # self-test.nix Checks 8+9 so the lifecycle output makes their
-        # outcome visible. Without this the default filter hides
-        # them; the checks still execute (and the daemon exercises the
-        # corresponding code paths) but the harness output is misleading.
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
+        # baseSentinels already surfaces NS_LIFECYCLE + NS_TRAFFIC (Checks
+        # 8+9) and every other check, so no extraSentinels needed here.
       };
     })
   );
@@ -542,7 +539,6 @@ let
         vm = vmsCoverageIoUring.${arch};
         suffix = "-coverage-iouring";
         scrapeCoverage = true;
-        sentinelRe = "SYSTEMD|METRICS|NETLINK|BINARIES_HELP|GRPC_ROUNDTRIP|POLL_STREAM|HEALTH|OUTPUT_CONTENT|LISTEN_STREAM|NS_INSPECT|NSTEST|NS_LIFECYCLE|NS_TRAFFIC|NS_DOCKER|NS_ANONYMOUS|CTL_HOT|CTL_TRIGGER|CTL_RESTART|OVERALL";
       };
     })
   );

--- a/nix/microvms/lib.nix
+++ b/nix/microvms/lib.nix
@@ -1436,16 +1436,47 @@ rec {
   # Parameters:
   #   arch         (string)  architecture key into constants.architectures
   #   vm           (drv)     microvm runner derivation
-  #   suffix       (string)  optional name suffix for the wrapper binary
-  #   sentinelRe   (string)  pipe-separated sentinel names to surface in the
-  #                          summary grep. Default matches the minimal flavor.
-  #   timeoutSec   (int)     overall scrape timeout in seconds.
+  #   suffix         (string)  optional name suffix for the wrapper binary
+  #   extraSentinels (list)    flavor-specific sentinel tokens surfaced in the
+  #                            summary grep on top of baseSentinels + OVERALL.
+  #   timeoutSec     (int)     overall scrape timeout in seconds.
+  # The self-test sentinels every lifecycle flavor emits (Checks 1-10 +
+  # the runtime-control ones). Each flavor's summary grep is
+  # `baseSentinels ++ its extraSentinels ++ [ "OVERALL" ]`, so a new
+  # baseline check is added in exactly one place instead of being copied
+  # into every caller's regex (where a single-token drift silently drops
+  # the check from the summary). NB this only affects the DISPLAYED
+  # summary — pass/fail keys solely on XTCP2_SELF_TEST_OVERALL_{PASS,FAIL}.
+  baseSentinels = [
+    "SYSTEMD"
+    "METRICS"
+    "NETLINK"
+    "BINARIES_HELP"
+    "GRPC_ROUNDTRIP"
+    "POLL_STREAM"
+    "HEALTH"
+    "OUTPUT_CONTENT"
+    "LISTEN_STREAM"
+    "NS_INSPECT"
+    "NSTEST"
+    "NS_LIFECYCLE"
+    "NS_TRAFFIC"
+    "NS_DOCKER"
+    "NS_ANONYMOUS"
+    "CTL_HOT"
+    "CTL_TRIGGER"
+    "CTL_RESTART"
+  ];
+
   mkLifecycleFullTest =
     {
       arch,
       vm,
       suffix ? "",
-      sentinelRe ? "SYSTEMD|METRICS|NETLINK|OVERALL",
+      # Flavor-specific sentinel tokens surfaced in the summary in addition
+      # to baseSentinels (e.g. [ "VALKEY_CONSUME" ]). Order is irrelevant —
+      # the tokens become a regex alternation.
+      extraSentinels ? [ ],
       timeoutSec ? 180,
       # When true, after a passing OVERALL sentinel the runner also looks
       # for an XTCP2_COVERAGE_DUMP_START / _END block in the log, decodes
@@ -1456,6 +1487,7 @@ rec {
     }:
     let
       cfg = constants.architectures.${arch};
+      sentinelRe = lib.concatStringsSep "|" (baseSentinels ++ extraSentinels ++ [ "OVERALL" ]);
     in
     pkgs.writeShellApplication {
       name = "xtcp2-lifecycle-full-test-${arch}${suffix}";


### PR DESCRIPTION
## What

The 9 `mkLifecycleFullTest` callers each copied a byte-identical ~18-token sentinel regex and inserted one flavor token before `OVERALL`. A single-token drift silently drops a check from the summary (self-documented risk in the old comments).

## How

- Factor the shared tokens into a `baseSentinels` list in `lib.nix`.
- Change `mkLifecycleFullTest`'s `sentinelRe` string param → an `extraSentinels` list; the runner assembles `baseSentinels ++ extraSentinels ++ [ "OVERALL" ]` internally.
- Callers now pass just their delta, e.g. `extraSentinels = [ "VALKEY_CONSUME" ]` (coverage/minimal pass nothing).

## Why it's safe

- **Byte-identical** assembled regex for all non-socket flavors (verified by evaluating `baseSentinels ++ extra ++ [OVERALL]` and diffing against each original string — all MATCH).
- The socket-sink flavor differs only in token *position* (`RAW_SOCKET` appended vs mid-list), irrelevant to a regex alternation.
- `sentinelRe` is **display-only** (`lib.nix` summary grep, `… || true`); pass/fail keys solely on `XTCP2_SELF_TEST_OVERALL_{PASS,FAIL}`.

## Verification

- `nixfmt --check` clean on both files.
- All migrated lifecycle derivations still evaluate (`test-microvm-lifecycle-x86_64{,-valkey,-s3parquet,-coverage,...}` drvPaths resolve).
- Regex byte-diff proof as above.

Second of the DRY series (after #113). Next: unify the three broker modules, then collapse the near-clone arg-lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)