### PR TITLE
feat(oci): publish slim client images (xtcp2client, xtcp2ctl)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Run `nix flake show` for the complete, current list. The main groups:
 
 ### OCI images (`nix build .#oci-<name>`)
 
-`oci-xtcp2`, `oci-xtcp2-debug`, `oci-xtcp2-stripped` (fat images with every binary), and the slim single-binary images `oci-xtcp2-min`, `oci-xtcp2-kafka`, `oci-xtcp2-nats`, `oci-xtcp2-nsq`, `oci-xtcp2-valkey`, plus `oci-xtcp2-tcp-stress` for load testing.
+`oci-xtcp2`, `oci-xtcp2-debug`, `oci-xtcp2-stripped` (fat images with every binary), the slim single-binary daemon images `oci-xtcp2-min`, `oci-xtcp2-kafka`, `oci-xtcp2-nats`, `oci-xtcp2-nsq`, `oci-xtcp2-valkey`, `oci-xtcp2-s3parquet`, the slim client images `oci-xtcp2client` and `oci-xtcp2ctl`, plus `oci-xtcp2-tcp-stress` for load testing.
 
 ### MicroVM integration tests (`nix build .#microvm-x86_64*` / `nix run .#microvm-x86_64-*`)
 

--- a/docs/build-flavors.md
+++ b/docs/build-flavors.md
@@ -72,6 +72,9 @@ The three "fat" images carry every cmd binary; the slim images carry only the si
 | `nix build .#oci-xtcp2-nats` | `xtcp2:nats` | only `xtcp2-nats` | 23 MiB |
 | `nix build .#oci-xtcp2-nsq` | `xtcp2:nsq` | only `xtcp2-nsq` | 22 MiB |
 | `nix build .#oci-xtcp2-valkey` | `xtcp2:valkey` | only `xtcp2-valkey` | 26 MiB |
+| `nix build .#oci-xtcp2-s3parquet` | `xtcp2:s3parquet` | only `xtcp2-s3parquet` | 26 MiB |
+| `nix build .#oci-xtcp2client` | `xtcp2client:latest` | only `xtcp2client` (gRPC record-stream client) | ~15 MiB |
+| `nix build .#oci-xtcp2ctl` | `xtcp2ctl:latest` | only `xtcp2ctl` (runtime-control client) | ~15 MiB |
 
 Images are built with `pkgs.dockerTools.streamLayeredImage`: `./result` is a script that streams a docker-loadable tarball on stdout.
 
@@ -85,6 +88,15 @@ docker run --rm xtcp2:kafka -dest kafka:broker:9092 -topic xtcp2
 nix build .#oci-xtcp2
 ./result | docker load
 docker run --rm --entrypoint /bin/register_schema xtcp2:latest -help
+
+# Slim client images (the gRPC clients, for users who only want the client)
+nix build .#oci-xtcp2client
+./result | docker load
+docker run --rm xtcp2client:latest -help
+docker run --rm xtcp2client:latest -target daemon-host -port 8889
+# xtcp2ctl is the runtime-control client:
+nix build .#oci-xtcp2ctl && ./result | docker load
+docker run --rm xtcp2ctl:latest -help
 ```
 
 ## Choosing a flavor

--- a/nix/containers/default.nix
+++ b/nix/containers/default.nix
@@ -21,6 +21,12 @@
 #   oci-xtcp2-valkey    single xtcp2 binary, valkey only                  (~26 MiB)
 #   oci-xtcp2-s3parquet single xtcp2 binary, s3parquet only               (~26 MiB)
 #
+#   3. Client binaries — slim single-binary scratch images for the gRPC
+#      clients, for users who want just the client (not the fat image).
+#
+#   oci-xtcp2client     single xtcp2client binary (FlatRecords / poll)
+#   oci-xtcp2ctl        single xtcp2ctl binary (runtime control)
+#
 {
   pkgs,
   lib,
@@ -149,6 +155,22 @@ let
       entrypoint = "/bin/xtcp2";
       healthcheck = xtcp2Healthcheck;
     };
+
+  # Slim single-binary images for the gRPC clients (xtcp2client, xtcp2ctl).
+  # Same scratch + CA-bundle base as the flavor images, carrying just the one
+  # client binary with its own entrypoint. No proto payload, no exposed ports,
+  # and no HEALTHCHECK: these dial the daemon and exit, they aren't long-running
+  # services. (The clients also ship inside the fat `oci-xtcp2` image — reach
+  # them there via `--entrypoint /bin/xtcp2client`; these images are for users
+  # who only want the client.)
+  mkClientImage =
+    name:
+    mkOciImage {
+      inherit name;
+      tag = "latest";
+      binaries = binaries.${name};
+      entrypoint = "/bin/${name}";
+    };
 in
 {
   oci-xtcp2 = mkFatImage {
@@ -170,6 +192,10 @@ in
   oci-xtcp2-nsq = mkFlavorImage "nsq";
   oci-xtcp2-valkey = mkFlavorImage "valkey";
   oci-xtcp2-s3parquet = mkFlavorImage "s3parquet";
+
+  # Slim per-client images (gRPC clients that talk to the daemon).
+  oci-xtcp2client = mkClientImage "xtcp2client";
+  oci-xtcp2ctl = mkClientImage "xtcp2ctl";
 
   # Phase B: tcp_server + tcp_client image, dispatched by TCP_MODE env.
   # Built so the Phase C docker-in-vm lifecycle harness can spin up

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -491,6 +491,11 @@ in
         oci-xtcp2-valkey
         oci-xtcp2-s3parquet
         ;
+      # Per-client OCI images (slim: single gRPC-client binary).
+      inherit (containers)
+        oci-xtcp2client
+        oci-xtcp2ctl
+        ;
 
       # Phase B: TCP-stress container for the multi-container test
       # harness. Run with TCP_MODE=server|client|both, TCP_COUNT,


### PR DESCRIPTION
## What

The flake already builds OCI images for the xtcp2 daemon (fat + per-flavor slim). This adds the same for the two gRPC **clients**, so they're easy to pull from Docker Hub / any registry:

- `oci-xtcp2client` → `xtcp2client:latest` — the FlatRecords / poll record-stream client
- `oci-xtcp2ctl` → `xtcp2ctl:latest` — the runtime-control client (set-poll-frequency, trigger-poll, reconfigure)

```sh
nix build .#oci-xtcp2client && ./result | docker load
docker run --rm xtcp2client:latest -help
docker run --rm xtcp2client:latest -target daemon-host -port 8889
```

## How

- **`nix/containers/default.nix`** — `mkClientImage` mirrors the existing `mkFlavorImage`: same scratch + CA-bundle base (`mkOciImage`), one binary, entrypoint `/bin/<name>`. **No** proto payload, exposed ports, or HEALTHCHECK — clients dial the daemon and exit, they aren't long-running services. ~15 MiB each.
- **`nix/default.nix`** — expose both as packages.
- **`docs/build-flavors.md` + `CONTRIBUTING.md`** — document them (and add the previously-missing `oci-xtcp2-s3parquet` row).

The clients also ship inside the fat `oci-xtcp2` image (reach them via `--entrypoint /bin/xtcp2client`); these slim images are for users who want just the client.

## Verification

- `nixfmt --check` clean; both images evaluate (`imageName`/`imageTag` = `xtcp2client`/`latest`, `xtcp2ctl`/`latest`).
- Built + streamed `oci-xtcp2client` and inspected the image config: **Entrypoint = `/bin/xtcp2client`**, `RepoTags = [xtcp2client:latest]`, client binary + CA bundle present in the layers, `Healthcheck = None`, `SSL_CERT_FILE` env set.
- Documented `-target`/`-port` flags confirmed against `xtcp2client -help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)