### PR TITLE
docs(cmd): add readme quickstarts for xtcp2client and xtcp2ctl

### DIFF
--- a/cmd/xtcp2client/readme.md
+++ b/cmd/xtcp2client/readme.md
@@ -1,0 +1,62 @@
+# xtcp2client
+
+The reference **gRPC client** for a running xtcp2 daemon. It connects to the
+daemon's `XTCPFlatRecordService` and prints the live per-socket TCP records it
+streams back — in JSON, CSV, TSV, a humanized form, or not at all (`null`, for
+benchmarking the transport). It's the quickest way to *see the data* a daemon is
+producing without standing up a Kafka/ClickHouse/S3 pipeline.
+
+Two modes:
+
+- **Listen** (default) — server-streaming `FlatRecords`. The daemon collects on
+  its own `-frequency` schedule and pushes records; the client just prints them.
+- **Poll** (`-poll`) — bidirectional `PollFlatRecords`. The *client* drives
+  collection, triggering a poll every `-pollFrequency`.
+
+The client auto-reconnects with jittered backoff, so a daemon soft-restart or a
+network blip doesn't end the stream.
+
+## Quickstart
+
+```sh
+# Build (produces ./result/bin/xtcp2client)
+nix build .#xtcp2client
+alias xtcp2client=./result/bin/xtcp2client
+
+# Listen mode — stream records the daemon collects on its own schedule
+xtcp2client -target 127.0.0.1 -port 8889
+
+# Poll mode — drive collection from the client, every 2s
+xtcp2client -poll -pollFrequency 2s
+
+# Pick a format; CSV/TSV can select and order columns
+xtcp2client -format csv -columns hostname,inetDiagMsgSocketSource,inetDiagMsgState,tcpInfoRtt
+xtcp2client -format humanize          # decoded IPs, TCP-state names, RFC3339 time
+```
+
+The daemon's gRPC port defaults to `8889` and **must match** its `-grpcPort`.
+The gRPC server has no auth or TLS — reach it over loopback or a trusted network.
+
+## Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-target` | `localhost` | Daemon hostname. |
+| `-port` | `8889` | Daemon gRPC port (must match the daemon's `-grpcPort`). |
+| `-poll` | `false` | Use `PollFlatRecords` (client-driven) instead of `FlatRecords`. |
+| `-pollFrequency` | `10s` | Poll interval, poll mode only. |
+| `-format` | `json` | Output: `json`, `csv`, `tsv`, `humanize`, or `null`. |
+| `-columns` | (all) | CSV/TSV only: comma-separated `XtcpFlatRecord` json field names. |
+| `-workers` | `10` | Concurrent listen-mode stream workers. |
+| `-d` | `11` | Debug verbosity (logs to stderr; records go to stdout). |
+| `-v` | | Print version and exit. |
+
+A slim single-binary container image is also published as `.#oci-xtcp2client`
+(see [build flavors](../../docs/build-flavors.md)).
+
+## See also
+
+- [gRPC API](../../docs/grpc-api.md) — the services, RPCs, and `grpcurl` equivalents.
+- [Output formats & destinations](../../docs/output-and-destinations.md) — what the `-format`/`-columns` values mean.
+- [Protobuf formats](../../docs/protobuf-formats.md) — the `XtcpFlatRecord` schema and field semantics.
+- [xtcp2ctl](../xtcp2ctl/readme.md) — the companion CLI that *changes* daemon settings (this one only *reads*).

--- a/cmd/xtcp2ctl/readme.md
+++ b/cmd/xtcp2ctl/readme.md
@@ -1,0 +1,74 @@
+# xtcp2ctl
+
+The **operator control CLI** for a running xtcp2 daemon. Where
+[xtcp2client](../xtcp2client/readme.md) *reads* records, `xtcp2ctl` *changes
+settings* — it drives the daemon's `ConfigService` to adjust poll cadence,
+trigger polls, tune S3 upload timing, and apply an entirely new config, all
+**without redeploying the container**. It's a thin, flag-based wrapper over the
+generated gRPC client; everything it does is also reachable with `grpcurl`.
+
+Two tiers of change — pick the least disruptive one that does the job:
+
+- **Hot** (no restart, no data loss): `set-poll-frequency`, `trigger-poll`,
+  `poll-burst`, `set-s3`.
+- **Soft restart** (`reconfigure`): applies a full config by re-exec'ing the
+  daemon in place (same PID/container); gRPC/metrics/health blip for a few
+  seconds while it re-initializes. Buffered records are flushed first, so no
+  data is lost.
+
+## Quickstart
+
+```sh
+# Build (produces ./result/bin/xtcp2ctl)
+nix build .#xtcp2ctl
+alias xtcp2ctl=./result/bin/xtcp2ctl        # all commands accept -target / -port
+
+# Inspect the running config (S3 creds redacted)
+xtcp2ctl get
+
+# Hot changes — take effect immediately
+xtcp2ctl set-poll-frequency -frequency 30s -timeout 5s
+xtcp2ctl trigger-poll
+xtcp2ctl poll-burst -count 6 -interval 10s   # a socket snapshot every 10s for a minute
+xtcp2ctl set-s3 -flush-interval 5s           # flush buffered snapshots to S3 promptly
+```
+
+**Incident workflow — read → edit → apply (soft restart):**
+
+```sh
+xtcp2ctl get > cfg.json
+# enable BBR detail + stamp a ticket. enabledDeserializers wraps a nested
+# "enabled" map, so the path is .enabledDeserializers.enabled.<key>.
+jq '.enabledDeserializers.enabled.bbr = true | .tag = "INC-1234"' cfg.json > cfg.new.json
+xtcp2ctl reconfigure -file cfg.new.json      # reads stdin when -file is "-" or omitted
+```
+
+Because empty credential fields are treated as *unchanged*, the redacted
+`get → reconfigure` round-trip preserves the daemon's S3 keys.
+
+## Commands
+
+| Command | Key flags | Tier |
+|---|---|---|
+| `get` | | none |
+| `set-poll-frequency` | `-frequency`, `-timeout` (both required, `timeout < frequency`) | hot |
+| `trigger-poll` | | hot |
+| `poll-burst` | `-count`, `-interval` (must exceed the daemon's poll timeout) | hot |
+| `set-s3` | `-flush-interval`, `-threshold-bytes` (at least one) | hot |
+| `reconfigure` | `-file` (`-` = stdin) | soft restart |
+
+Common flags on every command: `-target` (default `localhost`), `-port`
+(default `8889`, must match the daemon's `-grpcPort`), `-d` (debug level). Run
+`xtcp2ctl <command> -h` for per-command flags.
+
+> **Security.** The gRPC server has no auth or TLS. `get` redacts S3 credentials,
+> but any client that can reach the port can reconfigure or restart the daemon —
+> bind the port to loopback or a trusted network.
+
+A slim single-binary container image is also published as `.#oci-xtcp2ctl`
+(see [build flavors](../../docs/build-flavors.md)).
+
+## See also
+
+- [gRPC API](../../docs/grpc-api.md) — the `ConfigService` RPCs, the runtime-control tiers, and `grpcurl` equivalents.
+- [xtcp2client](../xtcp2client/readme.md) — the companion client that *reads* streamed records.


### PR DESCRIPTION
## Why

The two gRPC client commands (`cmd/xtcp2client`, `cmd/xtcp2ctl`) had no readme in their folders. This adds a short, scannable one for each — what the client does and a quickstart — so a new user can find and run them without digging through `docs/grpc-api.md` first.

## What

- **`cmd/xtcp2client/readme.md`** — the reference client that *reads* streamed TCP records: listen vs `-poll` modes, auto-reconnect, quickstart, formats/`-columns`, a flags table.
- **`cmd/xtcp2ctl/readme.md`** — the operator control CLI that *changes* daemon settings: hot vs soft-restart tiers, the `get → edit → reconfigure` incident workflow, a commands table, and the no-auth/TLS security note.

Both **distill and link to** `docs/grpc-api.md` (the authoritative reference) rather than duplicate it, and cross-link each other. Filenames use the lowercase `readme.md` convention already used by the other `cmd/` subdirectories.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)