### PR TITLE
feat(s3parquet): add derived event_date column for Snowpipe clustering

### DIFF
--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -460,6 +460,7 @@ The `#` column mirrors the check labels in `self-test.nix`, which are lettered (
 | 12 | `CLICKHOUSE_RECONCILE` | Prom `envelopeRows` reconciles with the ClickHouse row count (within tolerance) | clickhouse-pipeline* |
 | 13 | `S3PARQUET_FILES` | ≥1 `.parquet` object lands in MinIO within 90s | s3parquet |
 | 14 | `S3PARQUET_ROWS` | duckdb decodes the parquet file and returns ≥1 row | s3parquet |
+| 14b | `S3PARQUET_EVENTDATE` | the derived `event_date` column is present, every value is `YYYY-MM-DD`, and ≥1 distinct date | s3parquet |
 | 15 | `CLICKHOUSE_PARQUET` | ClickHouse `s3()` table function reads the MinIO parquet, `count() > 0` | clickhouse-pipeline-parquet |
 | 16 | `NS_ANONYMOUS` | **the Method B audit-gap proof**: an anonymous `unshare -n` netns (no `/run/netns` bind mount) held by a live process is discovered purely via `/proc` — the exact case dir-scan/inotify was blind to | all |
 | 17 | `CTL_HOT` | `xtcp2ctl set-poll-frequency` is reflected by a later `get` + bumps the Poller `ticker.Reset` counter | all |

--- a/docs/output-and-destinations.md
+++ b/docs/output-and-destinations.md
@@ -77,7 +77,7 @@ Notes on the stream sinks:
 
 ## S3 and Parquet
 
-`pkg/xtcp/destinations_s3parquet.go` (build tag `dest_s3parquet`) writes Hive-partitioned Parquet files to an S3-compatible store (e.g. MinIO) instead of streaming to a broker. The record-to-Parquet schema mapping is in `destinations_s3parquet_schema.go`. Files are partitioned `host=…/date=…/hour=…/<file>.parquet` and finalized/uploaded when the in-memory builder crosses `-s3ParquetFlushBytes` (default 63 MiB uncompressed). Credentials and endpoint come from `-s3*` flags or `S3_*` environment variables; the bucket must already exist.
+`pkg/xtcp/destinations_s3parquet.go` (build tag `dest_s3parquet`) writes Hive-partitioned Parquet files to an S3-compatible store (e.g. MinIO) instead of streaming to a broker. The record-to-Parquet schema mapping is in `destinations_s3parquet_schema.go`. Files are partitioned `host=…/date=…/hour=…/<file>.parquet` and finalized/uploaded when the in-memory builder crosses `-s3ParquetFlushBytes` (default 63 MiB uncompressed). Each row also carries a derived **`event_date`** column (per-row UTC date of `timestamp_ns`) so column-only readers (e.g. Snowflake Snowpipe) can prune/cluster without parsing the Hive path. Credentials and endpoint come from `-s3*` flags or `S3_*` environment variables; the bucket must already exist.
 
 For a consumer-facing reference of the Parquet layout, schema, and the key TCP columns — written for a **data team** ingesting this into an enterprise platform — see [parquet-format.md](parquet-format.md).
 

--- a/docs/parquet-format.md
+++ b/docs/parquet-format.md
@@ -36,7 +36,7 @@ xtcp/host=web-01/date=2026-06-19/hour=14/1750345200_9f3a1c20.parquet
 - `date=` / `hour=` — **UTC** wall clock at write time, ready for partition pruning (`WHERE date = '...' AND hour = '...'`).
 - The file name is `<unix-seconds>_<random-hex>.parquet` — unique, append-only; xtcp2 never rewrites a file.
 
-These partition keys are part of the **path, not the file** (standard Hive convention). Most engines (Spark, Trino/Athena, DuckDB, BigQuery external tables) expose `host`, `date`, `hour` as virtual columns automatically when you point them at `<prefix>/`.
+These partition keys are part of the **path, not the file** (standard Hive convention). Most engines (Spark, Trino/Athena, DuckDB, BigQuery external tables) expose `host`, `date`, `hour` as virtual columns automatically when you point them at `<prefix>/`. Readers that only see the file (e.g. Snowflake Snowpipe, or a file copied out of its prefix) instead get the per-sample date from the real **`event_date`** column — see [the columns that matter](#start-here-the-columns-that-matter).
 
 ## File size, cadence, and compression
 
@@ -68,41 +68,42 @@ df = dataset.to_table(columns=["timestamp_ns","hostname","tcp_info_rtt"]).to_pan
 -- partitions (host string, date string, hour string); project columns you need.
 ```
 
-**Always select only the columns you need** — there are 122, and columnar pruning is where Parquet earns its keep. Likewise filter on `date`/`hour` for partition pruning.
+**Always select only the columns you need** — there are 123, and columnar pruning is where Parquet earns its keep. Likewise filter on the `event_date` column (or the `date`/`hour` path partitions) for pruning.
 
-## Loading into Snowflake
+## Loading into Snowflake (Snowpipe → managed table)
 
-If your platform team already manages an S3 storage integration, ingesting is a few statements. The column names match the Parquet schema, so name-based matching does the mapping for you.
+The recommended path is **Snowpipe continuously loading into a managed table**, clustered on `(event_date, location)`. A managed (native) table is what makes clustering possible for date/DC pruning, and it **auto-absorbs our additive schema changes** — new columns we add over time land as `MATCH_BY_COLUMN_NAME` extra columns instead of being ignored (as they would be by an external table's fixed typed columns). Because `event_date`, `hostname`, and `location` are all **real columns**, Snowpipe maps them **by name** — no `metadata$filename` path parsing needed.
 
 ```sql
--- One-time: a Parquet file format and an external stage over the prefix.
--- STORAGE_INTEGRATION is the bucket grant your platform team provisions.
+-- One-time: Parquet file format + an external stage over the prefix.
 CREATE OR REPLACE FILE FORMAT xtcp_parquet TYPE = PARQUET;
 
 CREATE OR REPLACE STAGE xtcp_stage
   URL = 's3://bucket/xtcp/'
-  STORAGE_INTEGRATION = my_s3_int
+  STORAGE_INTEGRATION = my_s3_int          -- bucket grant from your platform team
   FILE_FORMAT = xtcp_parquet;
 
--- Auto-create a table whose columns mirror the Parquet schema.
+-- Managed table whose columns mirror the Parquet schema, clustered for pruning.
 CREATE OR REPLACE TABLE xtcp_flat_records
   USING TEMPLATE (
     SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*))
     FROM TABLE(INFER_SCHEMA(LOCATION => '@xtcp_stage', FILE_FORMAT => 'xtcp_parquet'))
-  );
+  )
+  CLUSTER BY (event_date, location);       -- date + DC pruning without path parsing
 
--- Load. MATCH_BY_COLUMN_NAME maps Parquet columns → table columns by name.
-COPY INTO xtcp_flat_records
+-- Continuous ingestion: Snowpipe auto-ingests new objects (via S3 event
+-- notification). MATCH_BY_COLUMN_NAME maps Parquet columns → table columns by
+-- name, so additive schema changes flow in without editing the pipe.
+CREATE OR REPLACE PIPE xtcp_pipe AUTO_INGEST = TRUE AS
+  COPY INTO xtcp_flat_records
   FROM @xtcp_stage
   FILE_FORMAT = (TYPE = PARQUET)
   MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
 ```
 
-For **continuous, query-in-place** ingestion instead of a one-shot load, define an external table with `AUTO_REFRESH = TRUE` (backed by Snowpipe + an S3 event notification) over the same stage.
+Notes:
 
-Two Snowflake-specific notes:
-
-- **Partitions live in the path, not the file.** Snowflake won't surface `host`/`date`/`hour` automatically the way Spark/Trino do — derive them from `metadata$filename` (e.g. `REGEXP_SUBSTR(metadata$filename, 'date=([^/]+)', 1, 1, 'e', 1)`) as virtual columns on an external table, or as extra columns during `COPY` via a transform. They make great clustering/pruning keys.
+- **Cluster on `event_date` (the column), not the path.** `event_date` is the per-sample UTC date; it prunes the same way the `date=` prefix does for S3 readers. For exact sub-day or midnight-boundary filtering, use `timestamp_ns`. The `hour=` path segment is the only partition value with no column — derive it from `metadata$filename` only if you need hour-grain pruning.
 - **The two IP-address columns load as `BINARY`.** Decode them with `inet_diag_msg_family` as in the [cheat sheet](#decoding-cheat-sheet) — or, if you'd rather not decode in SQL, point the daemon at the humanized CSV/JSON output instead (see [output formats](output-and-destinations.md)).
 
 ## The grain: one row per socket per poll
@@ -121,6 +122,7 @@ If you're scoping an initial implementation, these are the high-value columns. E
 | Column | Type | Meaning |
 |---|---|---|
 | `timestamp_ns` | double | When the sample was taken — **Unix epoch nanoseconds, UTC**. Divide by 1e9 for seconds. |
+| `event_date` | string | UTC calendar date (`YYYY-MM-DD`) of this row's `timestamp_ns`. A real column (unlike the `date=` path partition) so column-only readers — Snowflake Snowpipe, or anyone reading a file out of its prefix — can prune/cluster on it. |
 | `hostname` | string | Emitting machine (also the `host=` partition). |
 | `netns` | string | Network namespace path — distinguishes host vs container/pod sockets. |
 | `inet_diag_msg_socket_cookie` | uint64 | Stable per-socket id; use to track one connection across polls. |
@@ -172,9 +174,9 @@ A few columns are stored as machine values for fidelity/size and need decoding f
 
 ## Full schema and column types
 
-The complete column list (122 columns) groups as follows; column names are the proto's snake_case names, identical to the ClickHouse table columns:
+The complete column list (123 columns) groups as follows; column names are the proto's snake_case names, identical to the ClickHouse table columns — the one exception is `event_date`, a Parquet-only derived column with no proto/ClickHouse counterpart:
 
-- **Metadata** — `timestamp_ns` (double), `hostname`, `netns`, `nsid`, `label`, `tag`, `record_counter`, `socket_fd`, `netlinker_id`.
+- **Metadata** — `timestamp_ns` (double), `event_date` (string, derived — UTC date of `timestamp_ns`), `hostname`, `netns`, `nsid`, `label`, `tag`, `record_counter`, `socket_fd`, `netlinker_id`.
 - **`inet_diag_msg_*`** — the socket id/4-tuple, state, queues, uid/inode, ASN annotations.
 - **`mem_info_*` / `sk_mem_info_*`** — socket memory accounting.
 - **`tcp_info_*`** — the bulk of the data: RTT, cwnd, ssthresh, MSS, windows, segment and byte counters, pacing/delivery rates, RTO stats, busy/limited times.
@@ -190,6 +192,7 @@ Column types are: `double` (timestamp only), `string` (hostname/netns/label/tag/
 - **Counters are cumulative**, per socket lifetime — delta between consecutive polls (matched by `inet_diag_msg_socket_cookie`) for per-interval rates, or `MAX()` for totals.
 - **Units differ**: RTTs are microseconds; rates are bytes/second; `snd_cwnd` is packets; byte counters are bytes. The per-column units are in the tables above.
 - **Per-algorithm columns are sparse-in-meaning**: `bbr_info_*` is only populated when the socket uses BBR, etc. Filter on `congestion_algorithm_string` before trusting them.
+- **`event_date` is per-sample, not the file's write date.** It's the UTC date of each row's own `timestamp_ns`, so it ≈ the `date=` path segment but can differ for a file that spans UTC midnight (the column is the more precise one). It's a distinct column name from the hive `date` partition, so `hive_partitioning = true` reads expose both without collision. An unset `timestamp_ns` (0) yields `1970-01-01`. For exact sub-day or boundary filtering, use `timestamp_ns`.
 - **Schema evolution**: new fields are *added* (never renamed/reordered in place), so plan for forward-compatible reads (select by name, tolerate new columns).
 
 ## Where the schema is defined

--- a/nix/microvms/default.nix
+++ b/nix/microvms/default.nix
@@ -500,6 +500,7 @@ let
       extraSentinels = [
         "S3PARQUET_FILES"
         "S3PARQUET_ROWS"
+        "S3PARQUET_EVENTDATE"
       ];
       timeoutSec = 240;
     };

--- a/nix/microvms/self-test.nix
+++ b/nix/microvms/self-test.nix
@@ -808,6 +808,31 @@ pkgs.writeShellApplication {
         echo "XTCP2_SELF_TEST_S3PARQUET_ROWS_FAIL  (no parquet object to test)"
       fi
       if [ "$check14" -ne 0 ]; then overall_ok=0; fi
+
+      # ─── Check 14b: s3parquet event_date column present + well-formed ─
+      # Proves the derived event_date column shipped end-to-end: every value is
+      # YYYY-MM-DD and there is ≥1 distinct date. Exact per-row timestamp↔date
+      # correctness is covered by the Go readback unit test; here we stay
+      # TZ-robust and only check well-formedness + presence.
+      echo "--- check 14b: s3parquet — event_date column present ---"
+      check14b=1
+      if [ -s /tmp/xtcp2-s3p.parquet ]; then
+        edMalformed=$(duckdb -noheader -list \
+          -c "SELECT count(*) FROM read_parquet('/tmp/xtcp2-s3p.parquet') WHERE event_date NOT SIMILAR TO '[0-9]{4}-[0-9]{2}-[0-9]{2}'" 2>/dev/null \
+          | tail -n1 | tr -d '[:space:]')
+        edDistinct=$(duckdb -noheader -list \
+          -c "SELECT count(DISTINCT event_date) FROM read_parquet('/tmp/xtcp2-s3p.parquet')" 2>/dev/null \
+          | tail -n1 | tr -d '[:space:]')
+        if [ "''${edMalformed:-1}" = "0" ] && [ "''${edDistinct:-0}" -ge 1 ] 2>/dev/null; then
+          echo "XTCP2_SELF_TEST_S3PARQUET_EVENTDATE_PASS  (distinct=$edDistinct, malformed=0)"
+          check14b=0
+        else
+          echo "XTCP2_SELF_TEST_S3PARQUET_EVENTDATE_FAIL  (malformed=$edMalformed, distinct=$edDistinct)"
+        fi
+      else
+        echo "XTCP2_SELF_TEST_S3PARQUET_EVENTDATE_FAIL  (no parquet file to test)"
+      fi
+      if [ "$check14b" -ne 0 ]; then overall_ok=0; fi
     ''}
 
     ${lib.optionalString runValkeyCheck ''

--- a/pkg/xtcp/destinations_s3parquet.go
+++ b/pkg/xtcp/destinations_s3parquet.go
@@ -32,6 +32,10 @@ import (
 // bounded above by this value. Operator-tunable via config / env / flag.
 const S3ParquetFlushThresholdBytesCst = 63 * 1024 * 1024
 
+// nsPerDayCst is one UTC day in nanoseconds — used to memoize the event_date
+// string across the many same-day rows in a file.
+const nsPerDayCst = 24 * 60 * 60 * 1_000_000_000
+
 // s3ParquetDestQueueCapacity bounds the in-flight backlog between
 // Send() and the worker. Full queue → Send blocks; queueFull counter
 // bumps so operators can spot back-pressure.
@@ -351,6 +355,9 @@ func (d *s3ParquetDest) worker(ctx context.Context) {
 		envelopeCt         int
 		effectiveThreshold int
 	)
+	// event_date memo (worker-lifetime; the date depends only on the timestamp).
+	lastDayIdx := int64(-1) // sentinel; ns=0 → idx 0, so the first row always formats
+	lastDate := ""
 	startBuilder := func() {
 		buf = new(bytes.Buffer)
 		writer = parquet.NewGenericWriter[ParquetRow](buf)
@@ -402,6 +409,13 @@ func (d *s3ParquetDest) worker(ctx context.Context) {
 		d.returnBuf(item.buf)
 		for _, row := range env.Row {
 			parquetRow := rowFromProto(row)
+			// Stamp the derived event_date, re-formatting only when the UTC day
+			// changes (≈once per file).
+			if idx := int64(row.TimestampNs) / nsPerDayCst; idx != lastDayIdx {
+				lastDayIdx = idx
+				lastDate = utcDateFromNs(row.TimestampNs)
+			}
+			parquetRow.EventDate = lastDate
 			if _, err := writer.Write([]ParquetRow{parquetRow}); err != nil {
 				if d.x.pC != nil {
 					d.x.pC.WithLabelValues("destS3Parquet", "write", "error").Inc()
@@ -718,6 +732,11 @@ func approxRowBytes(r *xtcp_flat_record.XtcpFlatRecord) int {
 		len(r.CongestionAlgorithmString)
 	n += len(r.InetDiagMsgSocketSource) + len(r.InetDiagMsgSocketDestination)
 	return n
+}
+
+// utcDateFromNs formats an epoch-ns timestamp as its UTC date (YYYY-MM-DD).
+func utcDateFromNs(ns float64) string {
+	return time.Unix(0, int64(ns)).UTC().Format("2006-01-02")
 }
 
 // rowFromProto translates one *xtcp_flat_record.XtcpFlatRecord into a

--- a/pkg/xtcp/destinations_s3parquet_schema.go
+++ b/pkg/xtcp/destinations_s3parquet_schema.go
@@ -16,12 +16,17 @@ package xtcp
 // Drift defense: TestS3ParquetSchema_matchesProto asserts that the set of
 // `parquet:` tag names here exactly matches the field-name set in
 // xtcp_flat_record.XtcpFlatRecord's proto descriptor. If you add a field
-// to the proto, that test fails until you mirror it here.
+// to the proto, that test fails until you mirror it here. The sole exception
+// is the derived event_date column (allowlisted in that test).
 type ParquetRow struct {
 	TimestampNs float64 `parquet:"timestamp_ns,snappy"`
 
 	Hostname string `parquet:"hostname,zstd"`
 	Location string `parquet:"location,zstd"`
+
+	// event_date: derived, not a proto field. Per-row UTC date of timestamp_ns,
+	// named event_date (not date) to avoid the hive path-segment collision.
+	EventDate string `parquet:"event_date,zstd"`
 
 	Netns            string `parquet:"netns,zstd"`
 	NetnsInode       uint64 `parquet:"netns_inode,snappy"`

--- a/pkg/xtcp/destinations_s3parquet_schema_test.go
+++ b/pkg/xtcp/destinations_s3parquet_schema_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/randomizedcoder/xtcp2/gen/go/xtcp_flat_record"
 )
 
+// derivedColumns: ParquetRow columns not backed by a proto field. Excluded from
+// proto-parity; each must be present and must not shadow a proto field name.
+var derivedColumns = map[string]bool{"event_date": true}
+
 // parquetTagName extracts the column name from a parquet struct tag
 // (everything before the first comma). Returns "" if the tag is missing.
 func parquetTagName(field reflect.StructField) string {
@@ -52,8 +56,19 @@ func TestS3ParquetSchema_matchesProto(t *testing.T) {
 		parquetNames[name] = true
 	}
 
-	if len(protoNames) != len(parquetNames) {
-		t.Errorf("proto has %d fields, ParquetRow has %d columns", len(protoNames), len(parquetNames))
+	// Each derived column must be present and must not shadow a proto field.
+	for n := range derivedColumns {
+		if !parquetNames[n] {
+			t.Errorf("derived column %q missing from ParquetRow", n)
+		}
+		if protoNames[n] {
+			t.Errorf("column %q allowlisted as derived but is also a proto field", n)
+		}
+	}
+
+	if len(protoNames) != len(parquetNames)-len(derivedColumns) {
+		t.Errorf("proto has %d fields, ParquetRow has %d non-derived columns (+%d derived)",
+			len(protoNames), len(parquetNames)-len(derivedColumns), len(derivedColumns))
 	}
 
 	var missing, extra []string
@@ -63,7 +78,7 @@ func TestS3ParquetSchema_matchesProto(t *testing.T) {
 		}
 	}
 	for n := range parquetNames {
-		if !protoNames[n] {
+		if !protoNames[n] && !derivedColumns[n] {
 			extra = append(extra, n)
 		}
 	}
@@ -73,7 +88,7 @@ func TestS3ParquetSchema_matchesProto(t *testing.T) {
 		t.Errorf("proto fields NOT mirrored in ParquetRow: %v", missing)
 	}
 	if len(extra) > 0 {
-		t.Errorf("ParquetRow columns NOT in proto: %v", extra)
+		t.Errorf("ParquetRow columns NOT in proto and NOT allowlisted: %v", extra)
 	}
 }
 
@@ -118,6 +133,7 @@ func TestS3ParquetSchema_columnTypes(t *testing.T) {
 		wantKind parquet.Kind
 	}{
 		{"timestamp_ns", parquet.Double},
+		{"event_date", parquet.ByteArray},
 		{"hostname", parquet.ByteArray},
 		{"netns", parquet.ByteArray},
 		{"inet_diag_msg_socket_source", parquet.ByteArray},

--- a/pkg/xtcp/destinations_s3parquet_test.go
+++ b/pkg/xtcp/destinations_s3parquet_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/parquet-go/parquet-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
@@ -701,3 +702,76 @@ func promCounterValue(t *testing.T, x *XTCP, function, variable, typ string) flo
 // above; keep these "unused imports" defensive imports from leaking by
 // touching them here. Compiler errors on this line if either dep drops.
 var _ = bytes.NewReader
+
+// ─── event_date derived column ───────────────────────────────────────────
+
+// TestUtcDateFromNs pins the pure helper at UTC-day boundaries. Boundary cases
+// stay ≥1s off midnight: timestamp_ns is a float64, whose ~256ns granularity
+// near 2026 could otherwise round a sub-µs value across the day boundary.
+func TestUtcDateFromNs(t *testing.T) {
+	cases := []struct {
+		name string
+		ns   float64
+		want string
+	}{
+		{"epoch zero", 0, "1970-01-01"},
+		{"just before midnight", float64(time.Date(2026, 8, 2, 23, 59, 59, 0, time.UTC).UnixNano()), "2026-08-02"},
+		{"just after midnight", float64(time.Date(2026, 8, 3, 0, 0, 1, 0, time.UTC).UnixNano()), "2026-08-03"},
+		{"known midday", float64(time.Date(2026, 6, 19, 14, 30, 0, 0, time.UTC).UnixNano()), "2026-06-19"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := utcDateFromNs(tc.ns); got != tc.want {
+				t.Errorf("utcDateFromNs(%v) = %q, want %q", tc.ns, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestS3ParquetDest_eventDatePerRow proves the written event_date column is
+// stamped per row from that row's own timestamp_ns (not constant-per-file): a
+// file whose rows straddle UTC midnight carries two distinct event_date values,
+// and every row's column equals utcDateFromNs of its own timestamp.
+func TestS3ParquetDest_eventDatePerRow(t *testing.T) {
+	beforeMidnight := time.Date(2026, 8, 2, 23, 59, 59, 0, time.UTC)
+	afterMidnight := time.Date(2026, 8, 3, 0, 0, 1, 0, time.UTC)
+	env := &xtcp_flat_record.Envelope{Row: []*xtcp_flat_record.XtcpFlatRecord{
+		{Hostname: "h", TimestampNs: float64(beforeMidnight.UnixNano())},
+		{Hostname: "h", TimestampNs: float64(afterMidnight.UnixNano())},
+		{Hostname: "h", TimestampNs: float64(afterMidnight.UnixNano())},
+	}}
+
+	d, upl, x := newS3ParquetFixture(t, 1<<30, nil) // huge threshold → flush on Close
+	buf := marshalEnvelopeBuf(t, x, env)
+	if _, err := d.Send(context.Background(), buf); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	calls := upl.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("uploads = %d, want 1", len(calls))
+	}
+	body := calls[0].body
+	rows, err := parquet.Read[ParquetRow](bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("parquet.Read: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("read %d rows, want 3", len(rows))
+	}
+
+	distinct := map[string]bool{}
+	for i, r := range rows {
+		if got := utcDateFromNs(r.TimestampNs); r.EventDate != got {
+			t.Errorf("row %d event_date = %q, want %q (from its timestamp_ns)", i, r.EventDate, got)
+		}
+		distinct[r.EventDate] = true
+	}
+	if len(distinct) != 2 {
+		t.Errorf("distinct event_date = %d, want 2 (per-row straddle)", len(distinct))
+	}
+}


### PR DESCRIPTION
## Why

The S3/Parquet output is Hive-partitioned by a `date=` path segment, but that value lives **only in the object path**. Column-based readers — Snowflake **Snowpipe ingesting into a managed table**, or anyone reading a file out of its prefix — can't see it. This adds a real `event_date` column so those consumers can prune and `CLUSTER BY (event_date, location)` without parsing the path. (`hostname` and `location` are already real columns; `date` was the only path-only value.)

We're going straight to **Snowpipe → managed table** (skipping the external-table phase): a managed table lets us define clustering for date/DC pruning, and it's the only mode that auto-absorbs our additive schema changes.

## What

- **Parquet-only, derived column** — not added to the proto, ClickHouse, Kafka, or the CSV/JSON marshallers. The proto-parity drift test (`TestS3ParquetSchema_matchesProto`) gains a small `derivedColumns` allowlist so it still catches every *other* drift.
- **Named `event_date`, not `date`** — a real column literally named `date` would collide with the virtual `date` column that DuckDB/Spark/Trino/Athena synthesize from the `date=` path segment on a prefix read (our own doc query does this). `event_date` coexists with it.
- **Per-row sample date** — each row's `event_date` is the UTC date of *that row's own* `timestamp_ns`, memoized by UTC day-number (~one format per file). Non-straddle files (≈all) hold one distinct value → whole-file Parquet stat pruning; a file spanning UTC midnight correctly carries two values. `timestamp_ns` remains the exact sub-day filter. `objectKey`/the path is unchanged.

## Tests

- `TestUtcDateFromNs` — UTC-day boundary cases.
- `TestS3ParquetDest_eventDatePerRow` — writes a midnight-straddle envelope, reads the Parquet back, asserts each row's `event_date` matches its own `timestamp_ns` and that the straddle yields two distinct values (proving per-row, not constant-per-file).
- Drift + column-type tests updated for the allowlisted column.

## Integration tests

Existing parquet checks are schema-agnostic (`count()` with schema inference) and unaffected; the typed ClickHouse table is fed only by the Kafka/ProtobufList pipeline, never from Parquet. Added **self-test Check 14b** (`S3PARQUET_EVENTDATE`) asserting the column shipped and every value is well-formed `YYYY-MM-DD`.

Verified end-to-end via the `s3parquet` lifecycle microVM:
```
XTCP2_SELF_TEST_S3PARQUET_EVENTDATE_PASS  (distinct=1, malformed=0)
XTCP2_SELF_TEST_OVERALL_PASS
```
Also: `go test -tags dest_s3parquet ./pkg/xtcp/`, `golangci-lint` (0 issues), `nixfmt --check` all pass.

## Docs

- `docs/parquet-format.md` — column count 122→123, `event_date` in the Identity table + schema listing + gotchas, and the **Snowpipe → managed-table `CLUSTER BY (event_date, location)`** recipe.
- `docs/output-and-destinations.md`, `docs/integration-testing.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)